### PR TITLE
Fix Index page Overview button to Exploration page PEDS-119

### DIFF
--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -25,10 +25,15 @@ function IndexOverview({ overviewCounts }) {
         ? {}
         : { consortium: { selectedValues: [consortium.value] } };
 
+    const enabled =
+      overviewCounts !== undefined &&
+      overviewCounts[consortium.value].subject !== 0;
+
     return (
       <Button
         label='Explore more'
         buttonType='primary'
+        enabled={enabled}
         onClick={() =>
           history.push({
             pathname: '/explorer',

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -21,7 +21,7 @@ function IndexOverview({ overviewCounts }) {
   let history = useHistory();
   function ButtonToExplorer() {
     const filter =
-      consortium === 'total'
+      consortium.value === 'total'
         ? {}
         : { consortium: { selectedValues: [consortium.value] } };
 


### PR DESCRIPTION
For [PEDS-119](https://pcdc.atlassian.net/browse/PEDS-119)

This PR fixes the error with "Explorer more" for "All PCDC" consortium. This PR also disables "Explore more" button if the select consortium has no data, defined as subject count of 0.