### PR TITLE
Fix incorrectly hidden filter options PEDS-260

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -416,8 +416,8 @@ class FilterSection extends React.Component {
                 // options passed are the already selected options, as opposed
                 // to all available options in textfilters. So don't filter out
                 // any options based on `optionsVisibleStatus`.
-                !isSearchFilter ||
-                !this.state.optionsVisibleStatus[option.text] ||
+                (!isSearchFilter &&
+                  !this.state.optionsVisibleStatus[option.text]) ||
                 (index >= this.props.initVisibleItemNumber &&
                   !this.state.showingMore)
               ) {


### PR DESCRIPTION
For [PEDS-260](https://pcdc.atlassian.net/browse/PEDS-260).

This PR fixes a bug introduced by 779c769089d941f95a93714369b95fc9d3, caused by incorrectly translating `.filter` callback to a conditional inside the following `.map` callback.