### PR TITLE
Handle survival time inputs on client-side PEDS-169

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -156,6 +156,7 @@ const ControlForm = ({
         value={localTimeInterval}
       />
       <ControlFormInput
+        disabled
         label='Start time (year)'
         type='number'
         min={0}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -60,7 +60,6 @@ const ControlForm = ({
   const [survivalType, setSurvivalType] = useState('all');
 
   const [isInputChanged, setIsInputChanged] = useState(false);
-  const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
     setIsInputChanged(true);
   }, [
@@ -74,6 +73,11 @@ const ControlForm = ({
   useEffect(() => {
     if (!isInputChanged && isError) setIsInputChanged(true);
   }, [isInputChanged, isError]);
+
+  const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
+  useEffect(() => {
+    if (isFilterChanged) setShouldUpdateResults(true);
+  }, [isFilterChanged]);
 
   const validateNumberInput = (
     /** @type {{ target: { value: string, min: string, max: string }}} */ e

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -60,6 +60,7 @@ const ControlForm = ({
   const [survivalType, setSurvivalType] = useState('all');
 
   const [isInputChanged, setIsInputChanged] = useState(false);
+  const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
     setIsInputChanged(true);
   }, [
@@ -96,15 +97,20 @@ const ControlForm = ({
       startTime,
       endTime,
       efsFlag: survivalType === 'efs',
+      shouldUpdateResults,
     });
     setIsInputChanged(false);
     setIsFilterChanged(false);
+    setShouldUpdateResults(false);
   };
   useEffect(() => {
     submitUserInput();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const resetUserInput = () => {
+    if (factorVariable !== '' || stratificationVariable !== '')
+      setShouldUpdateResults(true);
+
     setFactorVariable('');
     setStratificationVariable('');
     setLocalTimeInterval(2);
@@ -123,6 +129,7 @@ const ControlForm = ({
             setStratificationVariable('');
 
           setFactorVariable(value);
+          setShouldUpdateResults(true);
         }}
         value={factorVariable}
       />
@@ -132,7 +139,10 @@ const ControlForm = ({
           factors.filter(({ value }) => value !== factorVariable)
         )}
         disabled={factorVariable === ''}
-        onChange={({ value }) => setStratificationVariable(value)}
+        onChange={({ value }) => {
+          setStratificationVariable(value);
+          setShouldUpdateResults(true);
+        }}
         value={stratificationVariable}
       />
       <ControlFormInput
@@ -172,7 +182,10 @@ const ControlForm = ({
           { label: 'Overall Survival', value: 'all' },
           { label: 'Event-Free Survival (EFS)', value: 'efs' },
         ]}
-        onChange={({ value }) => setSurvivalType(value)}
+        onChange={({ value }) => {
+          setSurvivalType(value);
+          setShouldUpdateResults(true);
+        }}
         value={survivalType}
       />
       <div className='explorer-survival-analysis__button-group'>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -89,7 +89,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     setStartTime(startTime);
     setEndTime(endTime);
 
-    if (shouldUpdateResults || isFilterChanged)
+    if (shouldUpdateResults)
       fetchResult({ filter: transformedFilter, ...requestBody })
         .then((result) => {
           setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -6,7 +6,11 @@ import Spinner from '../../components/Spinner';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
 import RiskTable from './RiskTable';
-import { getFactors } from './utils';
+import {
+  filterRisktableByTime,
+  filterSurvivalByTime,
+  getFactors,
+} from './utils';
 import { fetchWithCreds } from '../../actions';
 import './ExplorerSurvivalAnalysis.css';
 import './typedef';
@@ -33,6 +37,8 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [survival, setSurvival] = useState([]);
   const [stratificationVariable, setStratificationVariable] = useState('');
   const [timeInterval, setTimeInterval] = useState(2);
+  const [startTime, setStartTime] = useState(0);
+  const [endTime, setEndTime] = useState(0);
 
   const [transformedFilter, setTransformedFilter] = useState(
     getGQLFilter(filter)
@@ -68,12 +74,19 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [isFetching, setIsFetching] = useState(false);
   const [isError, setIsError] = useState(true);
   /** @type {UserInputSubmitHandler} */
-  const handleSubmit = ({ timeInterval, ...requestBody }) => {
+  const handleSubmit = ({
+    timeInterval,
+    startTime,
+    endTime,
+    ...requestBody
+  }) => {
     if (isError) setIsError(false);
     setIsFetching(true);
     setColorScheme(getNewColorScheme(requestBody.factorVariable));
     setStratificationVariable(requestBody.stratificationVariable);
     setTimeInterval(timeInterval);
+    setStartTime(startTime);
+    setEndTime(endTime);
 
     fetchResult({ filter: transformedFilter, ...requestBody })
       .then((result) => {
@@ -116,12 +129,12 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
             </div>
             <SurvivalPlot
               colorScheme={colorScheme}
-              data={survival}
+              data={filterSurvivalByTime(survival, startTime, endTime)}
               notStratified={stratificationVariable === ''}
               timeInterval={timeInterval}
             />
             <RiskTable
-              data={risktable}
+              data={filterRisktableByTime(risktable, startTime, endTime)}
               notStratified={stratificationVariable === ''}
               timeInterval={timeInterval}
             />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -71,7 +71,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     return newScheme;
   };
 
-  const [isFetching, setIsFetching] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
   const [isError, setIsError] = useState(true);
   /** @type {UserInputSubmitHandler} */
   const handleSubmit = ({
@@ -82,7 +82,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     ...requestBody
   }) => {
     if (isError) setIsError(false);
-    setIsFetching(true);
+    setIsUpdating(true);
     setColorScheme(getNewColorScheme(requestBody.factorVariable));
     setStratificationVariable(requestBody.stratificationVariable);
     setTimeInterval(timeInterval);
@@ -97,8 +97,8 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           setSurvival(result.survival);
         })
         .catch((e) => setIsError(true))
-        .finally(() => setIsFetching(false));
-    else setIsFetching(false);
+        .finally(() => setIsUpdating(false));
+    else setIsUpdating(false);
   };
 
   return (
@@ -114,7 +114,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
         />
       </div>
       <div className='explorer-survival-analysis__column-right'>
-        {isFetching ? (
+        {isUpdating ? (
           <Spinner />
         ) : isError ? (
           <div className='explorer-survival-analysis__error'>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -78,6 +78,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     timeInterval,
     startTime,
     endTime,
+    shouldUpdateResults,
     ...requestBody
   }) => {
     if (isError) setIsError(false);
@@ -88,14 +89,16 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     setStartTime(startTime);
     setEndTime(endTime);
 
-    fetchResult({ filter: transformedFilter, ...requestBody })
-      .then((result) => {
-        setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-        setRisktable(result.risktable);
-        setSurvival(result.survival);
-      })
-      .catch((e) => setIsError(true))
-      .finally(() => setIsFetching(false));
+    if (shouldUpdateResults || isFilterChanged)
+      fetchResult({ filter: transformedFilter, ...requestBody })
+        .then((result) => {
+          setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
+          setRisktable(result.risktable);
+          setSurvival(result.survival);
+        })
+        .catch((e) => setIsError(true))
+        .finally(() => setIsFetching(false));
+    else setIsFetching(false);
   };
 
   return (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -30,6 +30,7 @@
  * @property {number} startTime
  * @property {number} endTime
  * @property {boolean} efsFlag
+ * @property {boolean} shouldUpdateResults
  */
 
 /**

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -50,3 +50,29 @@ export const getXAxisTicks = (data, step = 2) => {
 
   return ticks;
 };
+
+/**
+ * Filter survival by start/end time
+ * @param {SurvivalData[]} data
+ * @param {number} startTime
+ * @param {number} endTime
+ * @returns {SurvivalData[]}
+ */
+export const filterSurvivalByTime = (data, startTime, endTime) =>
+  data.map(({ data, name }) => ({
+    data: data.filter(({ time }) => time >= startTime && time <= endTime),
+    name,
+  }));
+
+/**
+ * Filter risktable by start/end time
+ * @param {RisktableData[]} data
+ * @param {number} startTime
+ * @param {number} endTime
+ * @returns {RisktableData[]}
+ */
+export const filterRisktableByTime = (data, startTime, endTime) =>
+  data.map(({ data, name }) => ({
+    data: data.filter(({ time }) => time >= startTime && time <= endTime),
+    name,
+  }));


### PR DESCRIPTION
For [PEDS-169](https://pcdc.atlassian.net/browse/PEDS-169)

This PR makes the client side to handle `startTime` and `endTime` user inputs rather than including them in the request body to survival analysis backend. This PR also prevents making requests to backend if user input changes involve inputs handled by the client side only.

This PR also disables input for `startTime` based on the feedback (changing it is unlikely for typical survival analysis use cases).