### PR TITLE
Fix state update after unmount PEDS-236

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -108,9 +108,6 @@ const ControlForm = ({
     setIsFilterChanged(false);
     setShouldUpdateResults(false);
   };
-  useEffect(() => {
-    submitUserInput();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const resetUserInput = () => {
     if (factorVariable.value !== '' || stratificationVariable.value !== '')

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -40,7 +40,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [stratificationVariable, setStratificationVariable] = useState('');
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
-  const [endTime, setEndTime] = useState(0);
+  const [endTime, setEndTime] = useState(20);
 
   const [transformedFilter, setTransformedFilter] = useState(
     getGQLFilter(filter)

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -104,6 +104,31 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
         .finally(() => setIsUpdating(false));
     else setIsUpdating(false);
   };
+  useEffect(() => {
+    let isMounted = true;
+
+    if (isMounted) {
+      setIsError(false);
+      setIsUpdating(true);
+      fetchResult({
+        filter: transformedFilter,
+        factorVariable: '',
+        stratificationVariable: '',
+        efsFlag: false,
+      })
+        .then((result) => {
+          if (isMounted) {
+            setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
+            setRisktable(result.risktable);
+            setSurvival(result.survival);
+          }
+        })
+        .catch((e) => isMounted && setIsError(true))
+        .finally(() => isMounted && setIsUpdating(false));
+    }
+
+    return () => (isMounted = false);
+  }, []);
 
   return (
     <div className='explorer-survival-analysis'>

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -21,10 +21,19 @@ class GuppyDataExplorer extends React.Component {
       aggsData: {},
       filter: {},
     };
+    this._isMounted = false;
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   handleReceiveNewAggsData = (newAggsData) => {
-    this.setState({ aggsData: newAggsData });
+    this._isMounted && this.setState({ aggsData: newAggsData });
   };
 
   render() {

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -47,7 +47,7 @@ export function logoutListener(state = {}, action) {
  */
 class ProtectedContent extends React.Component {
   static propTypes = {
-    component: PropTypes.func.isRequired,
+    component: PropTypes.elementType.isRequired,
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     match: PropTypes.shape({

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -75,6 +75,8 @@ class ProtectedContent extends React.Component {
       from: null,
       user: null,
     };
+
+    this._isMounted = false;
   }
 
   /**
@@ -82,39 +84,49 @@ class ProtectedContent extends React.Component {
    * After mount, checks if the current session is authenticated
    */
   componentDidMount() {
+    this._isMounted = true;
     window.scrollTo(0, 0);
 
-    getReduxStore().then((store) =>
-      Promise.all([
-        store.dispatch({ type: 'CLEAR_COUNTS' }), // clear some counters
-        store.dispatch({ type: 'CLEAR_QUERY_NODES' }),
-      ]).then(() => {
-        const { filter } = this.props;
+    if (this._isMounted)
+      getReduxStore().then((store) =>
+        Promise.all([
+          store.dispatch({ type: 'CLEAR_COUNTS' }), // clear some counters
+          store.dispatch({ type: 'CLEAR_QUERY_NODES' }),
+        ]).then(() => {
+          const { filter } = this.props;
 
-        if (this.props.isPublic) {
-          const latestState = { ...store, dataLoaded: true };
+          if (this.props.isPublic) {
+            const latestState = { ...store, dataLoaded: true };
 
-          if (typeof filter === 'function') {
-            filter().finally(() => this.setState(latestState));
-          } else {
-            this.setState(latestState);
-          }
-        } else
-          this.checkLoginStatus(store, this.state)
-            .then((newState) => this.checkIfRegisterd(newState))
-            .then((newState) => this.checkIfAdmin(newState))
-            .then((newState) => this.checkQuizStatus(newState))
-            .then((newState) => {
-              const latestState = { ...newState, dataLoaded: true };
+            if (typeof filter === 'function') {
+              filter().finally(
+                () => this._isMounted && this.setState(latestState)
+              );
+            } else {
+              this._isMounted && this.setState(latestState);
+            }
+          } else
+            this.checkLoginStatus(store, this.state)
+              .then((newState) => this.checkIfRegisterd(newState))
+              .then((newState) => this.checkIfAdmin(newState))
+              .then((newState) => this.checkQuizStatus(newState))
+              .then((newState) => {
+                const latestState = { ...newState, dataLoaded: true };
 
-              if (newState.authenticated && typeof filter === 'function') {
-                filter().finally(() => this.setState(latestState));
-              } else {
-                this.setState(latestState);
-              }
-            });
-      })
-    );
+                if (newState.authenticated && typeof filter === 'function') {
+                  filter().finally(
+                    () => this._isMounted && this.setState(latestState)
+                  );
+                } else {
+                  this._isMounted && this.setState(latestState);
+                }
+              });
+        })
+      );
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -9,7 +9,8 @@ import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 import { intersection, isPageFullScreen } from '../utils';
 import './ProtectedContent.css';
 
-/** @typedef {Object} ComponentState
+/**
+ * @typedef {Object} ComponentState
  * @property {boolean} authenticated
  * @property {boolean} dataLoaded
  * @property {?string} redirectTo
@@ -37,13 +38,15 @@ export function logoutListener(state = {}, action) {
 /**
  * Container for components that require authentication to access.
  * Takes a few properties
- * @param component required child component
- * @param location from react-router
- * @param history from react-router
- * @param match from react-router.match
- * @param isAdminOnly default false - if true, redirect to index page
- * @param isPublic default false - set true to disable auth-guard
- * @param filter {() => Promise} optional filter to apply before rendering the child component
+ * @typedef {object} Props
+ * @property {React.ComponentType<*>} component required child component
+ * @property {*} location from react-router
+ * @property {*} history from react-router
+ * @property {*} match from react-router.match
+ * @property {boolean} isAdminOnly default false - if true, redirect to index page
+ * @property {boolean} isPublic default false - set true to disable auth-guard
+ * @property {() => Promise} filter optional filter to apply before rendering the child component
+ * @extends {React.Component<Props>}
  */
 class ProtectedContent extends React.Component {
   static propTypes = {


### PR DESCRIPTION
For [PEDS-236](https://pcdc.atlassian.net/browse/PEDS-236).

This PR fixes `Warning: Can't perform a React state update on an unmounted component` in the following components:

* `<ProtectedContent>`
* `<GuppyDataExplorer>`
* `<ExplorerSurvivalAnalysis>`

This PR also includes minor improvements to the changed files.

The following components imported from dependencies raise the same warning, but cannot be fixed by the application code:
* `<GraphiQL>` from `graphiql`
* `<GuppyWrapper>` from `@gen3/guppy`
* `<ConnectedFilter>` from `@gen3/guppy`