### PR TITLE
Add INRG compatibility config file

### DIFF
--- a/data/config/inrg_compat.json
+++ b/data/config/inrg_compat.json
@@ -1,0 +1,252 @@
+{
+  "gaTrackingId": "undefined",
+  "graphql": {
+    "boardCounts": [
+      {
+        "graphql": "_inrg_count",
+        "name": "Cases",
+        "plural": "Cases"
+      },
+      {
+        "graphql": "_init_trials_count",
+        "name": "Init Trial",
+        "plural": "Init Trials"
+      },
+      {
+        "graphql": "_relapse_sites_specific_count",
+        "name": "Relapse Site Specific",
+        "plural": "Relapse Sites Specific"
+      }
+    ],
+    "chartCounts": [
+      {
+        "graphql": "_inrg_count",
+        "name": "Case"
+      },
+      {
+        "graphql": "_init_trials_count",
+        "name": "Init Trial"
+      },
+      {
+        "graphql": "_relapse_sites_specific_count",
+        "name": "Relapse Site Specific"
+      }
+    ],
+    "projectDetails": "boardCounts"
+  },
+  "components": {
+    "appName": "Pediatric Cancer Data Commons Portal",
+    "index": {
+      "introduction": {
+        "heading": "Pediatric Cancer Data Commons",
+        "text": "The Pediatric Cancer Data Commons supports the management, analysis and sharing of data for the research community.",
+        "link": "/submission"
+      },
+      "buttons": [
+        {
+          "name": "Define Data Field",
+          "icon": "data-field-define",
+          "body": "The Pediatric Cancer Data Commons defines the data. Please study the dictionary before you start browsing.",
+          "link": "/DD",
+          "label": "Learn more"
+        },
+        {
+          "name": "Explore Data",
+          "icon": "data-explore",
+          "body": "The Exploration Page gives you insights and a clear overview under selected factors.",
+          "link": "/explorer",
+          "label": "Explore data"
+        },
+        {
+          "name": "Access Data",
+          "icon": "data-access",
+          "body": "Use our selected tool to filter out the data you need.",
+          "link": "/query",
+          "label": "Query data"
+        },
+        {
+          "name": "Submit Data",
+          "icon": "data-submit",
+          "body": "Submit Data based on the dictionary.",
+          "link": "/submission",
+          "label": "Submit data"
+        }
+      ]
+    },
+    "navigation": {
+      "title": "Pediatric Cancer Data Commons",
+      "items": [
+        {
+          "icon": "dictionary",
+          "link": "/DD",
+          "color": "#a2a2a2",
+          "name": "Dictionary"
+        },
+        {
+          "icon": "exploration",
+          "link": "/explorer",
+          "color": "#a2a2a2",
+          "name": "Exploration"
+        },
+        {
+          "icon": "files",
+          "link": "/files",
+          "color": "#a2a2a2",
+          "name": "Files"
+        },
+        {
+          "icon": "query",
+          "link": "/query",
+          "color": "#a2a2a2",
+          "name": "Query"
+        },
+        {
+          "icon": "workspace",
+          "link": "#hostname#workspace/",
+          "color": "#a2a2a2",
+          "name": "Workspace"
+        },
+        {
+          "icon": "profile",
+          "link": "/identity",
+          "color": "#a2a2a2",
+          "name": "Profile"
+        }
+      ]
+    },
+    "topBar": {
+      "items": [
+        {
+          "icon": "upload",
+          "link": "/submission",
+          "name": "Data Submission"
+        },
+        {
+          "link": "https://uc-cdis.github.io/gen3-user-doc/user-guide/guide-overview",
+          "name": "Documentation"
+        }
+      ]
+    },
+    "login": {
+      "title": "Pediatric Cancer Data Commons",
+      "subTitle": "search, compare, and download data",
+      "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
+      "contact": "If you have any questions about access or the registration process, please contact ",
+      "email": "pcdc_root@lists.uchicago.edu"
+    }
+  },
+  "featureFlags": {
+    "explorer": true
+  },
+  "dataExplorerConfig": {
+    "charts": {
+      "ETHNICITY": {
+        "chartType": "stackedBar",
+        "title": "Ethnicity"
+      },
+      "SEX": {
+        "chartType": "pie",
+        "title": "Gender"
+      },
+      "RACE": {
+        "chartType": "pie",
+        "title": "Race"
+      }
+    },
+    "filters": {
+      "tabs": [
+        {
+          "title": "Project",
+          "fields": [
+            "AGE",
+            "SEX",
+            "ETHNICITY",
+            "project_id",
+            "region_name",
+            "YEAR",
+            "INIT_TREAT",
+            "INSS_STAGE",
+            "INRG_STG",
+            "EVANS_STAGE",
+            "MYCN",
+            "PLOIDY",
+            "DNA_INDEX",
+            "_11Q_UBAB",
+            "_1P_LOAB",
+            "_17Q_GAIN",
+            "ALK",
+            "FERRITIN",
+            "LDH",
+            "PRI_ADRE",
+            "PRI_ABDRET",
+            "PRI_NECK",
+            "PRI_THOR",
+            "PRI_PELV",
+            "PRI_OTH",
+            "MET_BM",
+            "MET_BONE",
+            "MET_DLN",
+            "MET_LIV",
+            "MET_SKIN",
+            "MET_LUNG",
+            "MET_CNS",
+            "MET_OTH",
+            "HIST",
+            "DIAG",
+            "GRADE",
+            "MKI",
+            "EFSCENS",
+            "EFSTIME",
+            "SCENS",
+            "STIME",
+            "CAUSE_OF_DEATH",
+            "RACE",
+            "REL_SITE_GEN",
+            "OTH_REL_SITE",
+            "SECOND_MALIG_CENS",
+            "SECOND_MALIG_TIME",
+            "SMN_MORPH_SNO",
+            "SMN_MORPH_ICD0",
+            "SMN_MORPH_TXT",
+            "SMN_TOP_SNO",
+            "SMN_TOP_ICD0",
+            "SMN_TOP_TXT"
+          ]
+        },
+        {
+          "title": "Age",
+          "fields": ["AGE"]
+        },
+        {
+          "title": "Sex",
+          "fields": ["SEX"]
+        },
+        {
+          "title": "Ethnicity",
+          "fields": ["ETHNICITY"]
+        }
+      ]
+    },
+    "projectId": "search",
+    "graphqlField": "subject",
+    "index": "",
+    "buttons": [
+      {
+        "enabled": true,
+        "type": "data",
+        "title": "Download Data",
+        "leftIcon": "user",
+        "rightIcon": "download",
+        "fileName": "data.json"
+      }
+    ],
+    "table": {
+      "enabled": true
+    },
+    "guppyConfig": {
+      "dataType": "inrg",
+      "nodeCountTitle": "Subjects",
+      "fieldMapping": []
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --config .stylelintrc.js --fix",
     "sanity-check": "node ./sanity-check",
     "develop:inrg": "HOSTNAME=portal.pedscommons.org NODE_ENV=dev APP=inrg bash ./runWebpack.sh",
+    "develop:inrg_compat": "HOSTNAME=portal.pedscommons.org NODE_ENV=dev APP=inrg_compat bash ./runWebpack.sh",
     "format": "prettier --write ."
   },
   "graphql": {


### PR DESCRIPTION
This PR allows local development using the _old_ config file for INRG during the transition phase re: deploying a new data dictionary on the back end.

This was necessitated by a previous commit 1729e93 that updated `data/config/inrg.json`, which breaks local development build at the moment due to the currently missing fields on GraphQL side (e.g. `_person_count`).