### PR TITLE
Create index overview PEDS-101

### DIFF
--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -146,6 +146,11 @@ function buildConfig(appIn, data) {
   });
   return result;
 }
+function getConsortiumList() {
+  const dict = require(`${__dirname}/dictionary.json`);
+  const consortiumList = dict['subject'].properties.consortium.enum || [];
+  return JSON.stringify(consortiumList);
+}
 
 const config = buildConfig(process.env.app, params);
 console.log(`const gaTracking = '${defaultGA}';`);
@@ -163,6 +168,7 @@ console.log(`const config = ${JSON.stringify(config, null, '  ')};`);
 console.log(
   `const requiredCerts = [${defaultRequiredCerts.map((item) => `'${item}'`)}];`
 );
+console.log(`const consortiumList = ${getConsortiumList()};`);
 console.log(
-  'module.exports = { components, config, gaTracking, requiredCerts };'
+  'module.exports = { components, config, gaTracking, requiredCerts, consortiumList };'
 );

--- a/data/gqlHelper.js.njk
+++ b/data/gqlHelper.js.njk
@@ -22,18 +22,6 @@ const helperSingleton = {
     {% endfor %}
   }`,
 
-  indexPageOverviewQuery: graphql`query gqlHelperIndexPageOverviewQuery {
-    counts_total: subject(first: 10000) {
-      study: _studys_count
-      molecular_analysis: _molecular_analysiss_count
-    }
-    {% for id in consortiumList %}counts_{{ loop.index }}: subject(first: 10000, consortium: "{{ id }}") {
-      study: _studys_count
-      molecular_analysis: _molecular_analysiss_count
-    }
-    {% endfor %}
-  }`,
-
   submissionPageQuery: graphql`query gqlHelperSubmissionPageQuery {
     projectList: project(first: 10000) {
       name: project_id

--- a/data/gqlHelper.js.njk
+++ b/data/gqlHelper.js.njk
@@ -22,6 +22,18 @@ const helperSingleton = {
     {% endfor %}
   }`,
 
+  indexPageOverviewQuery: graphql`query gqlHelperIndexPageOverviewQuery {
+    counts_total: subject(first: 10000) {
+      study: _studys_count
+      molecular_analysis: _molecular_analysiss_count
+    }
+    {% for id in consortiumList %}counts_{{ loop.index }}: subject(first: 10000, consortium: "{{ id }}") {
+      study: _studys_count
+      molecular_analysis: _molecular_analysiss_count
+    }
+    {% endfor %}
+  }`,
+
   submissionPageQuery: graphql`query gqlHelperSubmissionPageQuery {
     projectList: project(first: 10000) {
       name: project_id

--- a/data/gqlHelper.js.njk
+++ b/data/gqlHelper.js.njk
@@ -188,13 +188,6 @@ export class GQLHelper {
     );
   }
 
-  static getConsortiumList() {
-    return [
-      {% for id in consortiumList %}'{{ id }}',
-      {% endfor %}
-    ]
-  }
-
   static updateOffset(data, cursors) {
     const fileLengthData = Object.keys(data).filter(key => key.indexOf('fileData') === 0).reduce(
       (map, key) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1891,6 +1891,21 @@
             "react-router-dom": "^4.3.1",
             "recharts": "^1.5.0",
             "stylelint": "^9.10.1"
+          },
+          "dependencies": {
+            "react-router-dom": {
+              "version": "4.3.1",
+              "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+              "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+              "requires": {
+                "history": "^4.7.2",
+                "invariant": "^2.2.4",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.1",
+                "react-router": "^4.3.1",
+                "warning": "^4.0.1"
+              }
+            }
           }
         },
         "file-saver": {
@@ -1902,6 +1917,36 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
           "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "react-router": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+          "requires": {
+            "history": "^4.7.2",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.1",
+            "warning": "^4.0.1"
+          }
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
         }
       }
     },
@@ -1921,6 +1966,51 @@
         "react-router-dom": "^4.3.1",
         "recharts": "^1.5.0",
         "stylelint": "^9.10.1"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "react-router": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+          "requires": {
+            "history": "^4.7.2",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.1",
+            "warning": "^4.0.1"
+          }
+        },
+        "react-router-dom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+          "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+          "requires": {
+            "history": "^4.7.2",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "prop-types": "^15.6.1",
+            "react-router": "^4.3.1",
+            "warning": "^4.0.1"
+          }
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "@iarna/cli": {
@@ -16385,6 +16475,15 @@
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
@@ -23616,19 +23715,30 @@
       }
     },
     "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -23636,38 +23746,21 @@
           "requires": {
             "isarray": "0.0.1"
           }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
         }
       }
     },
     "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-select": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-redux": "^5.0.7",
     "react-relay": "^1.6.0",
     "react-responsive": "^6.1.1",
