### PR TITLE
Bump material ui from v0.x to v4.x PEDS-129

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,8 +1695,7 @@
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "dev": true
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -2657,6 +2656,124 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
+      }
+    },
+    "@material-ui/core": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
+      "integrity": "sha512-bYo9uIub8wGhZySHqLQ833zi4ZML+XCBE1XwJ8EuUVSpTWWG57Pm+YugQToJNFsEyiKFhPh8DPD0bgupz8n01g==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.10.0",
+        "@material-ui/system": "^4.9.14",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.10.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.4.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+        },
+        "dom-helpers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
+      "integrity": "sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.9.14",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
+      "integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+      "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
       }
     },
     "@mdx-js/mdx": {
@@ -5037,6 +5154,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
       "integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
       "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -8943,6 +9068,15 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
+      }
+    },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
       }
     },
     "css-what": {
@@ -13406,6 +13540,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -15203,6 +15342,91 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
+      "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.4.0.tgz",
+      "integrity": "sha512-9oDjsQ/AgdBbMyRjc06Kl3P8lDCSEts2vYZiPZfGAxbGCegqE4RnMob3mDaBby5H9vL9gWmyyImhLRWqIkRUCw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.4.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.4.0.tgz",
+      "integrity": "sha512-BYJ+Y3RUYiMEgmlcYMLqwbA49DcSWsGgHpVmEEllTC8MK5iJ7++pT9TnKkKBnNZZxTV75ycyFCR5xeLSOzVm4A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.4.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.4.0.tgz",
+      "integrity": "sha512-b8IHMJUmv29cidt3nI4bUI1+Mo5RZE37kqthaFpmxf5K7r2aAegGliAw4hXvA70ca6ckAoXMUl4SN/zxiRcRag==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.4.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.4.0.tgz",
+      "integrity": "sha512-cKgpeHIxAP0ygeWh+drpLbrxFiak6zzJ2toVRi/NmHbpkNaLjTLgePmOz5+67ln3qzJiPdXXJB1tbOyYKAP4Pw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.4.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.4.0.tgz",
+      "integrity": "sha512-j/t0R40/2fp+Nzt6GgHeUFnHVY2kPGF5drUVlgkcwYoHCgtBDOhTTsOfdaQFW6sHWfoQYgnGV4CXdjlPiRrzwA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.4.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.4.0.tgz",
+      "integrity": "sha512-w8504Cdfu66+0SJoLkr6GUQlEb8keHg8ymtJXdVHWh0YvFxDG2l/nS93SI5Gfx0fV29dO6yUugXnKzDFJxrdFQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.4.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.4.0.tgz",
+      "integrity": "sha512-DpF+/a+GU8hMh/948sBGnKSNfKkoHg2p9aRFUmyoyxgKjOeH9n74Ht3Yt8lOgdZsuWNJbPrvaa3U4PXKwxVpTQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.4.0"
       }
     },
     "jsx-ast-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7486,11 +7486,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -8050,11 +8045,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
       "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
     },
-    "chain-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
-    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -8066,11 +8056,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "character-entities": {
       "version": "1.2.4",
@@ -8972,15 +8957,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
-    },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
     },
     "css-loader": {
       "version": "3.5.3",
@@ -13161,15 +13137,6 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
       "dev": true
     },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
-    },
     "inquirer": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
@@ -15446,11 +15413,6 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
-    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -16110,11 +16072,6 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -16347,38 +16304,6 @@
       "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
       "requires": {
         "css-mediaquery": "^0.1.2"
-      }
-    },
-    "material-ui": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.19.4.tgz",
-      "integrity": "sha1-ypzcqKqLtZTfrF2zjsn/BFoyNYc=",
-      "requires": {
-        "babel-runtime": "^6.23.0",
-        "inline-style-prefixer": "^3.0.2",
-        "keycode": "^2.1.8",
-        "lodash.merge": "^4.6.0",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.5.7",
-        "react-event-listener": "^0.5.1",
-        "react-transition-group": "^1.2.1",
-        "recompose": "^0.26.0",
-        "simple-assign": "^0.1.0",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-          "requires": {
-            "chain-function": "^1.0.0",
-            "dom-helpers": "^3.2.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.5.6",
-            "warning": "^3.0.0"
-          }
-        }
       }
     },
     "math-expression-evaluator": {
@@ -23698,33 +23623,6 @@
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==",
       "dev": true
     },
