### PR TITLE
Fix squashed survival plot PEDS-178

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -46,7 +46,7 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
   }
 
   return (
-    <ResponsiveContainer height={300}>
+    <ResponsiveContainer height={300 + Math.floor(data.length / 5) * 25}>
       <LineChart data={data} margin={{ left: 20, bottom: 10, right: 20 }}>
         <XAxis
           dataKey='time'


### PR DESCRIPTION
[PEDS-178](https://pcdc.atlassian.net/browse/PEDS-178)

This PR adjusts the height of the survival plot container based on the number of lines to draw to prevent long legend from squashing the chart. The chart height does not remain constant, but should remain acceptable (>70% of the default) even in the most edge cases.