### PR TITLE
Remove redux-form PEDS-129

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9371,6 +9371,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -10184,11 +10185,6 @@
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.14.tgz",
       "integrity": "sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==",
       "dev": true
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -13365,7 +13361,8 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -13621,11 +13618,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -21517,6 +21509,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -24310,28 +24303,6 @@
         "symbol-observable": "^1.0.2"
       }
     },
-    "redux-form": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-6.8.0.tgz",
-      "integrity": "sha512-rISN+EERGB8nAS/LDnOSQaTf0f+QreXEq+7pRVvBFzmH5vIsYRwVpBtYA8UsibGzO+0BL1bl5L5bxdrNwxI+sA==",
-      "requires": {
-        "deep-equal": "^1.0.1",
-        "es6-error": "^4.0.0",
-        "hoist-non-react-statics": "^1.2.0",
-        "invariant": "^2.2.2",
-        "is-promise": "^2.1.0",
-        "lodash": "^4.17.3",
-        "lodash-es": "^4.17.3",
-        "prop-types": "^15.5.9"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-        }
-      }
-    },
     "redux-mock-store": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
@@ -24427,6 +24398,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-virtualized": "^9.21.0",
     "recharts": "^1.0.0-beta.10",
     "redux": "^3.7.0",
-    "redux-form": "^6.5.0",
     "redux-persist": "^4.7.1",
     "redux-thunk": "^2.2.0",
     "relay-compiler": "^1.6.0",

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,4 +1,3 @@
-import { reducer as formReducer } from 'redux-form';
 import { combineReducers } from 'redux';
 import userProfile from './UserProfile/reducers';
 import coreMetadata from './CoreMetadata/reducers';
@@ -102,7 +101,6 @@ const reducers = combineReducers({
   certificate,
   graphiql,
   login,
-  form: formReducer,
   auth: logoutListener,
   ddgraph,
   userAccess,


### PR DESCRIPTION
For [PEDS-129](https://pcdc.atlassian.net/browse/PEDS-129)

This PR removes from dependencies unused and [now deprecated](https://github.com/redux-form/redux-form#%EF%B8%8F-attention-%EF%B8%8F) redux-form (~18kb gzipped), which, In fact, seems to have never really been used in the portal codebase since v0.5.0.