-    "react-event-listener": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.10.tgz",
-      "integrity": "sha512-YZklRszh9hq3WP3bdNLjFwJcTCVe7qyTf5+LWNaHfZQaZrptsefDK2B5HHpOsEEaMHvjllUPr0+qIFVTSsurow==",
-      "requires": {
-        "@babel/runtime": "7.0.0-beta.42",
-        "fbjs": "^0.8.16",
-        "prop-types": "^15.6.0",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.0.0-beta.42",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.42.tgz",
-          "integrity": "sha512-iOGRzUoONLOtmCvjUsZv3mZzgCT6ljHQY5fr1qG1QIiJQwtM7zbPWGGpa3QWETq+UqwWyJnoi5XZDZRwZDFciQ==",
-          "requires": {
-            "core-js": "^2.5.3",
-            "regenerator-runtime": "^0.11.1"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "react-fast-compare": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.1.1.tgz",
@@ -24335,17 +24233,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "recompose": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-      "requires": {
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "symbol-observable": "^1.0.4"
       }
     },
     "recursive-readdir": {
@@ -25799,11 +25686,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
       "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo="
-    },
-    "simple-assign": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
-      "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
     },
     "simplebar": {
       "version": "4.2.3",
@@ -28378,14 +28260,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/react-fontawesome": "^0.1.0",
     "@gen3/guppy": "^0.6.1",
     "@gen3/ui-component": "^0.5.1",
+    "@material-ui/core": "^4.11.0",
     "brace": "^0.10.0",
     "clipboard-plus": "^1.0.0",
     "d3-array": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "jszip": "^3.1.5",
-    "material-ui": "^0.19.2",
     "moment": "^2.22.2",
     "pluralize": "^8.0.0",
     "prop-types": "^15.6.0",

--- a/src/Submission/SubmitForm.jsx
+++ b/src/Submission/SubmitForm.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { Toggle } from 'material-ui';
 import PropTypes from 'prop-types';
+import Switch from '@material-ui/core/Switch';
 import Select from 'react-select';
 import { jsonToString } from '../utils';
 import SubmitNodeForm from './SubmitNodeForm';
@@ -113,11 +113,11 @@ class SubmitForm extends Component {
     return (
       <div>
         <form>
-          <Toggle
-            label='Use Form Submission'
-            labelStyle={{ width: '' }}
-            onToggle={this.onFormToggle}
-          />
+          <label style={{ display: 'block' }}>
+            Use Form Submission
+            <Switch onChange={this.onFormToggle} />
+          </label>
+
           {this.state.fill_form && (
             <Select
               name='nodeType'

--- a/src/Submission/SubmitTSV.test.jsx
+++ b/src/Submission/SubmitTSV.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import * as testData from './__test__/data.json';
 
 import SubmitTSV from './SubmitTSV';
@@ -27,23 +26,21 @@ describe('the TSV submission component', () => {
     uploadCallback = () => {}
   ) {
     const $dom = mount(
-      <MuiThemeProvider>
-        <SubmitTSV
-          project={testProjName}
-          submission={submission}
-          onUploadClick={(newFile, fileType) => {
-            console.log('onUploadClick');
-            uploadCallback(newFile, fileType);
-          }}
-          onSubmitClick={(project) => {
-            console.log('onSubmitClick');
-            submitCallback(project);
-          }}
-          onFileChange={() => {
-            console.log('onFileChange');
-          }}
-        />
-      </MuiThemeProvider>
+      <SubmitTSV
+        project={testProjName}
+        submission={submission}
+        onUploadClick={(newFile, fileType) => {
+          console.log('onUploadClick');
+          uploadCallback(newFile, fileType);
+        }}
+        onSubmitClick={(project) => {
+          console.log('onSubmitClick');
+          submitCallback(project);
+        }}
+        onFileChange={() => {
+          console.log('onFileChange');
+        }}
+      />
     );
 
     return { $dom };

--- a/src/components/tables/ProjectTable.test.jsx
+++ b/src/components/tables/ProjectTable.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { StaticRouter } from 'react-router-dom';
 
 import ProjectTable from './ProjectTable';
@@ -14,13 +13,10 @@ test('Project tables renders', () => {
   ];
   const summaryCounts = [5, 20, 30, 200];
 
-  // Material-UI components require the Mui theme ...
   const table = mount(
-    <MuiThemeProvider>
-      <StaticRouter location={{ pathname: '/identity' }} context={{}}>
-        <ProjectTable projectList={projectList} summaryCounts={summaryCounts} />
-      </StaticRouter>
-    </MuiThemeProvider>
+    <StaticRouter location={{ pathname: '/identity' }} context={{}}>
+      <ProjectTable projectList={projectList} summaryCounts={summaryCounts} />
+    </StaticRouter>
   );
   // 2 == 1 data row + 1 summary totals row
   expect(table.find('tbody tr').length).toBe(1);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,7 +3,6 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import 'react-select/dist/react-select.css';
 import querystring from 'querystring';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -88,143 +87,191 @@ async function init() {
     <div>
       <Provider store={store}>
         <ThemeProvider theme={theme}>
-          <MuiThemeProvider>
-            <BrowserRouter basename={basename}>
-              <div>
-                {GA.init(gaTracking, dev, gaDebug) && <RouteTracker />}
-                {isEnabled('noIndex') ? (
-                  <Helmet>
-                    <meta name='robots' content='noindex,nofollow' />
-                  </Helmet>
-                ) : null}
-                <ReduxTopBar />
-                <ReduxNavBar />
-                <div className='main-content'>
-                  <Switch>
-                    <Route
-                      path='/login'
-                      component={(props) => (
+          <BrowserRouter basename={basename}>
+            <div>
+              {GA.init(gaTracking, dev, gaDebug) && <RouteTracker />}
+              {isEnabled('noIndex') ? (
+                <Helmet>
+                  <meta name='robots' content='noindex,nofollow' />
+                </Helmet>
+              ) : null}
+              <ReduxTopBar />
+              <ReduxNavBar />
+              <div className='main-content'>
+                <Switch>
+                  <Route
+                    path='/login'
+                    component={(props) => (
+                      <ProtectedContent
+                        isPublic
+                        filter={() => store.dispatch(fetchLogin())}
+                        component={ReduxLogin}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/'
+                    component={(props) => (
+                      <ProtectedContent component={IndexPage} {...props} />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/submission'
+                    component={(props) => (
+                      <ProtectedContent
+                        isAdminOnly
+                        component={SubmissionPage}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/submission/files'
+                    component={(props) => (
+                      <ProtectedContent
+                        isAdminOnly
+                        component={ReduxMapFiles}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/submission/map'
+                    component={(props) => (
+                      <ProtectedContent
+                        isAdminOnly
+                        component={ReduxMapDataModel}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/document'
+                    component={(props) => (
+                      <ProtectedContent component={DocumentPage} {...props} />
+                    )}
+                  />
+                  <Route
+                    path='/query'
+                    component={(props) => (
+                      <ProtectedContent component={GraphQLQuery} {...props} />
+                    )}
+                  />
+                  <Route
+                    path='/identity'
+                    component={(props) => (
+                      <ProtectedContent
+                        filter={() => store.dispatch(fetchAccess())}
+                        component={UserProfile}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    path='/indexing'
+                    component={(props) => (
+                      <ProtectedContent component={Indexing} {...props} />
+                    )}
+                  />
+                  <Route
+                    path='/quiz'
+                    component={(props) => (
+                      <ProtectedContent
+                        component={UserAgreementCert}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    path='/dd/:node'
+                    component={(props) => (
+                      <ProtectedContent component={DataDictionary} {...props} />
+                    )}
+                  />
+                  <Route
+                    path='/dd'
+                    component={(props) => (
+                      <ProtectedContent component={DataDictionary} {...props} />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/files/*'
+                    component={(props) => (
+                      <ProtectedContent
+                        filter={() =>
+                          store.dispatch(
+                            fetchCoreMetadata(props.match.params[0])
+                          )
+                        }
+                        component={CoreMetadataPage}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    path='/files'
+                    component={(props) => (
+                      <ProtectedContent
+                        component={GuppyDataExplorer}
+                        {...props}
+                      />
+                    )}
+                  />
+                  <Route
+                    path='/workspace'
+                    component={(props) => (
+                      <ProtectedContent component={Workspace} {...props} />
+                    )}
+                  />
+                  <Route
+                    path={workspaceUrl}
+                    component={ErrorWorkspacePlaceholder}
+                  />
+                  <Route
+                    path={workspaceErrorUrl}
+                    component={ErrorWorkspacePlaceholder}
+                  />
+                  <Route
+                    path='/:project/search'
+                    component={(props) => {
+                      const queryFilter = () => {
+                        const location = props.location;
+                        const queryParams = querystring.parse(
+                          location.search
+                            ? location.search.replace(/^\?+/, '')
+                            : ''
+                        );
+                        if (Object.keys(queryParams).length > 0) {
+                          // Linking directly to a search result,
+                          // so kick-off search here (rather than on button click)
+                          return store.dispatch(
+                            submitSearchForm({
+                              project: props.match.params.project,
+                              ...queryParams,
+                            })
+                          );
+                        }
+                        return Promise.resolve('ok');
+                      };
+                      return (
                         <ProtectedContent
-                          isPublic
-                          filter={() => store.dispatch(fetchLogin())}
-                          component={ReduxLogin}
+                          filter={queryFilter}
+                          component={ReduxQueryNode}
                           {...props}
                         />
-                      )}
-                    />
+                      );
+                    }}
+                  />
+                  {isEnabled('explorer') ? (
                     <Route
-                      exact
-                      path='/'
-                      component={(props) => (
-                        <ProtectedContent component={IndexPage} {...props} />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path='/submission'
-                      component={(props) => (
-                        <ProtectedContent
-                          isAdminOnly
-                          component={SubmissionPage}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path='/submission/files'
-                      component={(props) => (
-                        <ProtectedContent
-                          isAdminOnly
-                          component={ReduxMapFiles}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path='/submission/map'
-                      component={(props) => (
-                        <ProtectedContent
-                          isAdminOnly
-                          component={ReduxMapDataModel}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path='/document'
-                      component={(props) => (
-                        <ProtectedContent component={DocumentPage} {...props} />
-                      )}
-                    />
-                    <Route
-                      path='/query'
-                      component={(props) => (
-                        <ProtectedContent component={GraphQLQuery} {...props} />
-                      )}
-                    />
-                    <Route
-                      path='/identity'
-                      component={(props) => (
-                        <ProtectedContent
-                          filter={() => store.dispatch(fetchAccess())}
-                          component={UserProfile}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      path='/indexing'
-                      component={(props) => (
-                        <ProtectedContent component={Indexing} {...props} />
-                      )}
-                    />
-                    <Route
-                      path='/quiz'
-                      component={(props) => (
-                        <ProtectedContent
-                          component={UserAgreementCert}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      path='/dd/:node'
-                      component={(props) => (
-                        <ProtectedContent
-                          component={DataDictionary}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      path='/dd'
-                      component={(props) => (
-                        <ProtectedContent
-                          component={DataDictionary}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      exact
-                      path='/files/*'
-                      component={(props) => (
-                        <ProtectedContent
-                          filter={() =>
-                            store.dispatch(
-                              fetchCoreMetadata(props.match.params[0])
-                            )
-                          }
-                          component={CoreMetadataPage}
-                          {...props}
-                        />
-                      )}
-                    />
-                    <Route
-                      path='/files'
+                      path='/explorer'
                       component={(props) => (
                         <ProtectedContent
                           component={GuppyDataExplorer}
@@ -232,99 +279,43 @@ async function init() {
                         />
                       )}
                     />
+                  ) : null}
+                  {components.privacyPolicy &&
+                  (!!components.privacyPolicy.file ||
+                    !!components.privacyPolicy.routeHref) ? (
                     <Route
-                      path='/workspace'
-                      component={(props) => (
-                        <ProtectedContent component={Workspace} {...props} />
-                      )}
+                      path='/privacy-policy'
+                      component={ReduxPrivacyPolicy}
                     />
+                  ) : null}
+                  {enableResourceBrowser ? (
                     <Route
-                      path={workspaceUrl}
-                      component={ErrorWorkspacePlaceholder}
-                    />
-                    <Route
-                      path={workspaceErrorUrl}
-                      component={ErrorWorkspacePlaceholder}
-                    />
-                    <Route
-                      path='/:project/search'
-                      component={(props) => {
-                        const queryFilter = () => {
-                          const location = props.location;
-                          const queryParams = querystring.parse(
-                            location.search
-                              ? location.search.replace(/^\?+/, '')
-                              : ''
-                          );
-                          if (Object.keys(queryParams).length > 0) {
-                            // Linking directly to a search result,
-                            // so kick-off search here (rather than on button click)
-                            return store.dispatch(
-                              submitSearchForm({
-                                project: props.match.params.project,
-                                ...queryParams,
-                              })
-                            );
-                          }
-                          return Promise.resolve('ok');
-                        };
-                        return (
-                          <ProtectedContent
-                            filter={queryFilter}
-                            component={ReduxQueryNode}
-                            {...props}
-                          />
-                        );
-                      }}
-                    />
-                    {isEnabled('explorer') ? (
-                      <Route
-                        path='/explorer'
-                        component={(props) => (
-                          <ProtectedContent
-                            component={GuppyDataExplorer}
-                            {...props}
-                          />
-                        )}
-                      />
-                    ) : null}
-                    {components.privacyPolicy &&
-                    (!!components.privacyPolicy.file ||
-                      !!components.privacyPolicy.routeHref) ? (
-                      <Route
-                        path='/privacy-policy'
-                        component={ReduxPrivacyPolicy}
-                      />
-                    ) : null}
-                    {enableResourceBrowser ? (
-                      <Route
-                        path='/resource-browser'
-                        component={(props) => (
-                          <ProtectedContent
-                            component={ResourceBrowser}
-                            {...props}
-                          />
-                        )}
-                      />
-                    ) : null}
-                    <Route
-                      path='/:project'
+                      path='/resource-browser'
                       component={(props) => (
                         <ProtectedContent
-                          component={ProjectSubmission}
+                          component={ResourceBrowser}
                           {...props}
                         />
                       )}
                     />
-                  </Switch>
-                </div>
-                <ReduxFooter
-                  logos={components.footerLogos}
-                  privacyPolicy={components.privacyPolicy}
-                />
+                  ) : null}
+                  <Route
+                    path='/:project'
+                    component={(props) => (
+                      <ProtectedContent
+                        component={ProjectSubmission}
+                        {...props}
+                      />
+                    )}
+                  />
+                </Switch>
               </div>
-            </BrowserRouter>
-          </MuiThemeProvider>
+              <ReduxFooter
+                logos={components.footerLogos}
+                privacyPolicy={components.privacyPolicy}
+              />
+            </div>
+          </BrowserRouter>
         </ThemeProvider>
       </Provider>
     </div>,


### PR DESCRIPTION
For [PEDS-129](https://pcdc.atlassian.net/browse/PEDS-129)

This PR updates material ui to the latest stable version that better supports tree-shaking. This change cuts the imported library size down to 1/4 gzipped, from ~100KB to ~25KB.

This PR also removes use of material-ui `<ThemeProvider>` which did not have any notable effect on UI.
