### PR TITLE
Fix survival undetected filter change

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "jszip": "^3.1.5",
+    "lodash.clonedeep": "^4.5.0",
     "markdown-it": "^10.0.0",
     "pluralize": "^8.0.0",
     "prop-types": "^15.6.0",

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import cloneDeep from 'lodash.clonedeep';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { getGQLFilter } from '@gen3/guppy/dist/components/Utils/queries';
 import Spinner from '../../components/Spinner';
@@ -45,7 +46,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   );
   const [isFilterChanged, setIsFilterChanged] = useState(false);
   useEffect(() => {
-    const updatedFilter = getGQLFilter(filter);
+    const updatedFilter = getGQLFilter(cloneDeep(filter));
     if (JSON.stringify(updatedFilter) !== JSON.stringify(transformedFilter)) {
       setTransformedFilter(updatedFilter);
       setIsFilterChanged(true);


### PR DESCRIPTION
For [PEDS-171](https://pcdc.atlassian.net/browse/PEDS-171)

This PR fixes undetected changes in filter in `<ExplorerSurvivalAnalysis>` caused by a mutable state.