### PR TITLE
Fix filter number selected info not showing PEDS-262

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -25,7 +25,7 @@ const getNumValuesSelected = (filterStatus) => {
   if (Array.isArray(filterStatus)) return 1;
 
   let numSelected = 0;
-  for (const status in Object.values(filterStatus)) {
+  for (const status of Object.values(filterStatus)) {
     if (status === true || Array.isArray(status)) numSelected += 1;
   }
   return numSelected;


### PR DESCRIPTION
For [PEDS-262](https://pcdc.atlassian.net/browse/PEDS-262)

This PR fixes a bug introduced by 30faf2a5a78df28115686392453f4392e466f008, caused by incorrectly translating `.forEach` call to `for...in` loop instead of `for...of`.