### PR TITLE
Fix responsive design for Data Dictionary page PEDS-185

### DIFF
--- a/src/DataDictionary/DataDictionary.css
+++ b/src/DataDictionary/DataDictionary.css
@@ -76,8 +76,8 @@
   color: var(--g3-color__white);
 }
 
-/* Less than laptop width */
-@media (max-width: 1023px) {
+/* Medium screen and less */
+@media screen and (max-width: 1090px) {
   .data-dictionary {
     flex-wrap: wrap;
     height: 100vh;
@@ -99,8 +99,8 @@
   }
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .data-dictionary__main {
     max-height: 90%;
   }

--- a/src/DataDictionary/DataDictionary.css
+++ b/src/DataDictionary/DataDictionary.css
@@ -20,7 +20,6 @@
 
 .data-dictionary__main {
   width: calc(100vw - var(--data-dictionary__sidebar-width));
-  min-width: 900px;
   overflow-y: scroll;
 }
 
@@ -44,7 +43,6 @@
   border: 1px solid var(--data-dictionary__switch-border-color);
   border-radius: var(--data-dictionary__switch-border-radius);
   cursor: pointer;
-  font-size: 18px;
   font-weight: 600;
   letter-spacing: 0.02rem;
   margin: 15px;
@@ -76,4 +74,34 @@
 .data-dictionary__switch-button--active {
   background-color: var(--g3-color__base-blue);
   color: var(--g3-color__white);
+}
+
+/* Less than laptop width */
+@media (max-width: 1023px) {
+  .data-dictionary {
+    flex-wrap: wrap;
+    height: 100vh;
+  }
+
+  .data-dictionary__sidebar {
+    width: 100%;
+    height: auto;
+  }
+
+  .data-dictionary__main {
+    width: 100%;
+    height: 100%;
+    max-height: 80%;
+  }
+
+  .data-dictionary__searcher {
+    display: hidden;
+  }
+}
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .data-dictionary__main {
+    max-height: 90%;
+  }
 }

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -74,7 +74,6 @@ class DataDictionary extends React.Component {
           <ReduxDictionarySearchHistory
             onClickSearchHistoryItem={this.handleClickSearchHistoryItem}
           />
-          <div className='data-dictionary__search-history' />
         </div>
         <div className='data-dictionary__main'>
           {this.props.isGraphView ? (

--- a/src/DataDictionary/DataModelStructure/DataModelStructure.css
+++ b/src/DataDictionary/DataModelStructure/DataModelStructure.css
@@ -57,8 +57,8 @@
   margin: 0 15px 15px 15px;
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .data-model-structure {
     display: none;
   }

--- a/src/DataDictionary/DataModelStructure/DataModelStructure.css
+++ b/src/DataDictionary/DataModelStructure/DataModelStructure.css
@@ -56,3 +56,10 @@
 .data-model-structure__template-download-dropdown {
   margin: 0 15px 15px 15px;
 }
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .data-model-structure {
+    display: none;
+  }
+}

--- a/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.css
+++ b/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.css
@@ -64,3 +64,10 @@
 .dictionary-search-history__clear:hover {
   color: var(--g3-color__base-blue-light);
 }
+
+/* Less than laptop width */
+@media (max-width: 1023px) {
+  .dictionary-search-history {
+    display: none;
+  }
+}

--- a/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.css
+++ b/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.css
@@ -65,8 +65,8 @@
   color: var(--g3-color__base-blue-light);
 }
 
-/* Less than laptop width */
-@media (max-width: 1023px) {
+/* Medium screen and less */
+@media screen and (max-width: 1090px) {
   .dictionary-search-history {
     display: none;
   }

--- a/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.css
+++ b/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.css
@@ -29,8 +29,8 @@
   color: var(--g3-color__base-blue-light);
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .data-dictionary-searcher {
     display: none;
   }

--- a/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.css
+++ b/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.css
@@ -28,3 +28,10 @@
 .dictionary-searcher__result-clear:hover {
   color: var(--g3-color__base-blue-light);
 }
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .data-dictionary-searcher {
+    display: none;
+  }
+}

--- a/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
+++ b/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
@@ -110,8 +110,8 @@
   background-color: var(--g3-color__black);
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .data-dictionary-category__download_template,
   .data-dictionary-node__download-group {
     display: none;

--- a/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
+++ b/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
@@ -109,3 +109,11 @@
   .data-dictionary-node__property-close-icon {
   background-color: var(--g3-color__black);
 }
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .data-dictionary-category__download_template,
+  .data-dictionary-node__download-group {
+    display: none;
+  }
+}

--- a/src/DataDictionary/table/DataDictionaryPropertyTable/DataDictionaryPropertyTable.css
+++ b/src/DataDictionary/table/DataDictionaryPropertyTable/DataDictionaryPropertyTable.css
@@ -63,3 +63,11 @@
 .data-dictionary-property-table__span--new-line {
   display: block;
 }
+
+/* Less than tablet width */
+@media (max-width: 819px) {
+  .data-dictionary-property-table__table
+    .data-dictionary-property-table__data:nth-last-child(-n + 2) {
+    display: none;
+  }
+}

--- a/src/DataDictionary/table/DataDictionaryPropertyTable/DataDictionaryPropertyTable.css
+++ b/src/DataDictionary/table/DataDictionaryPropertyTable/DataDictionaryPropertyTable.css
@@ -64,8 +64,8 @@
   display: block;
 }
 
-/* Less than tablet width */
-@media (max-width: 819px) {
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
   .data-dictionary-property-table__table
     .data-dictionary-property-table__data:nth-last-child(-n + 2) {
     display: none;


### PR DESCRIPTION
For [PEDS-185](https://pcdc.atlassian.net/browse/PEDS-185)

This PR improves responsiveness of the Data Dictionary page (/DD) based on breakpoints specified in `localconf.js`.

See the following images for before-after comparisons:

**For less than "laptop" screen width (1023px)**

_Table View_

<img width="514" alt="image" src="https://user-images.githubusercontent.com/22449454/99127719-99dfbe00-25ce-11eb-9862-406795d81e05.png">
<img width="514" alt="image" src="https://user-images.githubusercontent.com/22449454/99127703-93e9dd00-25ce-11eb-97f1-d69699e97f17.png">

_Graph View_

<img width="514" alt="image" src="https://user-images.githubusercontent.com/22449454/99127875-fd69eb80-25ce-11eb-8448-90469d994a6f.png">
<img width="514" alt="image" src="https://user-images.githubusercontent.com/22449454/99127882-022e9f80-25cf-11eb-9433-0e3266423fe4.png">

**For less than "tablet" screen width (819px)**

_Table View_

<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99127946-268a7c00-25cf-11eb-9b8e-ce45789813d1.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99127931-1f636e00-25cf-11eb-8906-e500274b3d21.png">

_Graph View_

<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99127967-3609c500-25cf-11eb-83c0-58ab369a4097.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/22449454/99127982-3b670f80-25cf-11eb-895e-74336e204234.png">
