### PR TITLE
Create simple input field component

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -2,37 +2,18 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import Button from '@gen3/ui-component/dist/components/Button';
+import SimpleInputField from '../../components/SimpleInputField';
 import './typedef';
 
-/**
- * @param {Object} prop
- * @param {string} prop.label
- * @param {JSX.Element} prop.input
- */
-const ControlFormField = ({ label, input }) => (
-  <div className='explorer-survival-analysis__field-container'>
-    <label className='explorer-survival-analysis__field-label'>{label}</label>
-    <div className='explorer-survival-analysis__field-input'>{input}</div>
-  </div>
-);
-
 const ControlFormSelect = ({ label, ...selectProps }) => (
-  <ControlFormField
+  <SimpleInputField
     label={label}
     input={<Select clearable={false} {...selectProps} />}
   />
 );
 
 const ControlFormInput = ({ label, ...inputAttrs }) => (
-  <ControlFormField
-    label={label}
-    input={
-      <input
-        className='explorer-survival-analysis__field_input__input'
-        {...inputAttrs}
-      />
-    }
-  />
+  <SimpleInputField label={label} input={<input {...inputAttrs} />} />
 );
 
 const emptySelectOption = { label: 'Select...', value: '' };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -8,7 +8,19 @@ import './typedef';
 const ControlFormSelect = ({ label, ...selectProps }) => (
   <SimpleInputField
     label={label}
-    input={<Select clearable={false} {...selectProps} />}
+    input={
+      <Select
+        {...selectProps}
+        clearable={false}
+        theme={(theme) => ({
+          ...theme,
+          colors: {
+            ...theme.colors,
+            primary: 'var(--g3-color__base-blue)',
+          },
+        })}
+      />
+    }
   />
 );
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -39,38 +39,6 @@
   width: 100%;
 }
 
-.explorer-survival-analysis__field-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 1rem;
-}
-
-.explorer-survival-analysis__field-label {
-  text-align: right;
-  margin-right: 10px;
-  width: 30%;
-}
-
-.explorer-survival-analysis__field-input {
-  width: 60%;
-}
-
-.explorer-survival-analysis__field_input__input {
-  border-color: #d9d9d9 #ccc #b3b3b3;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  color: #333;
-  cursor: default;
-  border-spacing: 0;
-  border-collapse: separate;
-  height: 36px;
-  outline: none;
-  overflow: hidden;
-  width: 100%;
-  text-align: center;
-}
-
 .explorer-survival-analysis__button-group {
   max-width: 200px;
   min-height: 100px;

--- a/src/UserRegistration/RegistrationForm.jsx
+++ b/src/UserRegistration/RegistrationForm.jsx
@@ -2,18 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Button from '@gen3/ui-component/dist/components/Button';
-
-/**
- * @param {Object} prop
- * @param {string} prop.label
- * @param {JSX.Element} prop.input
- */
-const RegistrationFormField = ({ label, input }) => (
-  <div className='user-registration__form__field-container'>
-    <label className='user-registration__form__field-label'>{label}</label>
-    <div className='user-registration__form__field-input'>{input}</div>
-  </div>
-);
+import SimpleInputField from '../components/SimpleInputField';
 
 /**
  * @typedef {Object} UserRegistrationInput
@@ -67,7 +56,7 @@ function RegistrationForm({ onClose, onRegister, onSubscribe }) {
         <br />
         Please register to gain access.
       </p>
-      <RegistrationFormField
+      <SimpleInputField
         label='First name'
         input={
           <input
@@ -81,7 +70,7 @@ function RegistrationForm({ onClose, onRegister, onSubscribe }) {
           />
         }
       />
-      <RegistrationFormField
+      <SimpleInputField
         label='Last name'
         input={
           <input
@@ -94,7 +83,7 @@ function RegistrationForm({ onClose, onRegister, onSubscribe }) {
           />
         }
       />
-      <RegistrationFormField
+      <SimpleInputField
         label='Institution'
         input={
           <input

--- a/src/UserRegistration/UserRegistration.css
+++ b/src/UserRegistration/UserRegistration.css
@@ -52,37 +52,3 @@
 .user-registration__subscribe input {
   margin-right: 10px;
 }
-
-.user-registration__form__field-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 1rem;
-}
-
-.user-registration__form__field-label {
-  text-align: right;
-  margin-right: 10px;
-  width: 30%;
-}
-
-.user-registration__form__field-input {
-  width: 60%;
-}
-
-.user-registration__form__field-input > input {
-  border-color: #d9d9d9 #ccc #b3b3b3;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  color: #333;
-  height: 36px;
-  outline: none;
-  overflow: hidden;
-  padding: 0 0.5rem;
-  width: 100%;
-}
-
-.user-registration__form__field-input > input:focus {
-  border-color: var(--g3-color__base-blue);
-  box-shadow: 0 0 0 1px var(--g3-color__base-blue);
-}

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -1,0 +1,28 @@
+.simple-input-field__container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 1rem;
+}
+
+.simple-input-field__label {
+  text-align: right;
+  margin-right: 10px;
+  width: 30%;
+}
+
+.simple-input-field__input {
+  width: 60%;
+}
+
+.simple-input-field__input > input {
+  border-color: #d9d9d9 #ccc #b3b3b3;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  color: #333;
+  height: 36px;
+  outline-color: var(--g3-color__base-blue);
+  overflow: hidden;
+  padding: 2px 10px;
+  width: 100%;
+}

--- a/src/components/SimpleInputField.jsx
+++ b/src/components/SimpleInputField.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './SimpleInputField.css';
+
+/**
+ * @param {Object} prop
+ * @param {string} prop.label
+ * @param {JSX.Element} prop.input
+ */
+function SimpleInputField({ label, input }) {
+  return (
+    <div className='simple-input-field__container'>
+      <label className='simple-input-field__label'>{label}</label>
+      <div className='simple-input-field__input'>{input}</div>
+    </div>
+  );
+}
+
+SimpleInputField.propTypes = {
+  label: PropTypes.string,
+  input: PropTypes.string,
+};
+
+export default SimpleInputField;


### PR DESCRIPTION
This PR extracts a duplicated form input field element used across the application into a single component, `<SimpleInputField>`, with consistent styles.

`<SimpleInputField>` replaces the private input field components in `<ControlForm>` in survival analysis component and `<RegistrationForm>` in user registration component.

The PR also makes a minor change to the react-select `<Select>` theme to use `--g3-color__base-blue` as primary color.