### PR TITLE
Use enum fields only for survival factor PEDS-172

### DIFF
--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -149,7 +149,7 @@ function buildConfig(appIn, data) {
 
 function getConsortiumList(dict) {
   const consortiumList = dict['subject'].properties.consortium.enum || [];
-  return JSON.stringify(consortiumList);
+  return JSON.stringify(consortiumList, null, 2);
 }
 
 const config = buildConfig(process.env.app, params);

--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -152,6 +152,30 @@ function getConsortiumList(dict) {
   return JSON.stringify(consortiumList, null, 2);
 }
 
+function getEnumFilterList(config, dict) {
+  const filterSet = new Set();
+  if (
+    config.hasOwnProperty('dataExplorerConfig') &&
+    config.dataExplorerConfig.hasOwnProperty('filters') &&
+    config.dataExplorerConfig.filters.hasOwnProperty('tabs')
+  )
+    for (const { fields } of config.dataExplorerConfig.filters.tabs)
+      for (const field of fields) filterSet.add(field);
+
+  const enumPropSet = new Set();
+  for (const value of Object.values(dict))
+    if (value.hasOwnProperty('properties'))
+      for (const [propName, propValue] of Object.entries(value.properties))
+        if (propValue.hasOwnProperty('enum')) enumPropSet.add(propName);
+
+  const filterList = Array.from(filterSet);
+  const enumFilterSet = new Set();
+  for (const filter of filterList)
+    if (enumPropSet.has(filter)) enumFilterSet.add(filter);
+
+  return JSON.stringify(Array.from(enumFilterSet), null, 2);
+}
+
 const config = buildConfig(process.env.app, params);
 const dict = require(`${__dirname}/dictionary.json`);
 console.log(`const gaTracking = '${defaultGA}';`);
@@ -170,6 +194,7 @@ console.log(
   `const requiredCerts = [${defaultRequiredCerts.map((item) => `'${item}'`)}];`
 );
 console.log(`const consortiumList = ${getConsortiumList(dict)};`);
+console.log(`const enumFilterList = ${getEnumFilterList(config, dict)};`);
 console.log(
-  'module.exports = { components, config, gaTracking, requiredCerts, consortiumList };'
+  'module.exports = { components, config, gaTracking, requiredCerts, consortiumList, enumFilterList };'
 );

--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -146,13 +146,14 @@ function buildConfig(appIn, data) {
   });
   return result;
 }
-function getConsortiumList() {
-  const dict = require(`${__dirname}/dictionary.json`);
+
+function getConsortiumList(dict) {
   const consortiumList = dict['subject'].properties.consortium.enum || [];
   return JSON.stringify(consortiumList);
 }
 
 const config = buildConfig(process.env.app, params);
+const dict = require(`${__dirname}/dictionary.json`);
 console.log(`const gaTracking = '${defaultGA}';`);
 console.log(
   "const hostname = typeof window !== 'undefined' ? `${window.location.protocol}//${window.location.hostname}/` : 'http://localhost/';"
@@ -168,7 +169,7 @@ console.log(`const config = ${JSON.stringify(config, null, '  ')};`);
 console.log(
   `const requiredCerts = [${defaultRequiredCerts.map((item) => `'${item}'`)}];`
 );
-console.log(`const consortiumList = ${getConsortiumList()};`);
+console.log(`const consortiumList = ${getConsortiumList(dict)};`);
 console.log(
   'module.exports = { components, config, gaTracking, requiredCerts, consortiumList };'
 );

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash.clonedeep';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { getGQLFilter } from '@gen3/guppy/dist/components/Utils/queries';
+import { enumFilterList } from '../../params';
 import Spinner from '../../components/Spinner';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
@@ -53,9 +54,11 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     }
   }, [filter]);
 
-  const [factors, setFactors] = useState(getFactors(aggsData, fieldMapping));
+  const [factors, setFactors] = useState(
+    getFactors(aggsData, fieldMapping, enumFilterList)
+  );
   useEffect(() => {
-    setFactors(getFactors(aggsData, fieldMapping));
+    setFactors(getFactors(aggsData, fieldMapping, enumFilterList));
   }, [aggsData, fieldMapping]);
 
   /** @type {ColorScheme} */

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -1,13 +1,11 @@
 import './typedef';
 
-const isString = (x) => Object.prototype.toString.call(x) === '[object String]';
-
 /**
  * Get factor variables to use for survival analysis
- * @param {{ [key: string]: { histogram: { key: any }[] }}} aggsData
+ * @param {{ [key: string]: any }} aggsData
  * @param {{ field: string; name: string }[]} fieldMapping
  */
-export const getFactors = (aggsData, fieldMapping) => {
+export const getFactors = (aggsData, fieldMapping, enumFilterList) => {
   const factors = [];
   const exceptions = ['project_id', 'data_contributor_id'];
 
@@ -15,21 +13,18 @@ export const getFactors = (aggsData, fieldMapping) => {
   const fieldNameMap = {};
   for (const { field, name } of fieldMapping) fieldNameMap[field] = name;
 
-  for (const [key, value] of Object.entries(aggsData))
-    if (
-      !exceptions.includes(key) &&
-      value.histogram.length > 0 &&
-      isString(value.histogram[0].key)
-    )
+  const fields = Object.keys(aggsData);
+  for (const field of fields)
+    if (enumFilterList.includes(field) && !exceptions.includes(field))
       factors.push({
-        label: fieldNameMap.hasOwnProperty(key)
-          ? fieldNameMap[key]
-          : key
+        label: fieldNameMap.hasOwnProperty(field)
+          ? fieldNameMap[field]
+          : field
               .toLowerCase()
               .replace(/_|\./gi, ' ')
               .replace(/\b\w/g, (c) => c.toUpperCase())
               .trim(),
-        value: key,
+        value: field,
       });
 
   return factors;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -27,7 +27,14 @@ export const getFactors = (aggsData, fieldMapping, enumFilterList) => {
         value: field,
       });
 
-  return factors;
+  return factors.sort((a, b) => {
+    var labelA = a.label.toUpperCase();
+    var labalB = b.label.toUpperCase();
+
+    if (labelA < labalB) return -1;
+    if (labelA > labalB) return 1;
+    return 0;
+  });
 };
 
 /**


### PR DESCRIPTION
For [PEDS-172](https://pcdc.atlassian.net/browse/PEDS-172)

This PR exports an array of all enum-type fields found in `data/dictionary.js` as `enumFieldList` variable to `src/param.js` and use it to select fields to use as factor variable options for `<ExplorerSurvivalAnalysis>`. This PR also sorts the factor options by label, alphabethically.