### PR TITLE
Fix responsive design for Exploration page PEDS-185

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -17,15 +17,14 @@
 
 .explorer-survival-analysis__column-left {
   display: flex;
-  min-width: 400px;
+  flex-grow: 1;
   max-width: 600px;
 }
 
 .explorer-survival-analysis__column-right {
   display: flex;
   flex-direction: column;
-  min-width: 50%;
-  max-width: 600px;
+  width: 600px;
 }
 
 .explorer-survival-analysis__error {
@@ -107,6 +106,7 @@
   font-weight: bold;
   padding: 0.5rem 1rem 0;
 }
+
 .explorer-survival-analysis__figure-placeholder {
   border: 1px dashed lightgray;
   color: gray;
@@ -116,4 +116,13 @@
   height: 100%;
   width: 90%;
   margin: auto;
+}
+
+/* Less than laptop width */
+@media (max-width: 1023px) {
+  .explorer-survival-analysis__column-left,
+  .explorer-survival-analysis__column-right {
+    min-width: 100%;
+    max-width: auto;
+  }
 }

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -118,8 +118,8 @@
   margin: auto;
 }
 
-/* Less than laptop width */
-@media (max-width: 1023px) {
+/* Medium screen and less */
+@media screen and (max-width: 1023px) {
   .explorer-survival-analysis__column-left,
   .explorer-survival-analysis__column-right {
     min-width: 100%;

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -38,15 +38,15 @@
   color: var(--g3-color__highlight-orange);
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .guppy-explorer-visualization__button-group {
     display: none;
   }
 }
 
-/* Less than mobile width */
-@media (max-width: 479px) {
+/* Mobile width and less */
+@media screen and (max-width: 480px) {
   .guppy-explorer-visualization__view-group {
     display: flex;
     flex-direction: column;
@@ -84,8 +84,8 @@
   display: none;
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .guppy-explorer-visualization__charts
     > .summary-chart-group
     > .summary-chart-group__column {

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -38,6 +38,13 @@
   color: var(--g3-color__highlight-orange);
 }
 
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .guppy-explorer-visualization__button-group {
+    display: none;
+  }
+}
+
 /* Overrides */
 .recharts-tooltip-wrapper {
   z-index: 1000;

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -45,6 +45,17 @@
   }
 }
 
+/* Less than mobile width */
+@media (max-width: 479px) {
+  .guppy-explorer-visualization__view-group {
+    display: flex;
+    flex-direction: column;
+  }
+  .guppy-explorer-visualization__view-group > button {
+    text-align: left;
+  }
+}
+
 /* Overrides */
 .recharts-tooltip-wrapper {
   z-index: 1000;

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -46,3 +46,31 @@
 .g3-single-select-filter__label {
   word-break: break-all;
 }
+
+.guppy-explorer-visualization__charts > .summary-chart-group {
+  flex-wrap: wrap;
+}
+
+.guppy-explorer-visualization__charts
+  > .summary-chart-group
+  > .summary-chart-group__column {
+  flex: 1 1 50%;
+  min-width: 400px;
+  margin: 0 auto;
+}
+
+.guppy-explorer-visualization__charts
+  > .summary-chart-group
+  > .summary-chart-group__column
+  > .summary-chart-group__column-left-border {
+  display: none;
+}
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .guppy-explorer-visualization__charts
+    > .summary-chart-group
+    > .summary-chart-group__column {
+    min-width: 100%;
+  }
+}

--- a/src/GuppyDataExplorer/GuppyDataExplorer.css
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.css
@@ -19,3 +19,19 @@
   width: 100%;
   margin-top: 10px;
 }
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .guppy-data-explorer {
+    padding: 0;
+  }
+
+  .guppy-data-explorer__filter {
+    display: none;
+  }
+
+  .guppy-data-explorer__visualization {
+    width: 100%;
+    padding: 0;
+  }
+}

--- a/src/GuppyDataExplorer/GuppyDataExplorer.css
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.css
@@ -20,8 +20,8 @@
   margin-top: 10px;
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .guppy-data-explorer {
     padding: 0;
   }


### PR DESCRIPTION
[For PEDS-185](https://pcdc.atlassian.net/browse/PEDS-185)

This PR improves responsiveness of the Exploration page (/explorer) based on breakpoints specified in `localconf.js`.

See the following images for "summary view" before-after comparisons:

**For large screen (1279px)**

<img width="680" alt="image" src="https://user-images.githubusercontent.com/22449454/99121693-7ca4f280-25c2-11eb-8d70-cd8ae7e851e0.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/22449454/99121728-8b8ba500-25c2-11eb-8993-cb945230070d.png">


**For less than "laptop" screen width (1023px)**

<img width="512" alt="image" src="https://user-images.githubusercontent.com/22449454/99121155-b4f80100-25c1-11eb-9b1a-a17e3bba7fe9.png">
<img width="512" alt="image" src="https://user-images.githubusercontent.com/22449454/99121188-c17c5980-25c1-11eb-8fd1-2a316e14d88a.png">

**For less than "tablet" screen width (819px)**

<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99121226-d78a1a00-25c1-11eb-99cd-d8072f37f7da.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99121242-dbb63780-25c1-11eb-90de-bf36fde1789c.png">

**For less than "mobile" screen width (479px)**

<img width="240" alt="image" src="https://user-images.githubusercontent.com/22449454/99121563-3a7bb100-25c2-11eb-806c-c30cc8e2e37b.png">
<img width="240" alt="image" src="https://user-images.githubusercontent.com/22449454/99121579-423b5580-25c2-11eb-8822-772ebc49361f.png">