-    "react-router-dom": "^4.2.2",
+    "react-router-dom": "^5.2.0",
     "react-select": "^1.3.0",
     "react-select-fast-filter-options": "^0.2.3",
     "react-svg-loader": "^3.0.3",

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -71,6 +71,10 @@ class Explorer extends React.Component {
       </React.Fragment>
     );
 
+    const overviewFilter = this.props.history.location.state.filter
+      ? this.props.history.location.state.filter
+      : {};
+
     return (
       <div className='guppy-explorer'>
         {explorerConfig.length > 1 ? tabFragment : null}
@@ -78,9 +82,10 @@ class Explorer extends React.Component {
           className={explorerConfig.length > 1 ? 'guppy-explorer__main' : ''}
         >
           <GuppyDataExplorer
-            adminAppliedPreFilters={
-              explorerConfig[this.state.tab].adminAppliedPreFilters
-            }
+            adminAppliedPreFilters={{
+              ...explorerConfig[this.state.tab].adminAppliedPreFilters,
+              ...overviewFilter,
+            }}
             chartConfig={explorerConfig[this.state.tab].charts}
             filterConfig={explorerConfig[this.state.tab].filters}
             tableConfig={explorerConfig[this.state.tab].table}

--- a/src/Index/IndexOverview.css
+++ b/src/Index/IndexOverview.css
@@ -1,0 +1,63 @@
+.index-overview {
+  background-color: white;
+  min-height: 200px;
+  padding: 20px;
+  margin: 20px;
+  border: 1px solid var(--g3-color__silver);
+  border-radius: 4px;
+  max-width: 1280px;
+  width: 90%;
+}
+
+.index-overview__title h2 {
+  text-align: center;
+}
+
+.index-overview__select {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 250px;
+}
+
+@media screen and (min-width: 821px) {
+  .index-overview__title {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .index-overview__select {
+    justify-content: flex-end;
+  }
+}
+
+.index-overview__select .Select {
+  margin-left: 0.5rem;
+  min-width: 150px;
+}
+
+.index-overview__body {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  padding: 10px;
+}
+
+.index-overview__count {
+  font-size: 1.25rem;
+  padding: 10px;
+  min-width: 250px;
+  text-align: center;
+}
+
+.index-overview__count > h3 {
+  font-size: 2em;
+  line-height: 1.5;
+  margin-top: 0;
+}
+
+.index-overview__count svg {
+  color: var(--g3-primary-btn__bg-color);
+  margin-right: 0.5rem;
+}

--- a/src/Index/IndexOverview.css
+++ b/src/Index/IndexOverview.css
@@ -13,40 +13,35 @@
   text-align: center;
 }
 
+.index-overview__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+}
+
 .index-overview__select {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 250px;
-}
-
-@media screen and (min-width: 821px) {
-  .index-overview__title {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-  }
-
-  .index-overview__select {
-    justify-content: flex-end;
-  }
+  width: 250px;
 }
 
 .index-overview__select .Select {
   margin-left: 0.5rem;
-  min-width: 150px;
+  width: 150px;
 }
 
 .index-overview__body {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;
-  padding: 10px;
+  padding: 20px 10px;
 }
 
 .index-overview__count {
   font-size: 1.25rem;
-  padding: 10px;
+  padding: 20px 10px;
   min-width: 250px;
   text-align: center;
 }
@@ -60,4 +55,21 @@
 .index-overview__count svg {
   color: var(--g3-primary-btn__bg-color);
   margin-right: 0.5rem;
+}
+
+.index-overview__footer {
+  text-align: center;
+}
+
+@media screen and (min-width: 821px) {
+  .index-overview__title {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .index-overview__body,
+  .index-overview__count {
+    padding: 10px;
+  }
 }

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import Select from 'react-select';
+import Spinner from '../components/Spinner';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GQLHelper } from '../gqlHelper';
+import './IndexOverview.css';
+
+const consortiumList = GQLHelper.getConsortiumList();
+
+function IndexOverview({ overviewCounts }) {
+  const [consortium, setConsortium] = useState('total');
+  const consortiumOptions = [
+    { label: 'All PCDC', value: 'total' },
+    ...consortiumList.map((option) => ({ label: option, value: option })),
+  ];
+
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
+  useEffect(() => {
+    if (overviewCounts !== undefined) setIsDataLoaded(true);
+  }, [overviewCounts]);
+
+  const getCountDataList = () => [
+    {
+      count: overviewCounts[consortium].study,
+      faIcon: 'flask',
+      name: { singular: 'Study', plural: 'Studies' },
+    },
+    {
+      count: overviewCounts[consortium].molecular_analysis,
+      faIcon: 'microscope',
+      name: {
+        singular: 'Molecular analysis',
+        plural: 'Molecular analyses',
+      },
+    },
+  ];
+
+  return (
+    <div className='index-overview'>
+      <div className='index-overview__title'>
+        <h2>Overview</h2>
+        <div className='index-overview__select'>
+          <label>Consortium</label>
+          <Select
+            clearable={false}
+            options={consortiumOptions}
+            value={consortium}
+            onChange={({ value }) => setConsortium(value)}
+          />
+        </div>
+      </div>
+      <div className='index-overview__body'>
+        {isDataLoaded ? (
+          getCountDataList().map(({ count, faIcon, name }) => (
+            <div className='index-overview__count' key={name.singular}>
+              <h3>{count}</h3>
+              <div>
+                <FontAwesomeIcon icon={faIcon} size='lg' />
+                {count > 1 ? name.plural : name.singular}
+              </div>
+            </div>
+          ))
+        ) : (
+          <Spinner />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default IndexOverview;

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -46,6 +46,11 @@ function IndexOverview({ overviewCounts }) {
 
   const getCountDataList = () => [
     {
+      count: overviewCounts[consortium].subject,
+      faIcon: 'user',
+      name: { singular: 'Subject', plural: 'Subjects' },
+    },
+    {
       count: overviewCounts[consortium].study,
       faIcon: 'flask',
       name: { singular: 'Study', plural: 'Studies' },

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import MediaQuery from 'react-responsive';
 import Select from 'react-select';
 import Spinner from '../components/Spinner';
+import Button from '@gen3/ui-component/dist/components/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { GQLHelper } from '../gqlHelper';
+import { breakpoints } from '../localconf';
 import './IndexOverview.css';
 
 const consortiumList = GQLHelper.getConsortiumList();
@@ -13,6 +17,27 @@ function IndexOverview({ overviewCounts }) {
     { label: 'All PCDC', value: 'total' },
     ...consortiumList.map((option) => ({ label: option, value: option })),
   ];
+
+  let history = useHistory();
+  function ButtonToExplorer() {
+    const filter =
+      consortium === 'total'
+        ? {}
+        : { consortium: { selectedValues: [consortium] } };
+
+    return (
+      <Button
+        label='Explore more'
+        buttonType='primary'
+        onClick={() =>
+          history.push({
+            pathname: '/explorer',
+            state: { filter },
+          })
+        }
+      />
+    );
+  }
 
   const [isDataLoaded, setIsDataLoaded] = useState(false);
   useEffect(() => {
@@ -39,14 +64,19 @@ function IndexOverview({ overviewCounts }) {
     <div className='index-overview'>
       <div className='index-overview__title'>
         <h2>Overview</h2>
-        <div className='index-overview__select'>
-          <label>Consortium</label>
-          <Select
-            clearable={false}
-            options={consortiumOptions}
-            value={consortium}
-            onChange={({ value }) => setConsortium(value)}
-          />
+        <div className='index-overview__actions'>
+          <div className='index-overview__select'>
+            <label>Consortium</label>
+            <Select
+              clearable={false}
+              options={consortiumOptions}
+              value={consortium}
+              onChange={({ value }) => setConsortium(value)}
+            />
+          </div>
+          <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
+            <ButtonToExplorer />
+          </MediaQuery>
         </div>
       </div>
       <div className='index-overview__body'>
@@ -64,6 +94,11 @@ function IndexOverview({ overviewCounts }) {
           <Spinner />
         )}
       </div>
+      <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
+        <div className='index-overview__footer'>
+          <ButtonToExplorer />
+        </div>
+      </MediaQuery>
     </div>
   );
 }

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -5,11 +5,9 @@ import Select from 'react-select';
 import Spinner from '../components/Spinner';
 import Button from '@gen3/ui-component/dist/components/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { GQLHelper } from '../gqlHelper';
+import { consortiumList } from '../params';
 import { breakpoints } from '../localconf';
 import './IndexOverview.css';
-
-const consortiumList = GQLHelper.getConsortiumList();
 
 function IndexOverview({ overviewCounts }) {
   const [consortium, setConsortium] = useState('total');

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -8,7 +8,8 @@ import {
   ReduxIndexOverview,
   ReduxIntroduction,
 } from './reduxer';
-import { getIndexPageChartData, getIndexPageOverviewData } from './relayer';
+import { getIndexPageChartData } from './relayer';
+import { getIndexPageOverviewData } from './utils';
 import dictIcons from '../img/icons';
 import { components } from '../params';
 import { breakpoints } from '../localconf';

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -5,9 +5,10 @@ import {
   ReduxIndexButtonBar,
   ReduxIndexBarChart,
   ReduxIndexCounts,
+  ReduxIndexOverview,
   ReduxIntroduction,
 } from './reduxer';
-import { getIndexPageChartData } from './relayer';
+import { getIndexPageChartData, getIndexPageOverviewData } from './relayer';
 import dictIcons from '../img/icons';
 import { components } from '../params';
 import { breakpoints } from '../localconf';
@@ -16,6 +17,7 @@ import './page.less';
 function IndexPage({ history }) {
   useEffect(() => {
     getIndexPageChartData();
+    getIndexPageOverviewData();
   }, []);
 
   return (
@@ -36,6 +38,7 @@ function IndexPage({ history }) {
           </MediaQuery>
         </div>
       </div>
+      <ReduxIndexOverview />
       <ReduxIndexButtonBar history={history} />
     </div>
   );

--- a/src/Index/reducers.js
+++ b/src/Index/reducers.js
@@ -18,6 +18,35 @@ const index = (state = {}, action) => {
         countNames: ['Subjects'],
       };
     }
+    case 'RECEIVE_INDEX_PAGE_OVERVIEW_COUNTS': {
+      const { names, counts_total, ...counts } = action.data;
+
+      const total = {};
+      for (const val of counts_total)
+        for (const count of Object.keys(val)) {
+          if (total.hasOwnProperty(count)) total[count] += val[count];
+          else total[count] = val[count];
+        }
+
+      const byConsortium = {};
+      for (const [key, vals] of Object.entries(counts)) {
+        const index = parseInt(key.split('_')[1]) - 1;
+        const name = names[index];
+
+        byConsortium[name] = {};
+        for (const val of vals)
+          for (const count of Object.keys(val)) {
+            if (byConsortium[name].hasOwnProperty(count))
+              byConsortium[name][count] += val[count];
+            else byConsortium[name][count] = val[count];
+          }
+      }
+
+      return {
+        ...state,
+        overviewCounts: { ...byConsortium, total, updatedAt: Date.now() },
+      };
+    }
     default:
       return state;
   }

--- a/src/Index/reducers.js
+++ b/src/Index/reducers.js
@@ -19,32 +19,9 @@ const index = (state = {}, action) => {
       };
     }
     case 'RECEIVE_INDEX_PAGE_OVERVIEW_COUNTS': {
-      const { names, counts_total, ...counts } = action.data;
-
-      const total = {};
-      for (const val of counts_total)
-        for (const count of Object.keys(val)) {
-          if (total.hasOwnProperty(count)) total[count] += val[count];
-          else total[count] = val[count];
-        }
-
-      const byConsortium = {};
-      for (const [key, vals] of Object.entries(counts)) {
-        const index = parseInt(key.split('_')[1]) - 1;
-        const name = names[index];
-
-        byConsortium[name] = {};
-        for (const val of vals)
-          for (const count of Object.keys(val)) {
-            if (byConsortium[name].hasOwnProperty(count))
-              byConsortium[name][count] += val[count];
-            else byConsortium[name][count] = val[count];
-          }
-      }
-
       return {
         ...state,
-        overviewCounts: { ...byConsortium, total, updatedAt: Date.now() },
+        overviewCounts: { ...action.data, updatedAt: Date.now() },
       };
     }
     default:

--- a/src/Index/reduxer.jsx
+++ b/src/Index/reduxer.jsx
@@ -6,6 +6,7 @@ import IndexBarChart from '../components/charts/IndexBarChart/.';
 import IndexCounts from '../components/cards/IndexCounts/.';
 import IndexButtonBar from '../components/IndexButtonBar';
 import Introduction from '../components/Introduction';
+import IndexOverview from './IndexOverview';
 import { components } from '../params';
 
 export const ReduxIndexBarChart = (() => {
@@ -49,6 +50,15 @@ export const ReduxIndexCounts = (() => {
     return {};
   };
   return connect(mapStateToProps, mapDispatchToProps)(IndexCounts);
+})();
+
+export const ReduxIndexOverview = (() => {
+  const mapStateToProps = (state) =>
+    state.index && state.index.overviewCounts
+      ? { overviewCounts: state.index.overviewCounts }
+      : {};
+
+  return connect(mapStateToProps)(IndexOverview);
 })();
 
 export const ReduxIndexButtonBar = (() => {

--- a/src/Index/relayer.js
+++ b/src/Index/relayer.js
@@ -5,7 +5,7 @@ import environment from '../environment';
 import { GQLHelper } from '../gqlHelper';
 import getReduxStore from '../reduxStore';
 
-const { indexPageQuery } = GQLHelper.getGQLHelper();
+const { indexPageQuery, indexPageOverviewQuery } = GQLHelper.getGQLHelper();
 const consortiumList = GQLHelper.getConsortiumList();
 
 export const getIndexPageChartData = () =>
@@ -17,6 +17,26 @@ export const getIndexPageChartData = () =>
         );
     },
     (error) => updateReduxError(error)
+  );
+
+export const getIndexPageOverviewData = () =>
+  getReduxStore().then(
+    (store) => {
+      const { overviewCounts } = store.getState().index;
+      const needsUpdate =
+        overviewCounts === undefined ||
+        Date.now() - overviewCounts.updatedAt > 300000;
+      if (needsUpdate)
+        fetchQuery(environment, indexPageOverviewQuery, {}).then(
+          (data) =>
+            store.dispatch({
+              type: 'RECEIVE_INDEX_PAGE_OVERVIEW_COUNTS',
+              data: { ...data, names: consortiumList },
+            }),
+          (error) => updateReduxError(error)
+        );
+    },
+    (err) => console.error('WARNING: failed to load redux store', err)
   );
 
 const checkIfNeedsUpdate = () =>

--- a/src/Index/relayer.js
+++ b/src/Index/relayer.js
@@ -4,9 +4,9 @@ import { fetchQuery } from 'relay-runtime';
 import environment from '../environment';
 import { GQLHelper } from '../gqlHelper';
 import getReduxStore from '../reduxStore';
+import { consortiumList } from '../params';
 
 const { indexPageQuery } = GQLHelper.getGQLHelper();
-const consortiumList = GQLHelper.getConsortiumList();
 
 export const getIndexPageChartData = () =>
   checkIfNeedsUpdate().then(

--- a/src/Index/relayer.js
+++ b/src/Index/relayer.js
@@ -5,7 +5,7 @@ import environment from '../environment';
 import { GQLHelper } from '../gqlHelper';
 import getReduxStore from '../reduxStore';
 
-const { indexPageQuery, indexPageOverviewQuery } = GQLHelper.getGQLHelper();
+const { indexPageQuery } = GQLHelper.getGQLHelper();
 const consortiumList = GQLHelper.getConsortiumList();
 
 export const getIndexPageChartData = () =>
@@ -17,26 +17,6 @@ export const getIndexPageChartData = () =>
         );
     },
     (error) => updateReduxError(error)
-  );
-
-export const getIndexPageOverviewData = () =>
-  getReduxStore().then(
-    (store) => {
-      const { overviewCounts } = store.getState().index;
-      const needsUpdate =
-        overviewCounts === undefined ||
-        Date.now() - overviewCounts.updatedAt > 300000;
-      if (needsUpdate)
-        fetchQuery(environment, indexPageOverviewQuery, {}).then(
-          (data) =>
-            store.dispatch({
-              type: 'RECEIVE_INDEX_PAGE_OVERVIEW_COUNTS',
-              data: { ...data, names: consortiumList },
-            }),
-          (error) => updateReduxError(error)
-        );
-    },
-    (err) => console.error('WARNING: failed to load redux store', err)
   );
 
 const checkIfNeedsUpdate = () =>

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -1,9 +1,7 @@
 import { fetchWithCreds } from '../actions';
 import { guppyDownloadUrl } from '../localconf';
 import getReduxStore from '../reduxStore';
-import { GQLHelper } from '../gqlHelper';
-
-const consortiumList = GQLHelper.getConsortiumList();
+import { consortiumList } from '../params';
 
 export function getIndexPageOverviewData() {
   const fetchOpts = {

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -1,0 +1,82 @@
+import { fetchWithCreds } from '../actions';
+import { guppyDownloadUrl } from '../localconf';
+import getReduxStore from '../reduxStore';
+import { GQLHelper } from '../gqlHelper';
+
+const consortiumList = GQLHelper.getConsortiumList();
+
+export function getIndexPageOverviewData() {
+  const fetchOpts = {
+    path: guppyDownloadUrl,
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'subject',
+      fields: ['consortium', 'study_id', '_molecular_analysis_count'],
+    }),
+    customHeaders: {
+      Accept: 'application/json',
+      Signature: 'signature token',
+    },
+  };
+
+  getReduxStore().then(
+    (store) => {
+      const { overviewCounts } = store.getState().index;
+      const needsUpdate =
+        overviewCounts === undefined ||
+        Date.now() - overviewCounts.updatedAt > 300000;
+      if (needsUpdate)
+        fetchWithCreds(fetchOpts).then(({ data, response }) => {
+          if (response.status === 200) {
+            store.dispatch({
+              type: 'RECEIVE_INDEX_PAGE_OVERVIEW_COUNTS',
+              data: getCountsData(data),
+            });
+          } else
+            console.error(
+              'WARNING: failed to with status',
+              response.statusText
+            );
+        });
+    },
+    (err) => console.error('WARNING: failed to load redux store', err)
+  );
+}
+
+function getCountsData(rawData) {
+  const data = [];
+  for (const { consortium, study_id, _molecular_analysis_count } of rawData)
+    data.push({
+      consortium,
+      molecular_analysis_count: _molecular_analysis_count,
+      study_id,
+    });
+
+  const counts = { total: getCountObject(data) };
+  for (const consortium of consortiumList)
+    counts[consortium] = getCountObject(data, consortium);
+
+  return { ...counts, names: consortiumList };
+}
+
+function getCountObject(data, whichConsortium) {
+  let molecularAnalysisCount = 0;
+  let studySet = new Set();
+  let subjectCount = whichConsortium === undefined ? data.length : 0;
+
+  for (const { consortium, study_id, molecular_analysis_count } of data)
+    if (whichConsortium === undefined) {
+      molecularAnalysisCount += molecular_analysis_count;
+      for (const id of study_id) studySet.add(id);
+    } else if (whichConsortium === consortium) {
+      molecularAnalysisCount += molecular_analysis_count;
+      for (const id of study_id) studySet.add(id);
+      subjectCount++;
+    }
+
+  return {
+    molecular_analysis: molecularAnalysisCount,
+    study: studySet.size,
+    subject: subjectCount,
+  };
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,7 +7,12 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import 'react-select/dist/react-select.css';
 import querystring from 'querystring';
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAngleUp,
+  faAngleDown,
+  faFlask,
+  faMicroscope,
+} from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import { Helmet } from 'react-helmet';
 
@@ -78,7 +83,7 @@ async function init() {
     store.dispatch(fetchUserAuthMapping),
   ]);
   // FontAwesome icons
-  library.add(faAngleUp, faAngleDown);
+  library.add(faAngleUp, faAngleDown, faFlask, faMicroscope);
 
   render(
     <div>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,7 @@ import {
   faAngleDown,
   faFlask,
   faMicroscope,
+  faUser,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import { Helmet } from 'react-helmet';
@@ -83,7 +84,7 @@ async function init() {
     store.dispatch(fetchUserAuthMapping),
   ]);
   // FontAwesome icons
-  library.add(faAngleUp, faAngleDown, faFlask, faMicroscope);
+  library.add(faAngleUp, faAngleDown, faFlask, faMicroscope, faUser);
 
   render(
     <div>


### PR DESCRIPTION
For [PEDS-101](https://pcdc.atlassian.net/browse/PEDS-101)

This PR adds "Overview" component to the index page, which displays per-consortium counts for select fields--currently subjects, studies, and molecular analyses.

In addition:
* `consortiumList` is now exported to `params.js` rather than as part of gqlHelper
* `react-router-dom` is bumped to v5