### PR TITLE
Fix crash caused by shouldRegister PEDS-250

### DIFF
--- a/src/UserRegistration/ReduxUserRegistration.js
+++ b/src/UserRegistration/ReduxUserRegistration.js
@@ -3,7 +3,8 @@ import { getIndexPageCounts } from '../Index/utils';
 import UserRegistration from './UserRegistration';
 
 const mapStateToProps = (state) => ({
-  shouldRegister: Object.keys(state.user.authz).length === 0,
+  shouldRegister:
+    !state.user.authz || Object.keys(state.user.authz).length === 0,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -15,7 +15,7 @@ const persistConfig = {
 const reducer = persistReducer(persistConfig, reducers);
 
 const preloadedState =
-  process.env.NODE_ENV !== 'proudction' && mockStore
+  process.env.NODE_ENV !== 'production' && mockStore
     ? {
         user: { username: 'test', certificates_uploaded: requiredCerts },
         submission: { dictionary, nodeTypes: Object.keys(dictionary).slice(2) },
@@ -24,7 +24,7 @@ const preloadedState =
     : { user: {}, status: {} };
 
 const composeEnhancers =
-  process.env.NODE_ENV !== 'proudction' &&
+  process.env.NODE_ENV !== 'production' &&
   typeof window === 'object' &&
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -24,7 +24,9 @@ const preloadedState =
     : { user: {}, status: {} };
 
 const composeEnhancers =
-  typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+  process.env.NODE_ENV !== 'proudction' &&
+  typeof window === 'object' &&
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     : compose;
 const enhancer = composeEnhancers(applyMiddleware(thunk));

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -14,13 +14,14 @@ const persistConfig = {
 };
 const reducer = persistReducer(persistConfig, reducers);
 
-const preloadedState = mockStore
-  ? {
-      user: { username: 'test', certificates_uploaded: requiredCerts },
-      submission: { dictionary, nodeTypes: Object.keys(dictionary).slice(2) },
-      status: {},
-    }
-  : { user: {}, status: {} };
+const preloadedState =
+  process.env.NODE_ENV !== 'proudction' && mockStore
+    ? {
+        user: { username: 'test', certificates_uploaded: requiredCerts },
+        submission: { dictionary, nodeTypes: Object.keys(dictionary).slice(2) },
+        status: {},
+      }
+    : { user: {}, status: {} };
 
 const composeEnhancers =
   typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__


### PR DESCRIPTION
For [PEDS-250](https://pcdc.atlassian.net/browse/PEDS-250).

The current PR fixes app crashing due to error in `shouldRegister` prop. This was caused by preloading Redux store state meant for mocking, which was missing `user.authz` used for deriving `shouldRegister` boolean value.

This PR's fix is a workaround that ensures that preloaded store state for mocking is not used for production build. This was implemented because I could not figure out why the environment variable `MOCK_STORE` was somehow set to `"true"`, which leads to `mockStore` local config value being set to `true` and in turn makes the preload state to use the object meant for mocking.  A more robust fix should prevent this.

This PR also disables Redux devtool for production build.