### PR TITLE
Remove obsolete token check PEDS-145

### DIFF
--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -59,7 +59,7 @@ export const ReduxCoreMetadataHeader = (() => {
     signedURLPopup: state.popups.signedURLPopup,
     error: state.coreMetadata.error,
     userAuthMapping: state.userAuthMapping,
-    projectAvail: state.submission.projectAvail,
+    projectAvail: state.project.projectAvail,
   });
 
   const mapDispatchToProps = (dispatch) => ({

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -25,7 +25,6 @@ import './ProtectedContent.css';
 /** @typedef {Object} ReduxStore */
 
 let lastAuthMs = 0;
-let lastTokenRefreshMs = 0;
 
 /**
  * Redux listener - just clears auth-cache on logout
@@ -34,7 +33,6 @@ export function logoutListener(state = {}, action) {
   switch (action.type) {
     case 'RECEIVE_API_LOGOUT':
       lastAuthMs = 0;
-      lastTokenRefreshMs = 0;
       break;
     default: // noop
   }

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -111,7 +111,6 @@ class ProtectedContent extends React.Component {
             .then((newState) => this.checkIfRegisterd(newState))
             .then((newState) => this.checkIfAdmin(newState))
             .then((newState) => this.checkQuizStatus(newState))
-            .then((newState) => this.checkApiToken(store, newState))
             .then((newState) => {
               const latestState = { ...newState, dataLoaded: true };
 
@@ -189,77 +188,6 @@ class ProtectedContent extends React.Component {
       initialState.user.authz.hasOwnProperty(resourcePath) &&
       initialState.user.authz[resourcePath][0].method === '*';
     return isAdminUser ? initialState : { ...initialState, redirectTo: '/' };
-  };
-
-  /**
-   * Filter refreshes the gdc-api token (acquired via oauth with user-api) if necessary.
-   * @param {ReduxStore} store
-   * @param {ComponentState} initialState
-   * @returns {Promise<ComponentState>}
-   */
-  checkApiToken = (store, initialState) => {
-    if (!initialState.authenticated || Date.now() - lastTokenRefreshMs < 41000)
-      return Promise.resolve(initialState);
-
-    // Assume fetchProjects either succeeds or fails.
-    // If fails (no project data), then refresh api token.
-    return store.dispatch(fetchProjects()).then((info) => {
-      if (
-        // user already has a valid token
-        store.getState().submission.projects ||
-        // or, do not authenticate unless we have a 403 or 401
-        // should only check 401 after we fix fence to return correct error code for all cases
-        // there may be no tables at startup time, or some other weirdness ...
-        info.status !== 403 ||
-        info.status !== 401
-      )
-        return Promise.resolve(initialState);
-
-      // NOW DEPRECATED: jwt access token works across all services
-      // The oauth dance below is only relevant for legacy commons - pre jwt
-      return (
-        store
-          .dispatch(fetchOAuthURL(submissionApiOauthPath))
-          .then((oauthUrl) =>
-            fetchWithCreds({
-              path: oauthUrl,
-              dispatch: store.dispatch.bind(store),
-            })
-          )
-          .then(({ status, data }) => {
-            switch (status) {
-              case 200:
-                return {
-                  type: 'RECEIVE_SUBMISSION_LOGIN',
-                  result: true,
-                };
-              default: {
-                return {
-                  type: 'RECEIVE_SUBMISSION_LOGIN',
-                  result: false,
-                  error: data,
-                };
-              }
-            }
-          })
-          .then((msg) => store.dispatch(msg))
-          // refetch the tables - since the earlier call failed with an invalid token
-          .then(() => store.dispatch(fetchProjects()))
-          .then(
-            () => {
-              lastTokenRefreshMs = Date.now();
-              return initialState;
-            },
-            // re-login if something went wrong
-            () => ({
-              ...initialState,
-              authenticated: false,
-              redirectTo: '/login',
-              from: this.props.location,
-            })
-          )
-      );
-    });
   };
 
   /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import {
-  fetchUser,
-  fetchOAuthURL,
-  fetchWithCreds,
-  fetchProjects,
-} from '../actions';
+import { fetchUser } from '../actions';
 import Spinner from '../components/Spinner';
 import getReduxStore from '../reduxStore';
-import { requiredCerts, submissionApiOauthPath } from '../localconf';
+import { requiredCerts } from '../localconf';
 import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 import { intersection, isPageFullScreen } from '../utils';
 import './ProtectedContent.css';

--- a/src/Submission/reducers.js
+++ b/src/Submission/reducers.js
@@ -13,20 +13,6 @@ const submission = (state = {}, action) => {
         ...state,
         formSchema: { ...state.formSchema, ...action.formSchema },
       };
-    case 'RECEIVE_PROJECTS':
-      return {
-        ...state,
-        projects: action.data.reduce((map, p) => {
-          const res = map;
-          res[p.code] = p.project_id;
-          return res;
-        }, {}),
-        projectAvail: action.data.reduce((map, p) => {
-          const res = map;
-          res[p.project_id] = p.availability_type;
-          return res;
-        }, {}),
-      };
     case 'RECEIVE_PROJECT_LIST': {
       //
       // Note - save projectsByName, b/c we acquire more data for individual tables

--- a/src/Submission/reducers.js
+++ b/src/Submission/reducers.js
@@ -73,10 +73,6 @@ const submission = (state = {}, action) => {
         nodeTypes: getNodeTypes(action.data),
         file_nodes: getFileNodes(action.data),
       };
-    case 'RECEIVE_AUTHORIZATION_URL':
-      return { ...state, oauth_url: action.url };
-    case 'RECEIVE_SUBMISSION_LOGIN':
-      return { ...state, login: state.result, error: state.error };
     case 'RECEIVE_SUBMISSION': {
       const prevCounts =
         'submit_entity_counts' in state ? state.submit_entity_counts : {};

--- a/src/UserProfile/ReduxUserProfile.js
+++ b/src/UserProfile/ReduxUserProfile.js
@@ -102,7 +102,7 @@ const mapStateToProps = (state) => ({
   userProfile: state.userProfile,
   userAuthMapping: state.userAuthMapping,
   popups: state.popups,
-  projects: state.submission.projects,
+  projects: state.project.projects,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/UserProfile/ReduxUserProfile.js
+++ b/src/UserProfile/ReduxUserProfile.js
@@ -102,7 +102,7 @@ const mapStateToProps = (state) => ({
   userProfile: state.userProfile,
   userAuthMapping: state.userAuthMapping,
   popups: state.popups,
-  submission: state.submission,
+  projects: state.submission.projects,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/UserProfile/UserProfile.jsx
+++ b/src/UserProfile/UserProfile.jsx
@@ -32,7 +32,7 @@ const UserProfile = ({
   userProfile,
   userAuthMapping,
   popups,
-  submission,
+  projects,
   onCreateKey,
   onClearCreationSession,
   onUpdatePopup,
@@ -143,15 +143,12 @@ const UserProfile = ({
       )}
       {showFenceAuthzOnProfile && (
         <AccessTable
-          projects={submission.projects}
+          projects={projects}
           projectsAccesses={user.project_access}
         />
       )}
       {showArboristAuthzOnProfile && (
-        <AccessTable
-          projects={submission.projects}
-          userAuthMapping={userAuthMapping}
-        />
+        <AccessTable projects={projects} userAuthMapping={userAuthMapping} />
       )}
     </div>
   );
@@ -162,7 +159,7 @@ UserProfile.propTypes = {
   userProfile: PropTypes.object.isRequired,
   userAuthMapping: PropTypes.object.isRequired,
   popups: PropTypes.object.isRequired,
-  submission: PropTypes.object,
+  projects: PropTypes.object,
   onClearCreationSession: PropTypes.func.isRequired,
   onCreateKey: PropTypes.func.isRequired,
   onUpdatePopup: PropTypes.func.isRequired,
@@ -172,7 +169,7 @@ UserProfile.propTypes = {
 };
 
 UserProfile.defaultProps = {
-  submission: {},
+  projects: {},
 };
 
 export default UserProfile;

--- a/src/actions.js
+++ b/src/actions.js
@@ -336,40 +336,6 @@ export const fetchUserNoRefresh = (dispatch) =>
     .then((status, data) => handleFetchUser(status, data))
     .then((msg) => dispatch(msg));
 
-/**
- * Retrieve the oath endpoint for the service under the given oathPath
- *
- * @param {String} oauthPath
- * @return {(dispatch) => Promise<string>} dispatch function
- */
-export const fetchOAuthURL = (oauthPath) => (dispatch) =>
-  fetchWithCreds({
-    path: `${oauthPath}authorization_url`,
-    dispatch,
-    useCache: true,
-  })
-    .then(({ status, data }) => {
-      switch (status) {
-        case 200:
-          return {
-            type: 'RECEIVE_AUTHORIZATION_URL',
-            url: data,
-          };
-        default:
-          return {
-            type: 'FETCH_ERROR',
-            error: data.error,
-          };
-      }
-    })
-    .then((msg) => {
-      dispatch(msg);
-      if (msg.url) {
-        return msg.url;
-      }
-      throw new Error('OAuth authorization failed');
-    });
-
 /*
  * redux-thunk support asynchronous redux actions via 'thunks' -
  * lambdas that accept dispatch and getState functions as arguments

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,6 +19,7 @@ import { Helmet } from 'react-helmet';
 import '@gen3/ui-component/dist/css/base.less';
 import {
   fetchDictionary,
+  fetchProjects,
   fetchSchema,
   fetchVersionInfo,
   fetchUserAccess,
@@ -79,6 +80,7 @@ async function init() {
     // resources can be open to anonymous users, so fetch access:
     store.dispatch(fetchUserAccess),
     store.dispatch(fetchUserAuthMapping),
+    store.dispatch(fetchProjects()),
   ]);
   // FontAwesome icons
   library.add(faAngleUp, faAngleDown, faFlask, faMicroscope, faUser);

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -80,19 +80,13 @@ const userAuthMapping = (state = {}, action) => {
 const project = (state = {}, action) => {
   switch (action.type) {
     case 'RECEIVE_PROJECTS':
-      return {
-        ...state,
-        projects: action.data.reduce((map, p) => {
-          const res = map;
-          res[p.code] = p.project_id;
-          return res;
-        }, {}),
-        projectAvail: action.data.reduce((map, p) => {
-          const res = map;
-          res[p.project_id] = p.availability_type;
-          return res;
-        }, {}),
-      };
+      const projects = {};
+      const projectAvail = {};
+      for (const { code, project_id, availability_type } of action.data) {
+        projects[code] = project_id;
+        projectAvail[project_id] = availability_type;
+      }
+      return { ...state, projects, projectAvail };
     default:
       return state;
   }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -77,6 +77,27 @@ const userAuthMapping = (state = {}, action) => {
   }
 };
 
+const project = (state = {}, action) => {
+  switch (action.type) {
+    case 'RECEIVE_PROJECTS':
+      return {
+        ...state,
+        projects: action.data.reduce((map, p) => {
+          const res = map;
+          res[p.code] = p.project_id;
+          return res;
+        }, {}),
+        projectAvail: action.data.reduce((map, p) => {
+          const res = map;
+          res[p.project_id] = p.availability_type;
+          return res;
+        }, {}),
+      };
+    default:
+      return state;
+  }
+};
+
 export const removeDeletedNode = (state, id) => {
   const searchResult = state.search_result;
   const nodeType = Object.keys(searchResult.data)[0];
@@ -87,6 +108,7 @@ export const removeDeletedNode = (state, id) => {
 
 const reducers = combineReducers({
   index,
+  project,
   popups,
   user,
   status,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -52,8 +52,6 @@ const user = (state = {}, action) => {
         ...state,
         vpc: action.vpc,
       };
-    case 'RECEIVE_AUTHORIZATION_URL':
-      return { ...state, oauth_url: action.url };
     case 'FETCH_ERROR':
       return { ...state, fetched_user: true, fetch_error: action.error };
     default:


### PR DESCRIPTION
For [PEDS-145](https://pcdc.atlassian.net/browse/PEDS-145)

This PR removes an obsolete check for API token which was originally put in place for a pre-JWT system. In doing so, the PR also:

- calls `fetchProjects` at initializing app to avoid making redundant requests
- reorganizes Redux code and moves handler for `'RECEIVE_PROJECTS'` action type under a new `project` reducer
    - the handler was originally under `submission` reducer, but the corresponding states were not used anywhere in `/src/Submission`
