### PR TITLE
Exclude data_contributor_id as survival factor PEDS-139

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -8,10 +8,11 @@ const isString = (x) => Object.prototype.toString.call(x) === '[object String]';
  */
 export const getFactors = (aggsData) => {
   const factors = [];
+  const exceptions = ['project_id', 'data_contributor_id'];
 
   for (const [key, value] of Object.entries(aggsData))
     if (
-      key !== 'project_id' &&
+      !exceptions.includes(key) &&
       value.histogram.length > 0 &&
       isString(value.histogram[0].key)
     )


### PR DESCRIPTION
For [PEDS-139](https://pcdc.atlassian.net/browse/PEDS-139)

For the record, it may be worth discussing in future whether to exclude all `id`-type filters from survival analysis factor variable options.