### PR TITLE
Retire Moment.js and replace with Day.js PEDS-129

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16843,11 +16843,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
-    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9315,6 +9315,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.3.tgz",
+      "integrity": "sha512-V+1SyIvkS+HmNbN1G7A9+ERbFTV9KTXu6Oor98v2xHmzzpp52OIJhQuJSTywWuBY5pyAEmlwbCi1Me87n/SLOw=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "jszip": "^3.1.5",
-    "moment": "^2.22.2",
     "pluralize": "^8.0.0",
     "prop-types": "^15.6.0",
     "query-string": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "d3-selection": "^1.1.0",
     "d3-transition": "^1.1.3",
     "d3-zoom": "^1.7.3",
+    "dayjs": "^1.9.3",
     "echarts": "^4.2.1",
     "echarts-for-react": "^2.0.14",
     "file-saver": "^1.3.3",

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { AutoSizer, Column, Table } from 'react-virtualized';
 import 'react-virtualized/styles.css'; // only needs to be imported once
 import Button from '@gen3/ui-component/dist/components/Button';
@@ -17,6 +18,8 @@ import './MapFiles.less';
 const SET_KEY = 'did';
 const ROW_HEIGHT = 70;
 const HEADER_HEIGHT = 70;
+
+dayjs.extend(customParseFormat);
 
 class MapFiles extends React.Component {
   constructor(props) {
@@ -67,7 +70,7 @@ class MapFiles extends React.Component {
   getSetSize = (set) => Object.keys(set).length;
 
   getTableHeaderText = (files) => {
-    const date = moment(files[0].created_date).format('MM/DD/YY');
+    const date = dayjs(files[0].created_date).format('MM/DD/YY');
     return `uploaded on ${date}, ${files.length} ${
       files.length > 1 ? 'files' : 'file'
     }`;
@@ -163,7 +166,7 @@ class MapFiles extends React.Component {
   groupUnmappedFiles = () => {
     const groupedFiles = {};
     this.props.unmappedFiles.forEach((file) => {
-      const fileDate = moment(file.created_date).format('MM/DD/YY');
+      const fileDate = dayjs(file.created_date).format('MM/DD/YY');
       if (groupedFiles[fileDate]) {
         groupedFiles[fileDate].push(file);
       } else {
@@ -171,7 +174,7 @@ class MapFiles extends React.Component {
       }
     });
     const sortedDates = Object.keys(groupedFiles).sort(
-      (a, b) => moment(b, 'MM/DD/YY') - moment(a, 'MM/DD/YY')
+      (a, b) => dayjs(b, 'MM/DD/YY') - dayjs(a, 'MM/DD/YY')
     );
     this.setState({ sortedDates });
     return groupedFiles;
@@ -357,7 +360,7 @@ class MapFiles extends React.Component {
                         width={300}
                         cellRenderer={({ cellData }) => (
                           <div>
-                            {moment(cellData).format(
+                            {dayjs(cellData).format(
                               'MM/DD/YY, hh:mm:ss a [UTC]Z'
                             )}
                           </div>


### PR DESCRIPTION
For [PEDS-129](https://pcdc.atlassian.net/browse/PEDS-129)

This PR retires heavyweight and [now-legacy](https://momentjs.com/docs/#/-project-status/) Moment.js and replace it with a lighter and modern alternative, Day.js. This change cuts the library size down to 1/16 gzipped, from ~64KB to ~4KB.