### PR TITLE
Respect field mapping in survival PEDS-158

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -24,9 +24,10 @@ const fetchResult = (body) =>
 /**
  * @param {Object} prop
  * @param {Object} prop.aggsData
+ * @param {Array} prop.fieldMapping
  * @param {Object} prop.filter
  */
-function ExplorerSurvivalAnalysis({ aggsData, filter }) {
+function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [pval, setPval] = useState(-1); // -1 is a placeholder for no p-value
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
@@ -133,6 +134,7 @@ function ExplorerSurvivalAnalysis({ aggsData, filter }) {
 
 ExplorerSurvivalAnalysis.propTypes = {
   aggsData: PropTypes.object,
+  fieldMapping: PropTypes.array,
   filter: PropTypes.object,
 };
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -46,10 +46,10 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     }
   }, [filter]);
 
-  const [factors, setFactors] = useState(getFactors(aggsData));
+  const [factors, setFactors] = useState(getFactors(aggsData, fieldMapping));
   useEffect(() => {
-    setFactors(getFactors(aggsData));
-  }, [aggsData]);
+    setFactors(getFactors(aggsData, fieldMapping));
+  }, [aggsData, fieldMapping]);
 
   /** @type {ColorScheme} */
   const initColorScheme = { All: schemeCategory10[0] };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -138,4 +138,8 @@ ExplorerSurvivalAnalysis.propTypes = {
   filter: PropTypes.object,
 };
 
+ExplorerSurvivalAnalysis.defaultProps = {
+  fieldMapping: [],
+};
+
 export default React.memo(ExplorerSurvivalAnalysis);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -4,7 +4,7 @@ const isString = (x) => Object.prototype.toString.call(x) === '[object String]';
 
 /**
  * Get factor variables to use for survival analysis
- * @param {{ histogram: { key: any }[] }[]} aggsData
+ * @param {{ [key: string]: { histogram: { key: any }[] }}} aggsData
  * @param {{ field: string; name: string }[]} fieldMapping
  */
 export const getFactors = (aggsData, fieldMapping) => {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -5,10 +5,15 @@ const isString = (x) => Object.prototype.toString.call(x) === '[object String]';
 /**
  * Get factor variables to use for survival analysis
  * @param {{ histogram: { key: any }[] }[]} aggsData
+ * @param {{ field: string; name: string }[]} fieldMapping
  */
-export const getFactors = (aggsData) => {
+export const getFactors = (aggsData, fieldMapping) => {
   const factors = [];
   const exceptions = ['project_id', 'data_contributor_id'];
+
+  /** @type {{ [key: string]: string }} */
+  const fieldNameMap = {};
+  for (const { field, name } of fieldMapping) fieldNameMap[field] = name;
 
   for (const [key, value] of Object.entries(aggsData))
     if (
@@ -17,11 +22,13 @@ export const getFactors = (aggsData) => {
       isString(value.histogram[0].key)
     )
       factors.push({
-        label: key
-          .toLowerCase()
-          .replace(/_|\./gi, ' ')
-          .replace(/\b\w/g, (c) => c.toUpperCase())
-          .trim(),
+        label: fieldNameMap.hasOwnProperty(key)
+          ? fieldNameMap[key]
+          : key
+              .toLowerCase()
+              .replace(/_|\./gi, ' ')
+              .replace(/\b\w/g, (c) => c.toUpperCase())
+              .trim(),
         value: key,
       });
 

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -221,6 +221,7 @@ class ExplorerVisualization extends React.Component {
         <ViewContainer showIf={this.state.explorerView === 'survival analysis'}>
           <ExplorerSurvivalAnalysis
             aggsData={this.props.aggsData}
+            fieldMapping={this.props.guppyConfig.fieldMapping}
             filter={this.props.filter}
           />
         </ViewContainer>


### PR DESCRIPTION
For [PEDS-158](https://pcdc.atlassian.net/browse/PEDS-158)

This PR fixes the disparity between explorer filter names and survival factor names when using portal config `dataExplorerConfig.guppyConfig.filterMapping` to set filter names.