### PR TITLE
Keep survival plot only PEDS-252

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -48,25 +48,9 @@
   justify-content: space-between;
 }
 
-.explorer-survival-analysis__pval {
-  margin-left: 12px;
-  padding: 0.5rem 1rem;
-  height: 1.25rem;
-  font-size: 1rem;
-}
-
 .explorer-survival-analysis__survival-plot {
   margin: 12px;
   min-height: 300px;
-}
-
-.explorer-survival-analysis__risk-table {
-  margin: 12px;
-  min-height: 150px;
-}
-
-.explorer-survival-analysis__risk-table .yAxis tspan {
-  font-size: 0.8rem;
 }
 
 .explorer-survival-analysis__figure-title {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -7,12 +7,7 @@ import { enumFilterList } from '../../params';
 import Spinner from '../../components/Spinner';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
-import RiskTable from './RiskTable';
-import {
-  filterRisktableByTime,
-  filterSurvivalByTime,
-  getFactors,
-} from './utils';
+import { filterSurvivalByTime, getFactors } from './utils';
 import { fetchWithCreds } from '../../actions';
 import './ExplorerSurvivalAnalysis.css';
 import './typedef';
@@ -34,7 +29,6 @@ const fetchResult = (body) =>
  * @param {Object} prop.filter
  */
 function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
-  const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
   const [stratificationVariable, setStratificationVariable] = useState('');
   const [timeInterval, setTimeInterval] = useState(2);
@@ -94,10 +88,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
 
     if (shouldUpdateResults)
       fetchResult({ filter: transformedFilter, ...requestBody })
-        .then((result) => {
-          setRisktable(result.risktable);
-          setSurvival(result.survival);
-        })
+        .then((result) => setSurvival(result.survival))
         .catch((e) => setIsError(true))
         .finally(() => setIsUpdating(false));
     else setIsUpdating(false);
@@ -115,10 +106,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
         efsFlag: false,
       })
         .then((result) => {
-          if (isMounted) {
-            setRisktable(result.risktable);
-            setSurvival(result.survival);
-          }
+          if (isMounted) setSurvival(result.survival);
         })
         .catch((e) => isMounted && setIsError(true))
         .finally(() => isMounted && setIsUpdating(false));
@@ -152,19 +140,12 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
             </p>
           </div>
         ) : (
-          <>
-            <SurvivalPlot
-              colorScheme={colorScheme}
-              data={filterSurvivalByTime(survival, startTime, endTime)}
-              notStratified={stratificationVariable === ''}
-              timeInterval={timeInterval}
-            />
-            <RiskTable
-              data={filterRisktableByTime(risktable, startTime, endTime)}
-              notStratified={stratificationVariable === ''}
-              timeInterval={timeInterval}
-            />
-          </>
+          <SurvivalPlot
+            colorScheme={colorScheme}
+            data={filterSurvivalByTime(survival, startTime, endTime)}
+            notStratified={stratificationVariable === ''}
+            timeInterval={timeInterval}
+          />
         )}
       </div>
     </div>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -34,7 +34,6 @@ const fetchResult = (body) =>
  * @param {Object} prop.filter
  */
 function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
-  const [pval, setPval] = useState(-1); // -1 is a placeholder for no p-value
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
   const [stratificationVariable, setStratificationVariable] = useState('');
@@ -96,7 +95,6 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     if (shouldUpdateResults)
       fetchResult({ filter: transformedFilter, ...requestBody })
         .then((result) => {
-          setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
           setRisktable(result.risktable);
           setSurvival(result.survival);
         })
@@ -118,7 +116,6 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
       })
         .then((result) => {
           if (isMounted) {
-            setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
             setRisktable(result.risktable);
             setSurvival(result.survival);
           }
@@ -156,9 +153,6 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           </div>
         ) : (
           <>
-            <div className='explorer-survival-analysis__pval'>
-              {pval >= 0 && `Log-rank test p-value: ${pval}`}
-            </div>
             <SurvivalPlot
               colorScheme={colorScheme}
               data={filterSurvivalByTime(survival, startTime, endTime)}


### PR DESCRIPTION
For [PEDS-252](https://pcdc.atlassian.net/browse/PEDS-252)

This PR (temporarily) removes the user of states and view for p-value and number-at-risk table in `<ExplorerSurvivalAnalysis>` component. This might come back later depending on future discussion.

In the meantime, it might be useful to remove `pval` and `risktable` from the response as well to avoid exposing the values.