### PR TITLE
Saved cohorts component with local state only PEDS-256

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,9 +93,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.44",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-          "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
+          "version": "10.17.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.50.tgz",
+          "integrity": "sha512-vwX+/ija9xKc/z9VqMCdbf4WYcMTGsI0I/L/6shIF3qXURxZOhPQlPRHtjTpiNhAwn0paMJzlOQqw6mAGEQnTA=="
         }
       }
     },
@@ -3101,29 +3101,36 @@
       "integrity": "sha512-jUJrjU62MUgHDSu5JfONfgRM2V7GfN5KknsygfIbxwRZXGeayIzxk4O9GiYgEAr9DG5HJThTF5+a5x3wtrOKzQ=="
     },
     "@elastic/elasticsearch": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.9.1.tgz",
-      "integrity": "sha512-NfPADbm9tRK/4ohpm9+aBtJ8WPKQqQaReyBKT225pi2oKQO1IzRlfM+OPplAvbhoH1efrSj1NKk27L+4BCrzXQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.10.0.tgz",
+      "integrity": "sha512-vXtMAQf5/DwqeryQgRriMtnFppJNLc/R7/R0D8E+wG5/kGM5i7mg+Hi7TM4NZEuXgtzZ2a/Nf7aR0vLyrxOK/w==",
       "requires": {
         "debug": "^4.1.1",
-        "decompress-response": "^4.2.0",
+        "hpagent": "^0.1.1",
         "ms": "^2.1.1",
         "pump": "^3.0.0",
         "secure-json-parse": "^2.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -4418,7 +4425,7 @@
       }
     },
     "@pcdc/guppy": {
-      "version": "github:chicagopcdc/guppy#c91684ca603953dc48706f968d79b500a019e4eb",
+      "version": "github:chicagopcdc/guppy#f8840b904d9e7feacf04be22a3f80f1e68cf820f",
       "from": "github:chicagopcdc/guppy#pcdc_dev",
       "requires": {
         "@elastic/elasticsearch": "^7.9.1",
@@ -6359,9 +6366,9 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -6372,9 +6379,9 @@
       "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
     },
     "@types/cookies": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.5.tgz",
-      "integrity": "sha512-3+TAFSm78O7/bAeYdB8FoYGntuT87vVP9JKuQRL8sRhv9313LP2SpHHL50VeFtnyjIcb3UELddMk5Yt0eOSOkg==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",
+      "integrity": "sha512-FK4U5Qyn7/Sc5ih233OuHO0qAkOpEcD/eG6584yEiLKizTFRny86qHLe/rej3HFQrkBuUjF4whFliAdODbVN/w==",
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -6397,9 +6404,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
-      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+      "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -6408,9 +6415,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
-      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.17.tgz",
+      "integrity": "sha512-YYlVaCni5dnHc+bLZfY908IG1+x5xuibKZMGv8srKkvtul3wUuanYvpIj9GXXoWkQbaAdR+kgX46IETKUALWNQ==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -6692,9 +6699,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
-      "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -6809,9 +6816,9 @@
       }
     },
     "@types/ws": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.9.tgz",
-      "integrity": "sha512-gmXYAXr7G4BrRMnkGQGkGonc3ArVro9VZd//C1uns/qqsJyl2dxaJdlPMhZbcq5MTxFFC+ttFWtHSfVW5+hlRA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
       "requires": {
         "@types/node": "*"
       }
@@ -7398,12 +7405,12 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.4.tgz",
-      "integrity": "sha512-FUKE8ASr8GxVq5rmky/tY8bsf++cleGT591lfLiqnPsP1fo3kAfgRfWA2QRHTCKFNlQxzUhVOEDv+PaysqiOjw==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.5.tgz",
+      "integrity": "sha512-jvarfQhwDRazpOsmkt5Pd7qGFrtbL70zMbUZGqDhJSYpfqI672f7bXXc7O3vtpbD3qnS3XTBvK2kspX/Bdo0IA==",
       "requires": {
         "apollo-server-env": "^2.4.5",
-        "apollo-server-plugin-base": "^0.10.2"
+        "apollo-server-plugin-base": "^0.10.3"
       }
     },
     "apollo-datasource": {
@@ -7427,9 +7434,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+          "version": "3.8.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
+          "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A=="
         },
         "node-fetch": {
           "version": "2.6.1",
@@ -7459,20 +7466,20 @@
       }
     },
     "apollo-reporting-protobuf": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.1.tgz",
-      "integrity": "sha512-qr4DheFP154PGZsd93SSIS9RkqHnR5b6vT+eCloWjy3UIpY+yZ3cVLlttlIjYvOG4xTJ25XEwcHiAExatQo/7g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
+      "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
       "requires": {
         "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-server": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.19.0.tgz",
-      "integrity": "sha512-CchLtSwgm6NxQPvOXcMaxp8ckQT2ryLqdWIxjs2e+lCZ15tDsbqyPE+jVmqQKs9rsQNKnTwkMRdqmXqTciFJ8Q==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.19.1.tgz",
+      "integrity": "sha512-vsOJdRz9n8wYst8P4ZB5H3+SaiRJ9ay0ovO0ZRyies2vmbVXvpPSrItqNSObNTpG2GPeNekV63X9kv1EBUSpvA==",
       "requires": {
-        "apollo-server-core": "^2.19.0",
-        "apollo-server-express": "^2.19.0",
+        "apollo-server-core": "^2.19.1",
+        "apollo-server-express": "^2.19.1",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -7487,27 +7494,27 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.19.0.tgz",
-      "integrity": "sha512-2aMKUVPyNbomJQaG2tkpfqvp1Tfgxgkdr7nX5zHudYNSzsPrHw+CcYlCbIVFFI/mTZsjoK9czNq1qerFRxZbJw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.19.1.tgz",
+      "integrity": "sha512-5EVmcY8Ij7Ywwu+Ze4VaUhZBcxl8t5ztcSatJrKMd4HYlEHyaNGBV2itfpyqAthxfdMbGKqlpeCHmTGSqDcNpA==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.26",
         "@types/graphql-upload": "^8.0.0",
         "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.11.4",
+        "apollo-cache-control": "^0.11.5",
         "apollo-datasource": "^0.7.2",
         "apollo-graphql": "^0.6.0",
-        "apollo-reporting-protobuf": "^0.6.1",
+        "apollo-reporting-protobuf": "^0.6.2",
         "apollo-server-caching": "^0.5.2",
         "apollo-server-env": "^2.4.5",
         "apollo-server-errors": "^2.4.2",
-        "apollo-server-plugin-base": "^0.10.2",
-        "apollo-server-types": "^0.6.1",
-        "apollo-tracing": "^0.12.0",
+        "apollo-server-plugin-base": "^0.10.3",
+        "apollo-server-types": "^0.6.2",
+        "apollo-tracing": "^0.12.1",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.12.6",
+        "graphql-extensions": "^0.12.7",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
@@ -7520,9 +7527,9 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -7548,19 +7555,19 @@
       "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ=="
     },
     "apollo-server-express": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.19.0.tgz",
-      "integrity": "sha512-3rgSrTme1SlLoecAYtSa8ThH6vYvz29QecgZCigq5Vdc6bFP2SZrCk0ls6BAdD8OZbVKUtizzRxd0yd/uREPAw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.19.1.tgz",
+      "integrity": "sha512-PJQmPtV3JD7RiV6cP7JcqAwVdUq6hWUtvDIoCOxPoeUWYf79nEF4WiYsPXVF0+meLLWKlL1fuSwEEt1CEHEG5w==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.26",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "2.8.8",
         "@types/express": "4.17.7",
-        "@types/express-serve-static-core": "4.17.13",
+        "@types/express-serve-static-core": "4.17.17",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.19.0",
-        "apollo-server-types": "^0.6.1",
+        "apollo-server-core": "^2.19.1",
+        "apollo-server-types": "^0.6.2",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -7585,30 +7592,30 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.2.tgz",
-      "integrity": "sha512-uM5uL1lOxbXdgvt/aEIbgs40fV9xA45Y3Mmh0VtQ/ddqq0MXR5aG92nnf8rM+URarBCUfxKJKaYzJJ/CXAnEdA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.3.tgz",
+      "integrity": "sha512-NCLOsk9Jsd8oLvefkQvROdMDQvnHnzbzz3MPCqEYjCOEv0YBM8T77D0wCwbcViDS2M5p0W6un2ub9s/vU71f7Q==",
       "requires": {
-        "apollo-server-types": "^0.6.1"
+        "apollo-server-types": "^0.6.2"
       }
     },
     "apollo-server-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.1.tgz",
-      "integrity": "sha512-IEQ37aYvMLiTUzsySVLOSuvvhxuyYdhI05f3cnH6u2aN1HgGp7vX6bg+U3Ue8wbHfdcifcGIk5UEU+Q+QO6InA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.2.tgz",
+      "integrity": "sha512-LgSKgAStiDzpUSLYwJoAmy0W8nkxx/ExMmgEPgEYVi6dKPkUmtu561J970PhGdYH+D79ke3g87D+plkUkgfnlQ==",
       "requires": {
-        "apollo-reporting-protobuf": "^0.6.1",
+        "apollo-reporting-protobuf": "^0.6.2",
         "apollo-server-caching": "^0.5.2",
         "apollo-server-env": "^2.4.5"
       }
     },
     "apollo-tracing": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.12.0.tgz",
-      "integrity": "sha512-cMUYGE6mOEwb9HDqhf4fiPEo2JMhjPIqEprAQEC57El76avRpRig5NM0bnqMZcYJZR5QmLlNcttNccOwf9WrNg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.12.1.tgz",
+      "integrity": "sha512-qdkUjW+pOaidGOSITypeYE288y28HkPmGNpUtyQSOeTxgqXHtQX3TDWiOJ2SmrLH08xdSwfvz9o5KrTq4PdISg==",
       "requires": {
         "apollo-server-env": "^2.4.5",
-        "apollo-server-plugin-base": "^0.10.2"
+        "apollo-server-plugin-base": "^0.10.3"
       }
     },
     "apollo-utilities": {
@@ -11163,14 +11170,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
-    "decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "requires": {
-        "mimic-response": "^2.0.0"
-      }
-    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -14120,13 +14119,13 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.6.tgz",
-      "integrity": "sha512-EUNw+OIRXYTPxToSoJjhJvS5aGa94KkdkZnL1I9DCZT64/+rzQNeLeGj+goj2RYuYvoQe1Bmcx0CNZ1GqwBhng==",
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.7.tgz",
+      "integrity": "sha512-yc9qOmEmWVZNkux9m0eCiHdtYSwNZRHkFhgfKfDn4u/gpsJolft1iyMUADnG/eytiRW0CGZFBpZjHkJhpginuQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "apollo-server-env": "^2.4.5",
-        "apollo-server-types": "^0.6.1"
+        "apollo-server-types": "^0.6.2"
       }
     },
     "graphql-language-service-interface": {
@@ -14171,18 +14170,18 @@
       }
     },
     "graphql-parse-resolve-info": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.9.0.tgz",
-      "integrity": "sha512-tJqpmG+t5e68ZUjlbNzZ6O6kjzULeVBa+2KOC0IwwxaajtnKpp1bzaZxteOvWATdPwuASfOFJA1epYiva6/ztQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.10.0.tgz",
+      "integrity": "sha512-4KWA4oiVnC1bduPZzmuUsTT9SZf/sbdrOAtOsHz747H6Azs4xPgj7/DPXCgdYvKrd4Ci9fNDcem4mOVV2Lct1w==",
       "requires": {
         "debug": "^4.1.1",
         "tslib": "^2.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -14193,9 +14192,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -14615,6 +14614,11 @@
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
       }
+    },
+    "hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ=="
     },
     "html-comment-regex": {
       "version": "1.1.2",
@@ -18691,11 +18695,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "min-document": {
       "version": "2.19.0",

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerCohort.css';
+import './typedef';
 
 function CohortButton(props) {
   return <Button className='guppy-explorer-cohort__button' {...props} />;
@@ -23,6 +24,13 @@ export function CohortActionButton({ labelIcon, labelText, ...attrs }) {
   );
 }
 
+/**
+ * @param {Object} prop
+ * @param {ExplorerCohort} prop.currentCohort
+ * @param {ExplorerCohort[]} prop.cohorts
+ * @param {(opened: ExplorerCohort) => void} prop.onAction
+ * @param {() => void} prop.onClose
+ */
 function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
   const emptyOption = {
     label: 'Open New (no cohort)',
@@ -85,6 +93,15 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
   );
 }
 
+/**
+ * @param {Object} prop
+ * @param {ExplorerCohort} prop.currentCohort
+ * @param {ExplorerFilter} prop.currentFilter
+ * @param {ExplorerCohort[]} prop.cohorts
+ * @param {boolean} prop.isFilterChanged
+ * @param {(saved: ExplorerCohort) => void} prop.onAction
+ * @param {() => void} prop.onClose
+ */
 function CohortSaveForm({
   currentCohort,
   currentFilter,
@@ -161,6 +178,14 @@ function CohortSaveForm({
   );
 }
 
+/**
+ * @param {Object} prop
+ * @param {ExplorerCohort} prop.currentCohort
+ * @param {ExplorerFilter} prop.currentFilter
+ * @param {boolean} prop.isFilterChanged
+ * @param {(updated: ExplorerCohort) => void} prop.onAction
+ * @param {() => void} prop.onClose
+ */
 function CohortUpdateForm({
   currentCohort,
   currentFilter,
@@ -223,6 +248,12 @@ function CohortUpdateForm({
   );
 }
 
+/**
+ * @param {Object} prop
+ * @param {ExplorerCohort} prop.currentCohort
+ * @param {(deleted: ExplorerCohort) => void} prop.onAction
+ * @param {() => void} prop.onClose
+ */
 function CohortDeleteForm({ currentCohort, onAction, onClose }) {
   return (
     <div className='guppy-explorer-cohort__form'>
@@ -242,6 +273,20 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
   );
 }
 
+/**
+ * @param {Object} prop
+ * @param {'open' | 'save' | 'update' | 'delete'} prop.actionType
+ * @param {ExplorerCohort} prop.currentCohort
+ * @param {ExplorerFilter} prop.currentFilter
+ * @param {ExplorerCohort[]} prop.cohorts
+ * @param {object} prop.handlers
+ * @param {(opened: ExplorerCohort) => void} prop.handlers.handleOpen
+ * @param {(saved: ExplorerCohort) => void} prop.handlers.handleSave
+ * @param {(updated: ExplorerCohort) => void} prop.handlers.handleUpdate
+ * @param {(deleted: ExplorerCohort) => void} prop.handlers.handleDelete
+ * @param {() => void} prop.handlers.handleClose
+ * @param {boolean} isFilterChanged
+ */
 export function CohortActionForm({
   actionType,
   currentCohort,

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import Select from 'react-select';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import SimpleInputField from '../../components/SimpleInputField';
+import Button from '../../gen3-ui-component/components/Button';
+import './ExplorerCohort.css';
+
+function CohortButton(props) {
+  return <Button className='guppy-explorer-cohort__button' {...props} />;
+}
+
+export function CohortActionButton({ labelIcon, labelText, ...attrs }) {
+  return (
+    <CohortButton
+      buttonType='default'
+      label={
+        <div>
+          {labelText} {labelIcon && <FontAwesomeIcon icon={labelIcon} />}
+        </div>
+      }
+      {...attrs}
+    />
+  );
+}
+
+function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
+  const emptyOption = {
+    label: 'Open New (no cohort)',
+    value: { name: '', description: '' },
+  };
+  const options = cohorts.map((cohort) => ({
+    label: cohort.name,
+    value: cohort,
+  }));
+  const [selected, setSelected] = useState({
+    label: currentCohort.name || 'Open New (no cohort)',
+    value: currentCohort,
+  });
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Select a saved Cohort to open</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={
+            <Select
+              options={[emptyOption, ...options]}
+              value={selected}
+              clearable={false}
+              theme={(theme) => ({
+                ...theme,
+                colors: {
+                  ...theme.colors,
+                  primary: 'var(--g3-color__base-blue)',
+                },
+              })}
+              onChange={(e) => setSelected(e)}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Description'
+          input={<textarea disabled value={selected.value.description} />}
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Open Cohort'
+          onClick={() => onAction(selected.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CohortSaveForm({ currentCohort, onAction, onClose }) {
+  const [cohort, setCohort] = useState(currentCohort);
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Save as a new Cohort</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={
+            <input
+              value={cohort.name}
+              onChange={(e) => {
+                e.persist();
+                setCohort((prev) => ({ ...prev, name: e.target.value }));
+              }}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Description'
+          input={
+            <textarea
+              value={cohort.description}
+              onChange={(e) => {
+                e.persist();
+                setCohort((prev) => ({ ...prev, description: e.target.value }));
+              }}
+            />
+          }
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton label='Save Cohort' onClick={() => onAction(cohort)} />
+      </div>
+    </div>
+  );
+}
+
+function CohortUpdateForm({ currentCohort, onAction, onClose }) {
+  const [description, setDescription] = useState(currentCohort.description);
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Update the current Cohort</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={<input disabled value={currentCohort.name} />}
+        />
+        <SimpleInputField
+          label='Description'
+          input={
+            <textarea
+              value={description}
+              onChange={(e) => {
+                e.persist();
+                setDescription(e.target.value);
+              }}
+            />
+          }
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Update Cohort'
+          onClick={() =>
+            onAction({
+              ...currentCohort,
+              description,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function CohortDeleteForm({ currentCohort, onAction, onClose }) {
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Are you sure to delete the current Cohort?</h4>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Delete Cohort'
+          onClick={() => onAction(currentCohort)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function CohortActionForm({
+  actionType,
+  currentCohort,
+  cohorts,
+  handlers,
+}) {
+  const {
+    handleOpen,
+    handleSave,
+    handleUpdate,
+    handleDelete,
+    handleClose,
+  } = handlers;
+
+  switch (actionType) {
+    case 'open':
+      return (
+        <CohortOpenForm
+          currentCohort={currentCohort}
+          cohorts={cohorts}
+          onAction={handleOpen}
+          onClose={handleClose}
+        />
+      );
+    case 'save':
+      return (
+        <CohortSaveForm
+          currentCohort={currentCohort}
+          onAction={handleSave}
+          onClose={handleClose}
+        />
+      );
+    case 'update':
+      return (
+        <CohortUpdateForm
+          currentCohort={currentCohort}
+          onAction={handleUpdate}
+          onClose={handleClose}
+        />
+      );
+    case 'delete':
+      return (
+        <CohortDeleteForm
+          currentCohort={currentCohort}
+          onAction={handleDelete}
+          onClose={handleClose}
+        />
+      );
+  }
+}

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -46,6 +46,7 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
             <Select
               options={[emptyOption, ...options]}
               value={selected}
+              autoFocus
               clearable={false}
               theme={(theme) => ({
                 ...theme,
@@ -88,6 +89,7 @@ function CohortSaveForm({ currentCohort, onAction, onClose }) {
           label='Name'
           input={
             <input
+              autoFocus
               value={cohort.name}
               onChange={(e) => {
                 e.persist();
@@ -135,6 +137,7 @@ function CohortUpdateForm({ currentCohort, onAction, onClose }) {
           label='Description'
           input={
             <textarea
+              autoFocus
               value={description}
               onChange={(e) => {
                 e.persist();

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -85,8 +85,17 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
   );
 }
 
-function CohortSaveForm({ currentCohort, onAction, onClose }) {
+function CohortSaveForm({ currentCohort, cohorts, onAction, onClose }) {
   const [cohort, setCohort] = useState(currentCohort);
+  const [error, setError] = useState({ isError: false, message: '' });
+  function validate() {
+    if (cohort.name === '')
+      setError({ isError: true, message: 'Name is required!' });
+    else if (cohorts.filter((c) => c.name === cohort.name).length > 0)
+      setError({ isError: true, message: 'Name is already in use!' });
+    else setError({ isError: false, message: '' });
+  }
+
   return (
     <div className='guppy-explorer-cohort__form'>
       <h4>Save as a new Cohort</h4>
@@ -98,12 +107,14 @@ function CohortSaveForm({ currentCohort, onAction, onClose }) {
               autoFocus
               placeholder='Enter the cohort name'
               value={cohort.name}
+              onBlur={validate}
               onChange={(e) => {
                 e.persist();
                 setCohort((prev) => ({ ...prev, name: e.target.value }));
               }}
             />
           }
+          error={error}
         />
         <SimpleInputField
           label='Description'
@@ -125,7 +136,11 @@ function CohortSaveForm({ currentCohort, onAction, onClose }) {
           label='Back to page'
           onClick={onClose}
         />
-        <CohortButton label='Save Cohort' onClick={() => onAction(cohort)} />
+        <CohortButton
+          enabled={!error.isError}
+          label='Save Cohort'
+          onClick={() => onAction(cohort)}
+        />
       </div>
     </div>
   );
@@ -223,6 +238,7 @@ export function CohortActionForm({
       return (
         <CohortSaveForm
           currentCohort={currentCohort}
+          cohorts={cohorts}
           onAction={handleSave}
           onClose={handleClose}
         />

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import cloneDeep from 'lodash.clonedeep';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerCohort.css';
@@ -26,7 +27,7 @@ export function CohortActionButton({ labelIcon, labelText, ...attrs }) {
 function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
   const emptyOption = {
     label: 'Open New (no cohort)',
-    value: { name: '', description: '' },
+    value: { name: '', description: '', filter: {} },
   };
   const options = cohorts.map((cohort) => ({
     label: cohort.name,
@@ -85,7 +86,13 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
   );
 }
 
-function CohortSaveForm({ currentCohort, cohorts, onAction, onClose }) {
+function CohortSaveForm({
+  currentCohort,
+  currentFilter,
+  cohorts,
+  onAction,
+  onClose,
+}) {
   const [cohort, setCohort] = useState(currentCohort);
   const [error, setError] = useState({ isError: false, message: '' });
   function validate() {
@@ -139,14 +146,16 @@ function CohortSaveForm({ currentCohort, cohorts, onAction, onClose }) {
         <CohortButton
           enabled={cohort.name !== currentCohort.name && !error.isError}
           label='Save Cohort'
-          onClick={() => onAction(cohort)}
+          onClick={() =>
+            onAction({ ...cohort, filter: cloneDeep(currentFilter) })
+          }
         />
       </div>
     </div>
   );
 }
 
-function CohortUpdateForm({ currentCohort, onAction, onClose }) {
+function CohortUpdateForm({ currentCohort, currentFilter, onAction, onClose }) {
   const [description, setDescription] = useState(currentCohort.description);
   return (
     <div className='guppy-explorer-cohort__form'>
@@ -184,6 +193,7 @@ function CohortUpdateForm({ currentCohort, onAction, onClose }) {
             onAction({
               ...currentCohort,
               description,
+              filter: cloneDeep(currentFilter),
             })
           }
         />
@@ -214,6 +224,7 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
 export function CohortActionForm({
   actionType,
   currentCohort,
+  currentFilter,
   cohorts,
   handlers,
 }) {
@@ -239,6 +250,7 @@ export function CohortActionForm({
       return (
         <CohortSaveForm
           currentCohort={currentCohort}
+          currentFilter={currentFilter}
           cohorts={cohorts}
           onAction={handleSave}
           onClose={handleClose}
@@ -248,6 +260,7 @@ export function CohortActionForm({
       return (
         <CohortUpdateForm
           currentCohort={currentCohort}
+          currentFilter={currentFilter}
           onAction={handleUpdate}
           onClose={handleClose}
         />

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -154,9 +154,20 @@ function CohortSaveForm({
 
 function CohortUpdateForm({ currentCohort, currentFilter, onAction, onClose }) {
   const [description, setDescription] = useState(currentCohort.description);
+  const isFilterChanged =
+    JSON.stringify(currentFilter) !== JSON.stringify(currentCohort.filter);
   return (
     <div className='guppy-explorer-cohort__form'>
       <h4>Update the current Cohort</h4>
+      {isFilterChanged && (
+        <p>
+          <FontAwesomeIcon
+            icon='exclamation-triangle'
+            color='#EF8523' // g3-color__highlight-orange
+          />{' '}
+          You have changed filters for this Cohort.
+        </p>
+      )}
       <form>
         <SimpleInputField
           label='Name'
@@ -185,7 +196,7 @@ function CohortUpdateForm({ currentCohort, currentFilter, onAction, onClose }) {
         />
         <CohortButton
           label='Update Cohort'
-          enabled={description !== currentCohort.description}
+          enabled={description !== currentCohort.description || isFilterChanged}
           onClick={() =>
             onAction({
               ...currentCohort,

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -275,7 +275,7 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
 
 /**
  * @param {Object} prop
- * @param {'open' | 'save' | 'update' | 'delete'} prop.actionType
+ * @param {ExplorerCohortActionType} prop.actionType
  * @param {ExplorerCohort} prop.currentCohort
  * @param {ExplorerFilter} prop.currentFilter
  * @param {ExplorerCohort[]} prop.cohorts
@@ -285,7 +285,7 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
  * @param {(updated: ExplorerCohort) => void} prop.handlers.handleUpdate
  * @param {(deleted: ExplorerCohort) => void} prop.handlers.handleDelete
  * @param {() => void} prop.handlers.handleClose
- * @param {boolean} isFilterChanged
+ * @param {boolean} prop.isFilterChanged
  */
 export function CohortActionForm({
   actionType,

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -137,7 +137,7 @@ function CohortSaveForm({ currentCohort, cohorts, onAction, onClose }) {
           onClick={onClose}
         />
         <CohortButton
-          enabled={!error.isError}
+          enabled={cohort.name !== currentCohort.name && !error.isError}
           label='Save Cohort'
           onClick={() => onAction(cohort)}
         />
@@ -179,6 +179,7 @@ function CohortUpdateForm({ currentCohort, onAction, onClose }) {
         />
         <CohortButton
           label='Update Cohort'
+          enabled={description !== currentCohort.description}
           onClick={() =>
             onAction({
               ...currentCohort,

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -102,9 +102,21 @@ function CohortSaveForm({
     else setError({ isError: false, message: '' });
   }
 
+  const isFilterChanged =
+    JSON.stringify(currentFilter) !== JSON.stringify(currentCohort.filter);
+
   return (
     <div className='guppy-explorer-cohort__form'>
       <h4>Save as a new Cohort</h4>
+      {currentCohort.name !== '' && isFilterChanged && (
+        <p>
+          <FontAwesomeIcon
+            icon='exclamation-triangle'
+            color='#EF8523' // g3-color__highlight-orange
+          />{' '}
+          You have changed filters for this Cohort.
+        </p>
+      )}
       <form>
         <SimpleInputField
           label='Name'

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import cloneDeep from 'lodash.clonedeep';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerCohort.css';
@@ -79,7 +78,7 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
         />
         <CohortButton
           label='Open Cohort'
-          onClick={() => onAction(cloneDeep(selected.value))}
+          onClick={() => onAction(selected.value)}
         />
       </div>
     </div>
@@ -146,9 +145,7 @@ function CohortSaveForm({
         <CohortButton
           enabled={cohort.name !== currentCohort.name && !error.isError}
           label='Save Cohort'
-          onClick={() =>
-            onAction({ ...cohort, filter: cloneDeep(currentFilter) })
-          }
+          onClick={() => onAction({ ...cohort, filter: currentFilter })}
         />
       </div>
     </div>
@@ -193,7 +190,7 @@ function CohortUpdateForm({ currentCohort, currentFilter, onAction, onClose }) {
             onAction({
               ...currentCohort,
               description,
-              filter: cloneDeep(currentFilter),
+              filter: currentFilter,
             })
           }
         />

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -89,6 +89,7 @@ function CohortSaveForm({
   currentCohort,
   currentFilter,
   cohorts,
+  isFilterChanged,
   onAction,
   onClose,
 }) {
@@ -101,10 +102,6 @@ function CohortSaveForm({
       setError({ isError: true, message: 'Name is already in use!' });
     else setError({ isError: false, message: '' });
   }
-
-  const isFilterChanged =
-    JSON.stringify(currentFilter) !== JSON.stringify(currentCohort.filter);
-
   return (
     <div className='guppy-explorer-cohort__form'>
       <h4>Save as a new Cohort</h4>
@@ -164,10 +161,14 @@ function CohortSaveForm({
   );
 }
 
-function CohortUpdateForm({ currentCohort, currentFilter, onAction, onClose }) {
+function CohortUpdateForm({
+  currentCohort,
+  currentFilter,
+  isFilterChanged,
+  onAction,
+  onClose,
+}) {
   const [description, setDescription] = useState(currentCohort.description);
-  const isFilterChanged =
-    JSON.stringify(currentFilter) !== JSON.stringify(currentCohort.filter);
   return (
     <div className='guppy-explorer-cohort__form'>
       <h4>Update the current Cohort</h4>
@@ -247,6 +248,7 @@ export function CohortActionForm({
   currentFilter,
   cohorts,
   handlers,
+  isFilterChanged,
 }) {
   const {
     handleOpen,
@@ -272,6 +274,7 @@ export function CohortActionForm({
           currentCohort={currentCohort}
           currentFilter={currentFilter}
           cohorts={cohorts}
+          isFilterChanged={isFilterChanged}
           onAction={handleSave}
           onClose={handleClose}
         />
@@ -281,6 +284,7 @@ export function CohortActionForm({
         <CohortUpdateForm
           currentCohort={currentCohort}
           currentFilter={currentFilter}
+          isFilterChanged={isFilterChanged}
           onAction={handleUpdate}
           onClose={handleClose}
         />

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerCohort.css';
@@ -10,6 +11,9 @@ function CohortButton(props) {
   return <Button className='guppy-explorer-cohort__button' {...props} />;
 }
 
+/**
+ * @param {{ labelIcon: IconProp; labelText: string; [x: string]: * }} prop
+ */
 export function CohortActionButton({ labelIcon, labelText, ...attrs }) {
   return (
     <CohortButton

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -79,7 +79,7 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
         />
         <CohortButton
           label='Open Cohort'
-          onClick={() => onAction(selected.value)}
+          onClick={() => onAction(cloneDeep(selected.value))}
         />
       </div>
     </div>

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -61,7 +61,13 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
         />
         <SimpleInputField
           label='Description'
-          input={<textarea disabled value={selected.value.description} />}
+          input={
+            <textarea
+              disabled
+              placeholder='No description'
+              value={selected.value.description}
+            />
+          }
         />
       </form>
       <div>
@@ -90,6 +96,7 @@ function CohortSaveForm({ currentCohort, onAction, onClose }) {
           input={
             <input
               autoFocus
+              placeholder='Enter the cohort name'
               value={cohort.name}
               onChange={(e) => {
                 e.persist();
@@ -102,6 +109,7 @@ function CohortSaveForm({ currentCohort, onAction, onClose }) {
           label='Description'
           input={
             <textarea
+              placeholder='Describe the cohort (optional)'
               value={cohort.description}
               onChange={(e) => {
                 e.persist();
@@ -138,6 +146,7 @@ function CohortUpdateForm({ currentCohort, onAction, onClose }) {
           input={
             <textarea
               autoFocus
+              placeholder='Describe the cohort (optional)'
               value={description}
               onChange={(e) => {
                 e.persist();

--- a/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
+++ b/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
@@ -1,0 +1,40 @@
+.guppy-explorer-cohort__name {
+  line-height: 1.25;
+}
+
+.guppy-explorer-cohort__button {
+  margin-right: 10px;
+}
+
+.guppy-explorer-cohort__placeholder {
+  font-style: italic;
+}
+
+.guppy-explorer-cohort__overlay {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(245, 245, 245, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.guppy-explorer-cohort__form {
+  background-color: var(--g3-color__white);
+  border: 1px solid var(--g3-color__silver);
+  border-top: 4px solid var(--g3-color__base-blue);
+  border-radius: 4px;
+  min-height: 200px;
+  width: 100%;
+  max-width: 480px;
+  padding: 2rem 1rem;
+  margin: 0 0.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
-function ExplorerCohort({ className, filter }) {
+function ExplorerCohort({ className, filter, onOpenCohort }) {
   const [cohort, setCohort] = useState({
     name: '',
     description: '',
@@ -24,6 +24,7 @@ function ExplorerCohort({ className, filter }) {
   function handleOpen(opened) {
     console.log('Cohort action: open');
     setCohort(opened);
+    onOpenCohort(opened);
     closeActionForm();
   }
   function handleSave(saved) {

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import cloneDeep from 'lodash.clonedeep';
+import Tooltip from 'rc-tooltip';
+import 'rc-tooltip/assets/bootstrap_white.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
@@ -62,13 +65,39 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     closeActionForm();
   }
 
+  const isFilterChanged =
+    JSON.stringify(filter) !== JSON.stringify(cohort.filter);
+  function FilterChangedWarning() {
+    return (
+      <Tooltip
+        placement='top'
+        overlay='You have changed filters for this Cohort. Click this icon to undo.'
+        arrowContent={<div className='rc-tooltip-arrow-inner' />}
+      >
+        <FontAwesomeIcon
+          icon='exclamation-triangle'
+          color='#EF8523' // g3-color__highlight-orange
+          size='xs'
+          style={{
+            cursor: 'pointer',
+          }}
+          onClick={() => onOpenCohort(cloneDeep(cohort))}
+        />
+      </Tooltip>
+    );
+  }
+
   return (
     <>
       <div className={className}>
         <div>
           <h1 className='guppy-explorer-cohort__name'>
             Cohort:{' '}
-            {cohort.name || (
+            {cohort.name ? (
+              <>
+                {cohort.name} {isFilterChanged && <FilterChangedWarning />}
+              </>
+            ) : (
               <span className='guppy-explorer-cohort__placeholder'>
                 untitled
               </span>

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
-function ExplorerCohort({ className, filter, onOpenCohort }) {
+function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   const [cohort, setCohort] = useState({
     name: '',
     description: '',
@@ -53,6 +53,7 @@ function ExplorerCohort({ className, filter, onOpenCohort }) {
     }
     setCohort({ name: '', description: '', filter: {} });
     setCohorts(updatedCohorts);
+    onDeleteCohort({ name: '', description: '', filter: {} });
     closeActionForm();
   }
 

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -4,7 +4,7 @@ import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
 function ExplorerCohort({ className }) {
-  const [cohort, setCohort] = useState({ name: '', descripton: '' });
+  const [cohort, setCohort] = useState({ name: '', description: '' });
   const [cohorts, setCohorts] = useState([]);
 
   const [actionType, setActionType] = useState('');

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -3,12 +3,16 @@ import ReactDOM from 'react-dom';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
-function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
-  const [cohort, setCohort] = useState({
+function createEmptyCohort() {
+  return {
     name: '',
     description: '',
     filter: {},
-  });
+  };
+}
+
+function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
+  const [cohort, setCohort] = useState(createEmptyCohort());
   const [cohorts, setCohorts] = useState([]);
 
   const [actionType, setActionType] = useState('');
@@ -51,9 +55,9 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
       if (name === deleted.name) continue;
       else updatedCohorts.push({ name, description });
     }
-    setCohort({ name: '', description: '', filter: {} });
+    setCohort(createEmptyCohort());
     setCohorts(updatedCohorts);
-    onDeleteCohort({ name: '', description: '', filter: {} });
+    onDeleteCohort(createEmptyCohort());
     closeActionForm();
   }
 

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -65,9 +65,9 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   }
   function handleUpdate(/** @type {ExplorerCohort} */ updated) {
     const updatedCohorts = [];
-    for (const { name, description } of cohorts) {
+    for (const { name, description, filter } of cohorts) {
       if (name === updated.name) updatedCohorts.push(cloneDeep(updated));
-      else updatedCohorts.push({ name, description });
+      else updatedCohorts.push({ name, description, filter });
     }
     setCohort(cloneDeep(updated));
     setCohorts(updatedCohorts);
@@ -76,9 +76,9 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   function handleDelete(/** @type {ExplorerCohort} */ deleted) {
     /** @type {ExplorerCohort[]} */
     const updatedCohorts = [];
-    for (const { name, description } of cohorts) {
+    for (const { name, description, filter } of cohorts) {
       if (name === deleted.name) continue;
-      else updatedCohorts.push({ name, description });
+      else updatedCohorts.push({ name, description, filter });
     }
     setCohort(createEmptyCohort());
     setCohorts(updatedCohorts);

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -1,0 +1,330 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import Select from 'react-select';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import SimpleInputField from '../../components/SimpleInputField';
+import Button from '../../gen3-ui-component/components/Button';
+import './ExplorerCohort.css';
+
+function CohortButton(props) {
+  return <Button className='guppy-explorer-cohort__button' {...props} />;
+}
+
+function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
+  const emptyOption = {
+    label: 'Open New (no cohort)',
+    value: { name: '', description: '' },
+  };
+  const options = cohorts.map((cohort) => ({
+    label: cohort.name,
+    value: cohort,
+  }));
+  const [selected, setSelected] = useState({
+    label: currentCohort.name || 'Open New (no cohort)',
+    value: currentCohort,
+  });
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Select a saved Cohort to open</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={
+            <Select
+              options={[emptyOption, ...options]}
+              value={selected}
+              clearable={false}
+              theme={(theme) => ({
+                ...theme,
+                colors: {
+                  ...theme.colors,
+                  primary: 'var(--g3-color__base-blue)',
+                },
+              })}
+              onChange={(e) => setSelected(e)}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Description'
+          input={<textarea disabled value={selected.value.description} />}
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Open Cohort'
+          onClick={() => onAction(selected.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CohortSaveForm({ currentCohort, onAction, onClose }) {
+  const [cohort, setCohort] = useState(currentCohort);
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Save as a new Cohort</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={
+            <input
+              value={cohort.name}
+              onChange={(e) => {
+                e.persist();
+                setCohort((prev) => ({ ...prev, name: e.target.value }));
+              }}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Description'
+          input={
+            <textarea
+              value={cohort.description}
+              onChange={(e) => {
+                e.persist();
+                setCohort((prev) => ({ ...prev, description: e.target.value }));
+              }}
+            />
+          }
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton label='Save Cohort' onClick={() => onAction(cohort)} />
+      </div>
+    </div>
+  );
+}
+
+function CohortUpdateForm({ currentCohort, onAction, onClose }) {
+  const [description, setDescription] = useState(currentCohort.description);
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Update the current Cohort</h4>
+      <form>
+        <SimpleInputField
+          label='Name'
+          input={<input disabled value={currentCohort.name} />}
+        />
+        <SimpleInputField
+          label='Description'
+          input={
+            <textarea
+              value={description}
+              onChange={(e) => {
+                e.persist();
+                setDescription(e.target.value);
+              }}
+            />
+          }
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Update Cohort'
+          onClick={() =>
+            onAction({
+              ...currentCohort,
+              description,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function CohortDeleteForm({ currentCohort, onAction, onClose }) {
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Are you sure to delete the current Cohort?</h4>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Delete Cohort'
+          onClick={() => onAction(currentCohort)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CohortActionButton({ labelIcon, labelText, ...attrs }) {
+  return (
+    <CohortButton
+      buttonType='default'
+      label={
+        <div>
+          {labelText} {labelIcon && <FontAwesomeIcon icon={labelIcon} />}
+        </div>
+      }
+      {...attrs}
+    />
+  );
+}
+
+function ExplorerCohort({ className }) {
+  const [cohort, setCohort] = useState({ name: '', descripton: '' });
+  const [cohorts, setCohorts] = useState([]);
+
+  const [actionType, setActionType] = useState('');
+  const [showActionForm, setShowActionForm] = useState(false);
+  function openActionForm(actionType) {
+    setActionType(actionType);
+    setShowActionForm(true);
+  }
+  function closeActionForm() {
+    setShowActionForm(false);
+  }
+
+  function handleOpen(opened) {
+    console.log('Cohort action: open');
+    setCohort(opened);
+    closeActionForm();
+  }
+  function handleSave(saved) {
+    console.log('Cohort action: save');
+    setCohort(saved);
+    setCohorts([...cohorts, saved]);
+    closeActionForm();
+  }
+  function handleUpdate(updated) {
+    console.log('Cohort action: update');
+    const updatedCohorts = [];
+    for (const { name, description } of cohorts) {
+      if (name === updated.name) updatedCohorts.push(updated);
+      else updatedCohorts.push({ name, description });
+    }
+    setCohort(updated);
+    setCohorts(updatedCohorts);
+    closeActionForm();
+  }
+  function handleDelete(deleted) {
+    console.log('Cohort action: delete');
+    const updatedCohorts = [];
+    for (const { name, description } of cohorts) {
+      if (name === deleted.name) continue;
+      else updatedCohorts.push({ name, description });
+    }
+    setCohort({ name: '', description: '' });
+    setCohorts(updatedCohorts);
+    closeActionForm();
+  }
+
+  function CohortActionForm() {
+    switch (actionType) {
+      case 'open':
+        return (
+          <CohortOpenForm
+            currentCohort={cohort}
+            cohorts={cohorts}
+            onAction={handleOpen}
+            onClose={closeActionForm}
+          />
+        );
+      case 'save':
+        return (
+          <CohortSaveForm
+            currentCohort={cohort}
+            onAction={handleSave}
+            onClose={closeActionForm}
+          />
+        );
+      case 'update':
+        return (
+          <CohortUpdateForm
+            currentCohort={cohort}
+            onAction={handleUpdate}
+            onClose={closeActionForm}
+          />
+        );
+      case 'delete':
+        return (
+          <CohortDeleteForm
+            currentCohort={cohort}
+            onAction={handleDelete}
+            onClose={closeActionForm}
+          />
+        );
+    }
+  }
+
+  return (
+    <>
+      <div className={className}>
+        <div>
+          <h1 className='guppy-explorer-cohort__name'>
+            Cohort:{' '}
+            {cohort.name || (
+              <span className='guppy-explorer-cohort__placeholder'>
+                untitled
+              </span>
+            )}
+          </h1>
+          <p>
+            {cohort.description || (
+              <span className='guppy-explorer-cohort__placeholder'>
+                No description
+              </span>
+            )}
+          </p>
+        </div>
+        <div>
+          <CohortActionButton
+            labelIcon='folder-open'
+            labelText='Open Cohort'
+            enabled={cohorts.length > 0}
+            onClick={() => openActionForm('open')}
+          />
+          <CohortActionButton
+            labelIcon='save'
+            labelText={`Save ${cohort.name === '' ? 'New' : 'As'}`}
+            onClick={() => openActionForm('save')}
+          />
+          <CohortActionButton
+            labelIcon='pen'
+            labelText='Update Cohort'
+            enabled={cohort.name !== ''}
+            onClick={() => openActionForm('update')}
+          />
+          <CohortActionButton
+            labelIcon='trash-alt'
+            labelText='Delete Cohort'
+            enabled={cohort.name !== ''}
+            onClick={() => openActionForm('delete')}
+          />
+        </div>
+      </div>
+      {showActionForm &&
+        ReactDOM.createPortal(
+          <div className='guppy-explorer-cohort__overlay'>
+            <CohortActionForm />
+          </div>,
+          document.getElementById('root')
+        )}
+    </>
+  );
+}
+
+export default ExplorerCohort;

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -51,7 +51,7 @@ function ExplorerCohort({ className, filter, onOpenCohort }) {
       if (name === deleted.name) continue;
       else updatedCohorts.push({ name, description });
     }
-    setCohort({ name: '', description: '' });
+    setCohort({ name: '', description: '', filter: {} });
     setCohorts(updatedCohorts);
     closeActionForm();
   }

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -1,188 +1,7 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
-import Select from 'react-select';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import SimpleInputField from '../../components/SimpleInputField';
-import Button from '../../gen3-ui-component/components/Button';
+import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
-
-function CohortButton(props) {
-  return <Button className='guppy-explorer-cohort__button' {...props} />;
-}
-
-function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
-  const emptyOption = {
-    label: 'Open New (no cohort)',
-    value: { name: '', description: '' },
-  };
-  const options = cohorts.map((cohort) => ({
-    label: cohort.name,
-    value: cohort,
-  }));
-  const [selected, setSelected] = useState({
-    label: currentCohort.name || 'Open New (no cohort)',
-    value: currentCohort,
-  });
-  return (
-    <div className='guppy-explorer-cohort__form'>
-      <h4>Select a saved Cohort to open</h4>
-      <form>
-        <SimpleInputField
-          label='Name'
-          input={
-            <Select
-              options={[emptyOption, ...options]}
-              value={selected}
-              clearable={false}
-              theme={(theme) => ({
-                ...theme,
-                colors: {
-                  ...theme.colors,
-                  primary: 'var(--g3-color__base-blue)',
-                },
-              })}
-              onChange={(e) => setSelected(e)}
-            />
-          }
-        />
-        <SimpleInputField
-          label='Description'
-          input={<textarea disabled value={selected.value.description} />}
-        />
-      </form>
-      <div>
-        <CohortButton
-          buttonType='default'
-          label='Back to page'
-          onClick={onClose}
-        />
-        <CohortButton
-          label='Open Cohort'
-          onClick={() => onAction(selected.value)}
-        />
-      </div>
-    </div>
-  );
-}
-
-function CohortSaveForm({ currentCohort, onAction, onClose }) {
-  const [cohort, setCohort] = useState(currentCohort);
-  return (
-    <div className='guppy-explorer-cohort__form'>
-      <h4>Save as a new Cohort</h4>
-      <form>
-        <SimpleInputField
-          label='Name'
-          input={
-            <input
-              value={cohort.name}
-              onChange={(e) => {
-                e.persist();
-                setCohort((prev) => ({ ...prev, name: e.target.value }));
-              }}
-            />
-          }
-        />
-        <SimpleInputField
-          label='Description'
-          input={
-            <textarea
-              value={cohort.description}
-              onChange={(e) => {
-                e.persist();
-                setCohort((prev) => ({ ...prev, description: e.target.value }));
-              }}
-            />
-          }
-        />
-      </form>
-      <div>
-        <CohortButton
-          buttonType='default'
-          label='Back to page'
-          onClick={onClose}
-        />
-        <CohortButton label='Save Cohort' onClick={() => onAction(cohort)} />
-      </div>
-    </div>
-  );
-}
-
-function CohortUpdateForm({ currentCohort, onAction, onClose }) {
-  const [description, setDescription] = useState(currentCohort.description);
-  return (
-    <div className='guppy-explorer-cohort__form'>
-      <h4>Update the current Cohort</h4>
-      <form>
-        <SimpleInputField
-          label='Name'
-          input={<input disabled value={currentCohort.name} />}
-        />
-        <SimpleInputField
-          label='Description'
-          input={
-            <textarea
-              value={description}
-              onChange={(e) => {
-                e.persist();
-                setDescription(e.target.value);
-              }}
-            />
-          }
-        />
-      </form>
-      <div>
-        <CohortButton
-          buttonType='default'
-          label='Back to page'
-          onClick={onClose}
-        />
-        <CohortButton
-          label='Update Cohort'
-          onClick={() =>
-            onAction({
-              ...currentCohort,
-              description,
-            })
-          }
-        />
-      </div>
-    </div>
-  );
-}
-
-function CohortDeleteForm({ currentCohort, onAction, onClose }) {
-  return (
-    <div className='guppy-explorer-cohort__form'>
-      <h4>Are you sure to delete the current Cohort?</h4>
-      <div>
-        <CohortButton
-          buttonType='default'
-          label='Back to page'
-          onClick={onClose}
-        />
-        <CohortButton
-          label='Delete Cohort'
-          onClick={() => onAction(currentCohort)}
-        />
-      </div>
-    </div>
-  );
-}
-
-function CohortActionButton({ labelIcon, labelText, ...attrs }) {
-  return (
-    <CohortButton
-      buttonType='default'
-      label={
-        <div>
-          {labelText} {labelIcon && <FontAwesomeIcon icon={labelIcon} />}
-        </div>
-      }
-      {...attrs}
-    />
-  );
-}
 
 function ExplorerCohort({ className }) {
   const [cohort, setCohort] = useState({ name: '', descripton: '' });
@@ -230,44 +49,6 @@ function ExplorerCohort({ className }) {
     setCohort({ name: '', description: '' });
     setCohorts(updatedCohorts);
     closeActionForm();
-  }
-
-  function CohortActionForm() {
-    switch (actionType) {
-      case 'open':
-        return (
-          <CohortOpenForm
-            currentCohort={cohort}
-            cohorts={cohorts}
-            onAction={handleOpen}
-            onClose={closeActionForm}
-          />
-        );
-      case 'save':
-        return (
-          <CohortSaveForm
-            currentCohort={cohort}
-            onAction={handleSave}
-            onClose={closeActionForm}
-          />
-        );
-      case 'update':
-        return (
-          <CohortUpdateForm
-            currentCohort={cohort}
-            onAction={handleUpdate}
-            onClose={closeActionForm}
-          />
-        );
-      case 'delete':
-        return (
-          <CohortDeleteForm
-            currentCohort={cohort}
-            onAction={handleDelete}
-            onClose={closeActionForm}
-          />
-        );
-    }
   }
 
   return (
@@ -319,7 +100,18 @@ function ExplorerCohort({ className }) {
       {showActionForm &&
         ReactDOM.createPortal(
           <div className='guppy-explorer-cohort__overlay'>
-            <CohortActionForm />
+            <CohortActionForm
+              actionType={actionType}
+              currentCohort={cohort}
+              cohorts={cohorts}
+              handlers={{
+                handleOpen,
+                handleSave,
+                handleUpdate,
+                handleDelete,
+                handleClose: closeActionForm,
+              }}
+            />
           </div>,
           document.getElementById('root')
         )}

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -43,7 +43,8 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   const emptyCohorts = [];
   const [cohorts, setCohorts] = useState(emptyCohorts);
 
-  const [actionType, setActionType] = useState('');
+  /** @type {[ExplorerCohortActionType, React.Dispatch<React.SetStateAction<ExplorerCohortActionType>>]} */
+  const [actionType, setActionType] = useState('open');
   const [showActionForm, setShowActionForm] = useState(false);
   function openActionForm(actionType) {
     setActionType(actionType);

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -15,6 +15,12 @@ function createEmptyCohort() {
   };
 }
 
+function truncateWithEllipsis(string, maxLength) {
+  return string.length > maxLength
+    ? string.slice(0, maxLength - 3) + '...'
+    : string;
+}
+
 function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   const [cohort, setCohort] = useState(createEmptyCohort());
   const [cohorts, setCohorts] = useState([]);
@@ -95,7 +101,8 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
             Cohort:{' '}
             {cohort.name ? (
               <>
-                {cohort.name} {isFilterChanged && <FilterChangedWarning />}
+                {truncateWithEllipsis(cohort.name, 30)}{' '}
+                {isFilterChanged && <FilterChangedWarning />}
               </>
             ) : (
               <span className='guppy-explorer-cohort__placeholder'>
@@ -104,7 +111,9 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
             )}
           </h1>
           <p>
-            {cohort.description || (
+            {cohort.description ? (
+              truncateWithEllipsis(cohort.description, 80)
+            ) : (
               <span className='guppy-explorer-cohort__placeholder'>
                 No description
               </span>

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -94,57 +94,53 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   }
 
   return (
-    <>
-      <div className={className}>
-        <div>
-          <h1 className='guppy-explorer-cohort__name'>
-            Cohort:{' '}
-            {cohort.name ? (
-              <>
-                {truncateWithEllipsis(cohort.name, 30)}{' '}
-                {isFilterChanged && <FilterChangedWarning />}
-              </>
-            ) : (
-              <span className='guppy-explorer-cohort__placeholder'>
-                untitled
-              </span>
-            )}
-          </h1>
-          <p>
-            {cohort.description ? (
-              truncateWithEllipsis(cohort.description, 80)
-            ) : (
-              <span className='guppy-explorer-cohort__placeholder'>
-                No description
-              </span>
-            )}
-          </p>
-        </div>
-        <div>
-          <CohortActionButton
-            labelIcon='folder-open'
-            labelText='Open Cohort'
-            enabled={cohorts.length > 0}
-            onClick={() => openActionForm('open')}
-          />
-          <CohortActionButton
-            labelIcon='save'
-            labelText={`Save ${cohort.name === '' ? 'New' : 'As'}`}
-            onClick={() => openActionForm('save')}
-          />
-          <CohortActionButton
-            labelIcon='pen'
-            labelText='Update Cohort'
-            enabled={cohort.name !== ''}
-            onClick={() => openActionForm('update')}
-          />
-          <CohortActionButton
-            labelIcon='trash-alt'
-            labelText='Delete Cohort'
-            enabled={cohort.name !== ''}
-            onClick={() => openActionForm('delete')}
-          />
-        </div>
+    <div className={className}>
+      <div>
+        <h1 className='guppy-explorer-cohort__name'>
+          Cohort:{' '}
+          {cohort.name ? (
+            <>
+              {truncateWithEllipsis(cohort.name, 30)}{' '}
+              {isFilterChanged && <FilterChangedWarning />}
+            </>
+          ) : (
+            <span className='guppy-explorer-cohort__placeholder'>untitled</span>
+          )}
+        </h1>
+        <p>
+          {cohort.description ? (
+            truncateWithEllipsis(cohort.description, 80)
+          ) : (
+            <span className='guppy-explorer-cohort__placeholder'>
+              No description
+            </span>
+          )}
+        </p>
+      </div>
+      <div>
+        <CohortActionButton
+          labelIcon='folder-open'
+          labelText='Open Cohort'
+          enabled={cohorts.length > 0}
+          onClick={() => openActionForm('open')}
+        />
+        <CohortActionButton
+          labelIcon='save'
+          labelText={`Save ${cohort.name === '' ? 'New' : 'As'}`}
+          onClick={() => openActionForm('save')}
+        />
+        <CohortActionButton
+          labelIcon='pen'
+          labelText='Update Cohort'
+          enabled={cohort.name !== ''}
+          onClick={() => openActionForm('update')}
+        />
+        <CohortActionButton
+          labelIcon='trash-alt'
+          labelText='Delete Cohort'
+          enabled={cohort.name !== ''}
+          onClick={() => openActionForm('delete')}
+        />
       </div>
       {showActionForm &&
         ReactDOM.createPortal(
@@ -166,7 +162,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
           </div>,
           document.getElementById('root')
         )}
-    </>
+    </div>
   );
 }
 

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
+import cloneDeep from 'lodash.clonedeep';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
@@ -27,24 +28,24 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
 
   function handleOpen(opened) {
     console.log('Cohort action: open');
-    setCohort(opened);
-    onOpenCohort(opened);
+    setCohort(cloneDeep(opened));
+    onOpenCohort(cloneDeep(opened));
     closeActionForm();
   }
   function handleSave(saved) {
     console.log('Cohort action: save');
-    setCohort(saved);
-    setCohorts([...cohorts, saved]);
+    setCohort(cloneDeep(saved));
+    setCohorts([...cohorts, cloneDeep(saved)]);
     closeActionForm();
   }
   function handleUpdate(updated) {
     console.log('Cohort action: update');
     const updatedCohorts = [];
     for (const { name, description } of cohorts) {
-      if (name === updated.name) updatedCohorts.push(updated);
+      if (name === updated.name) updatedCohorts.push(cloneDeep(updated));
       else updatedCohorts.push({ name, description });
     }
-    setCohort(updated);
+    setCohort(cloneDeep(updated));
     setCohorts(updatedCohorts);
     closeActionForm();
   }

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -3,8 +3,12 @@ import ReactDOM from 'react-dom';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
 
-function ExplorerCohort({ className }) {
-  const [cohort, setCohort] = useState({ name: '', description: '' });
+function ExplorerCohort({ className, filter }) {
+  const [cohort, setCohort] = useState({
+    name: '',
+    description: '',
+    filter: {},
+  });
   const [cohorts, setCohorts] = useState([]);
 
   const [actionType, setActionType] = useState('');
@@ -103,6 +107,7 @@ function ExplorerCohort({ className }) {
             <CohortActionForm
               actionType={actionType}
               currentCohort={cohort}
+              currentFilter={filter}
               cohorts={cohorts}
               handlers={{
                 handleOpen,

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -152,6 +152,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
                 handleDelete,
                 handleClose: closeActionForm,
               }}
+              isFilterChanged={isFilterChanged}
             />
           </div>,
           document.getElementById('root')

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -6,7 +6,11 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import './ExplorerCohort.css';
+import './typedef';
 
+/**
+ * @return {ExplorerCohort}
+ */
 function createEmptyCohort() {
   return {
     name: '',
@@ -15,15 +19,29 @@ function createEmptyCohort() {
   };
 }
 
+/**
+ * @param {string} string
+ * @param {number} maxLength
+ */
 function truncateWithEllipsis(string, maxLength) {
   return string.length > maxLength
     ? string.slice(0, maxLength - 3) + '...'
     : string;
 }
 
+/**
+ * @param {Object} prop
+ * @param {string} prop.className
+ * @param {ExplorerFilter} prop.filter
+ * @param {({ filter }: { filter: ExplorerFilter }) => void} prop.onOpenCohort
+ * @param {({ filter }: { filter: ExplorerFilter }) => void} prop.onDeleteCohort
+ */
 function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   const [cohort, setCohort] = useState(createEmptyCohort());
-  const [cohorts, setCohorts] = useState([]);
+
+  /** @type {ExplorerCohort[]} */
+  const emptyCohorts = [];
+  const [cohorts, setCohorts] = useState(emptyCohorts);
 
   const [actionType, setActionType] = useState('');
   const [showActionForm, setShowActionForm] = useState(false);
@@ -35,17 +53,17 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     setShowActionForm(false);
   }
 
-  function handleOpen(opened) {
+  function handleOpen(/** @type {ExplorerCohort} */ opened) {
     setCohort(cloneDeep(opened));
     onOpenCohort(cloneDeep(opened));
     closeActionForm();
   }
-  function handleSave(saved) {
+  function handleSave(/** @type {ExplorerCohort} */ saved) {
     setCohort(cloneDeep(saved));
     setCohorts([...cohorts, cloneDeep(saved)]);
     closeActionForm();
   }
-  function handleUpdate(updated) {
+  function handleUpdate(/** @type {ExplorerCohort} */ updated) {
     const updatedCohorts = [];
     for (const { name, description } of cohorts) {
       if (name === updated.name) updatedCohorts.push(cloneDeep(updated));
@@ -55,7 +73,8 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     setCohorts(updatedCohorts);
     closeActionForm();
   }
-  function handleDelete(deleted) {
+  function handleDelete(/** @type {ExplorerCohort} */ deleted) {
+    /** @type {ExplorerCohort[]} */
     const updatedCohorts = [];
     for (const { name, description } of cohorts) {
       if (name === deleted.name) continue;

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -36,19 +36,16 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   }
 
   function handleOpen(opened) {
-    console.log('Cohort action: open');
     setCohort(cloneDeep(opened));
     onOpenCohort(cloneDeep(opened));
     closeActionForm();
   }
   function handleSave(saved) {
-    console.log('Cohort action: save');
     setCohort(cloneDeep(saved));
     setCohorts([...cohorts, cloneDeep(saved)]);
     closeActionForm();
   }
   function handleUpdate(updated) {
-    console.log('Cohort action: update');
     const updatedCohorts = [];
     for (const { name, description } of cohorts) {
       if (name === updated.name) updatedCohorts.push(cloneDeep(updated));
@@ -59,7 +56,6 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     closeActionForm();
   }
   function handleDelete(deleted) {
-    console.log('Cohort action: delete');
     const updatedCohorts = [];
     for (const { name, description } of cohorts) {
       if (name === deleted.name) continue;

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -23,3 +23,7 @@
  * @property {string} description
  * @property {ExplorerFilter} filter
  */
+
+/**
+ * @typedef {'open' | 'save' | 'update' | 'delete'} ExplorerCohortActionType
+ */

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -1,0 +1,25 @@
+/**
+ * @typedef {object} OptionFilterItem
+ * @property {string[]} selectedValues
+ */
+
+/**
+ * @typedef {object} RangeFilterItem
+ * @property {number} lowerBound
+ * @property {number} upperBound
+ */
+
+/**
+ * @typedef {OptionFilterItem | RangeFilterItem} ExplorerFilterItem
+ */
+
+/**
+ * @typedef {{[x: string]: ExplorerFilterItem}} ExplorerFilter
+ */
+
+/**
+ * @typedef {object} ExplorerCohort
+ * @property {string} name
+ * @property {string} description
+ * @property {ExplorerFilter} filter
+ */

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -140,6 +140,7 @@ class ExplorerFilter extends React.Component {
       onProcessFilterAggsData: this.onProcessFilterAggsData,
       onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
+      initialAppliedFilters: this.props.initialAppliedFilters,
       lockedTooltipMessage:
         this.props.tierAccessLevel === 'regular'
           ? `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.`
@@ -219,6 +220,7 @@ ExplorerFilter.propTypes = {
   accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
   unaccessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
+  initialAppliedFilters: PropTypes.object,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string), // inherit from GuppyWrapper
   getAccessButtonLink: PropTypes.string,
   hideGetAccessButton: PropTypes.bool,
@@ -236,6 +238,7 @@ ExplorerFilter.defaultProps = {
   accessibleFieldObject: {},
   unaccessibleFieldObject: {},
   adminAppliedPreFilters: {},
+  initialAppliedFilters: {},
   accessibleFieldCheckList: [],
   getAccessButtonLink: undefined,
   hideGetAccessButton: false,

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -1,5 +1,6 @@
 .simple-input-field__container {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   margin: 1rem;
@@ -29,8 +30,21 @@
   width: 100%;
 }
 
+.simple-input-field__input--error > input {
+  border-color: red;
+}
+
 .simple-input-field__input > textarea {
   min-height: 72px;
   padding: 10px;
   overflow: scroll;
+}
+
+.simple-input-field__error-message {
+  color: red;
+  font-size: 0.8rem;
+  font-family: inherit;
+  margin-left: 36%;
+  text-align: left;
+  width: 100%;
 }

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -21,6 +21,7 @@
   border-radius: 4px;
   border: 1px solid #ccc;
   color: #333;
+  font-family: inherit;
   height: 36px;
   outline-color: var(--g3-color__base-blue);
   overflow: hidden;

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -15,7 +15,8 @@
   width: 60%;
 }
 
-.simple-input-field__input > input {
+.simple-input-field__input > input,
+.simple-input-field__input > textarea {
   border-color: #d9d9d9 #ccc #b3b3b3;
   border-radius: 4px;
   border: 1px solid #ccc;
@@ -25,4 +26,10 @@
   overflow: hidden;
   padding: 2px 10px;
   width: 100%;
+}
+
+.simple-input-field__input > textarea {
+  min-height: 72px;
+  padding: 10px;
+  overflow: scroll;
 }

--- a/src/components/SimpleInputField.jsx
+++ b/src/components/SimpleInputField.jsx
@@ -6,12 +6,23 @@ import './SimpleInputField.css';
  * @param {Object} prop
  * @param {string} prop.label
  * @param {JSX.Element} prop.input
+ * @param {{ isError: boolean; message: string }} prop.error
  */
-function SimpleInputField({ label, input }) {
+function SimpleInputField({ label, input, error }) {
   return (
     <div className='simple-input-field__container'>
       <label className='simple-input-field__label'>{label}</label>
-      <div className='simple-input-field__input'>{input}</div>
+      <div
+        className={
+          'simple-input-field__input' +
+          (error && error.isError ? ' simple-input-field__input--error' : '')
+        }
+      >
+        {input}
+      </div>
+      {error && error.isError && (
+        <div className='simple-input-field__error-message'>{error.message}</div>
+      )}
     </div>
   );
 }
@@ -19,6 +30,10 @@ function SimpleInputField({ label, input }) {
 SimpleInputField.propTypes = {
   label: PropTypes.string,
   input: PropTypes.object,
+  error: PropTypes.shape({
+    isError: PropTypes.bool,
+    message: PropTypes.string,
+  }),
 };
 
 export default SimpleInputField;

--- a/src/components/SimpleInputField.jsx
+++ b/src/components/SimpleInputField.jsx
@@ -6,7 +6,7 @@ import './SimpleInputField.css';
  * @param {Object} prop
  * @param {string} prop.label
  * @param {JSX.Element} prop.input
- * @param {{ isError: boolean; message: string }} prop.error
+ * @param {?{ isError: boolean; message: string }} [prop.error]
  */
 function SimpleInputField({ label, input, error }) {
   return (

--- a/src/gen3-ui-component/components/Button/index.jsx
+++ b/src/gen3-ui-component/components/Button/index.jsx
@@ -65,7 +65,7 @@ class Button extends Component {
 }
 
 Button.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   buttonType: PropTypes.oneOf(['primary', 'secondary', 'default']),
   enabled: PropTypes.bool,
   className: PropTypes.string,

--- a/src/gen3-ui-component/components/Button/index.jsx
+++ b/src/gen3-ui-component/components/Button/index.jsx
@@ -33,16 +33,16 @@ class Button extends Component {
           />
         )}
         {this.props.label}
-        {this.props.rightIcon && !this.props.isPending ? (
+        {this.props.rightIcon && !this.props.isPending && (
           <i
             className={`g3-icon g3-icon--sm g3-icon--${this.props.rightIcon} g3-button__icon g3-button__icon--right`}
           />
-        ) : null}
-        {this.props.isPending ? (
+        )}
+        {this.props.isPending && (
           <div className='g3-button__spinner g3-button__icon--right'>
             <Spinner />
           </div>
-        ) : null}
+        )}
       </button>
     );
 

--- a/src/gen3-ui-component/components/Button/index.jsx
+++ b/src/gen3-ui-component/components/Button/index.jsx
@@ -13,7 +13,10 @@ class Button extends Component {
   }
 
   render() {
-    const buttonTypeClassName = !this.props.enabled || this.props.isPending ? 'g3-button--disabled' : `g3-button--${this.props.buttonType}`;
+    const buttonTypeClassName =
+      !this.props.enabled || this.props.isPending
+        ? 'g3-button--disabled'
+        : `g3-button--${this.props.buttonType}`;
     const otherAttrs = {};
     if (this.props.id) otherAttrs.id = this.props.id;
     if (this.props.value) otherAttrs.value = this.props.value;
@@ -21,42 +24,41 @@ class Button extends Component {
       <button
         type='button'
         className={`${this.props.className} g3-button ${buttonTypeClassName}`}
-        onClick={e => this.handleClick(e)}
+        onClick={(e) => this.handleClick(e)}
         {...otherAttrs}
       >
-        {
-          this.props.leftIcon && (
-            <i className={`g3-icon g3-icon--sm g3-icon--${this.props.leftIcon} g3-button__icon g3-button__icon--left`} />
-          )
-        }
-        { this.props.label }
-        {
-          this.props.rightIcon && !this.props.isPending
-            ? <i className={`g3-icon g3-icon--sm g3-icon--${this.props.rightIcon} g3-button__icon g3-button__icon--right`} />
-            : null
-        }
-        { this.props.isPending ? (
+        {this.props.leftIcon && (
+          <i
+            className={`g3-icon g3-icon--sm g3-icon--${this.props.leftIcon} g3-button__icon g3-button__icon--left`}
+          />
+        )}
+        {this.props.label}
+        {this.props.rightIcon && !this.props.isPending ? (
+          <i
+            className={`g3-icon g3-icon--sm g3-icon--${this.props.rightIcon} g3-button__icon g3-button__icon--right`}
+          />
+        ) : null}
+        {this.props.isPending ? (
           <div className='g3-button__spinner g3-button__icon--right'>
             <Spinner />
           </div>
-        ) : null
-        }
+        ) : null}
       </button>
     );
 
     return (
       <React.Fragment>
-        {
-          this.props.tooltipEnabled ? (
-            <Tooltip
-              placement='bottom'
-              overlay={this.props.tooltipText}
-              arrowContent={<div className='rc-tooltip-arrow-inner' />}
-            >
-              {button}
-            </Tooltip>
-          ) : button
-        }
+        {this.props.tooltipEnabled ? (
+          <Tooltip
+            placement='bottom'
+            overlay={this.props.tooltipText}
+            arrowContent={<div className='rc-tooltip-arrow-inner' />}
+          >
+            {button}
+          </Tooltip>
+        ) : (
+          button
+        )}
       </React.Fragment>
     );
   }

--- a/src/gen3-ui-component/components/Button/index.jsx
+++ b/src/gen3-ui-component/components/Button/index.jsx
@@ -46,20 +46,16 @@ class Button extends Component {
       </button>
     );
 
-    return (
-      <React.Fragment>
-        {this.props.tooltipEnabled ? (
-          <Tooltip
-            placement='bottom'
-            overlay={this.props.tooltipText}
-            arrowContent={<div className='rc-tooltip-arrow-inner' />}
-          >
-            {button}
-          </Tooltip>
-        ) : (
-          button
-        )}
-      </React.Fragment>
+    return this.props.tooltipEnabled ? (
+      <Tooltip
+        placement='bottom'
+        overlay={this.props.tooltipText}
+        arrowContent={<div className='rc-tooltip-arrow-inner' />}
+      >
+        {button}
+      </Tooltip>
+    ) : (
+      button
     );
   }
 }

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -50,8 +50,25 @@ class FilterGroup extends React.Component {
     const initialExpandedStatus = props.filterConfig.tabs.map((t) =>
       t.fields.map(() => initialExpandedStatusControl)
     );
+    const initialFilterResults = props.initialAppliedFilters;
     const initialFilterStatus = props.filterConfig.tabs.map((t) =>
-      t.fields.map(() => ({}))
+      t.fields.map((field) => {
+        if (Object.keys(initialFilterResults).includes(field)) {
+          const {
+            selectedValues,
+            lowerBound,
+            upperBound,
+          } = initialFilterResults[field];
+          if (selectedValues === undefined) {
+            return [lowerBound, upperBound];
+          } else {
+            const status = {};
+            for (const selected of selectedValues) status[selected] = true;
+            return status;
+          }
+        }
+        return {};
+      })
     );
     this.state = {
       selectedTabIndex: 0,
@@ -78,7 +95,7 @@ class FilterGroup extends React.Component {
        *     ...
        *   }
        */
-      filterResults: {},
+      filterResults: initialFilterResults,
     };
     this.currentFilterListRef = React.createRef();
   }
@@ -389,12 +406,14 @@ FilterGroup.propTypes = {
   onFilterChange: PropTypes.func,
   hideZero: PropTypes.bool,
   className: PropTypes.string,
+  initialAppliedFilters: PropTypes.object,
 };
 
 FilterGroup.defaultProps = {
   onFilterChange: () => {},
   hideZero: true,
   className: '',
+  initialAppliedFilters: {},
 };
 
 export default FilterGroup;

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -5,14 +5,22 @@ import './FilterGroup.css';
 const removeEmptyFilter = (filterResults) => {
   const newFilterResults = {};
   Object.keys(filterResults).forEach((field) => {
-    const containsRangeFilter = typeof filterResults[field].lowerBound !== 'undefined';
-    const containsCheckboxFilter = filterResults[field].selectedValues
-      && filterResults[field].selectedValues.length > 0;
+    const containsRangeFilter =
+      typeof filterResults[field].lowerBound !== 'undefined';
+    const containsCheckboxFilter =
+      filterResults[field].selectedValues &&
+      filterResults[field].selectedValues.length > 0;
     // Filter settings are prefaced with two underscores, e.g., __combineMode
-    const configFields = Object.keys(filterResults[field]).filter(x => x.startsWith('__'));
+    const configFields = Object.keys(filterResults[field]).filter((x) =>
+      x.startsWith('__')
+    );
     // A given config setting is still informative to Guppy even if the setting becomes empty
     const containsConfigSetting = configFields.length > 0;
-    if (containsRangeFilter || containsCheckboxFilter || containsConfigSetting) {
+    if (
+      containsRangeFilter ||
+      containsCheckboxFilter ||
+      containsConfigSetting
+    ) {
       newFilterResults[field] = filterResults[field];
     }
   });
@@ -26,7 +34,9 @@ const tabHasActiveFilters = (tabFilterStatus) => {
   let hasActiveFilters = false;
   tabFilterStatus.forEach((section) => {
     const fieldStatuses = Object.values(section);
-    if (fieldStatuses.some(status => status !== undefined && status !== false)) {
+    if (
+      fieldStatuses.some((status) => status !== undefined && status !== false)
+    ) {
       hasActiveFilters = true;
     }
   });
@@ -37,10 +47,12 @@ class FilterGroup extends React.Component {
   constructor(props) {
     super(props);
     const initialExpandedStatusControl = true;
-    const initialExpandedStatus = props.filterConfig.tabs
-      .map(t => t.fields.map(() => (initialExpandedStatusControl)));
-    const initialFilterStatus = props.filterConfig.tabs
-      .map(t => t.fields.map(() => ({})));
+    const initialExpandedStatus = props.filterConfig.tabs.map((t) =>
+      t.fields.map(() => initialExpandedStatusControl)
+    );
+    const initialFilterStatus = props.filterConfig.tabs.map((t) =>
+      t.fields.map(() => ({}))
+    );
     this.state = {
       selectedTabIndex: 0,
       expandedStatus: initialExpandedStatus,
@@ -107,124 +119,171 @@ class FilterGroup extends React.Component {
   }
 
   handleSectionClear(tabIndex, sectionIndex) {
-    this.setState((prevState) => {
-      // update filter status
-      const newFilterStatus = prevState.filterStatus.slice(0);
-      newFilterStatus[tabIndex][sectionIndex] = {};
+    this.setState(
+      (prevState) => {
+        // update filter status
+        const newFilterStatus = prevState.filterStatus.slice(0);
+        newFilterStatus[tabIndex][sectionIndex] = {};
 
-      // update filter results; clear the results for this filter
-      let newFilterResults = Object.assign({}, prevState.filterResults);
-      const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
-      newFilterResults[field] = {};
-      newFilterResults = removeEmptyFilter(newFilterResults);
+        // update filter results; clear the results for this filter
+        let newFilterResults = Object.assign({}, prevState.filterResults);
+        const field = this.props.filterConfig.tabs[tabIndex].fields[
+          sectionIndex
+        ];
+        newFilterResults[field] = {};
+        newFilterResults = removeEmptyFilter(newFilterResults);
 
-      // update component state
-      return {
-        filterStatus: newFilterStatus,
-        filterResults: newFilterResults,
-      };
-    }, () => {
-      this.callOnFilterChange();
-    });
-  }
-
-  handleCombineOptionToggle(sectionIndex, combineModeFieldName, combineModeValue) {
-    // The combine option toggle (also known as the and/or option toggle)
-    this.setState((prevState) => {
-      // update filter status
-      const newFilterStatus = prevState.filterStatus.slice(0);
-      const tabIndex = prevState.selectedTabIndex;
-      newFilterStatus[tabIndex][sectionIndex][combineModeFieldName] = combineModeValue;
-
-      // update filter results
-      let newFilterResults = prevState.filterResults;
-      const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
-      if (typeof newFilterResults[field] === 'undefined') {
-        newFilterResults[field] = { };
-        newFilterResults[field][combineModeFieldName] = combineModeValue;
-      } else {
-        newFilterResults[field][combineModeFieldName] = combineModeValue;
-      }
-
-      newFilterResults = removeEmptyFilter(newFilterResults);
-      // update component state
-      return {
-        filterStatus: newFilterStatus,
-        filterResults: newFilterResults,
-      };
-    }, () => {
-      // If no other filter is applied, the combineMode is not yet useful to Guppy
-      const tabIndex = this.state.selectedTabIndex;
-      const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
-      if (this.state.filterResults[field].selectedValues
-          && this.state.filterResults[field].selectedValues.length > 0) {
+        // update component state
+        return {
+          filterStatus: newFilterStatus,
+          filterResults: newFilterResults,
+        };
+      },
+      () => {
         this.callOnFilterChange();
       }
-    });
+    );
+  }
+
+  handleCombineOptionToggle(
+    sectionIndex,
+    combineModeFieldName,
+    combineModeValue
+  ) {
+    // The combine option toggle (also known as the and/or option toggle)
+    this.setState(
+      (prevState) => {
+        // update filter status
+        const newFilterStatus = prevState.filterStatus.slice(0);
+        const tabIndex = prevState.selectedTabIndex;
+        newFilterStatus[tabIndex][sectionIndex][
+          combineModeFieldName
+        ] = combineModeValue;
+
+        // update filter results
+        let newFilterResults = prevState.filterResults;
+        const field = this.props.filterConfig.tabs[tabIndex].fields[
+          sectionIndex
+        ];
+        if (typeof newFilterResults[field] === 'undefined') {
+          newFilterResults[field] = {};
+          newFilterResults[field][combineModeFieldName] = combineModeValue;
+        } else {
+          newFilterResults[field][combineModeFieldName] = combineModeValue;
+        }
+
+        newFilterResults = removeEmptyFilter(newFilterResults);
+        // update component state
+        return {
+          filterStatus: newFilterStatus,
+          filterResults: newFilterResults,
+        };
+      },
+      () => {
+        // If no other filter is applied, the combineMode is not yet useful to Guppy
+        const tabIndex = this.state.selectedTabIndex;
+        const field = this.props.filterConfig.tabs[tabIndex].fields[
+          sectionIndex
+        ];
+        if (
+          this.state.filterResults[field].selectedValues &&
+          this.state.filterResults[field].selectedValues.length > 0
+        ) {
+          this.callOnFilterChange();
+        }
+      }
+    );
   }
 
   handleSelect(sectionIndex, singleFilterLabel) {
-    this.setState((prevState) => {
-      // update filter status
-      const newFilterStatus = prevState.filterStatus.slice(0);
-      const tabIndex = prevState.selectedTabIndex;
-      const oldSelected = newFilterStatus[tabIndex][sectionIndex][singleFilterLabel];
-      const newSelected = typeof oldSelected === 'undefined' ? true : !oldSelected;
-      newFilterStatus[tabIndex][sectionIndex][singleFilterLabel] = newSelected;
+    this.setState(
+      (prevState) => {
+        // update filter status
+        const newFilterStatus = prevState.filterStatus.slice(0);
+        const tabIndex = prevState.selectedTabIndex;
+        const oldSelected =
+          newFilterStatus[tabIndex][sectionIndex][singleFilterLabel];
+        const newSelected =
+          typeof oldSelected === 'undefined' ? true : !oldSelected;
+        newFilterStatus[tabIndex][sectionIndex][
+          singleFilterLabel
+        ] = newSelected;
 
-      // update filter results
-      let newFilterResults = prevState.filterResults;
-      const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
-      if (typeof newFilterResults[field] === 'undefined') {
-        newFilterResults[field] = { selectedValues: [singleFilterLabel] };
-      } else if (typeof newFilterResults[field].selectedValues === 'undefined') {
-        newFilterResults[field].selectedValues = [singleFilterLabel];
-      } else {
-        const findIndex = newFilterResults[field].selectedValues.indexOf(singleFilterLabel);
-        if (findIndex >= 0 && !newSelected) {
-          newFilterResults[field].selectedValues.splice(findIndex, 1);
-        } else if (findIndex < 0 && newSelected) {
-          newFilterResults[field].selectedValues.push(singleFilterLabel);
+        // update filter results
+        let newFilterResults = prevState.filterResults;
+        const field = this.props.filterConfig.tabs[tabIndex].fields[
+          sectionIndex
+        ];
+        if (typeof newFilterResults[field] === 'undefined') {
+          newFilterResults[field] = { selectedValues: [singleFilterLabel] };
+        } else if (
+          typeof newFilterResults[field].selectedValues === 'undefined'
+        ) {
+          newFilterResults[field].selectedValues = [singleFilterLabel];
+        } else {
+          const findIndex = newFilterResults[field].selectedValues.indexOf(
+            singleFilterLabel
+          );
+          if (findIndex >= 0 && !newSelected) {
+            newFilterResults[field].selectedValues.splice(findIndex, 1);
+          } else if (findIndex < 0 && newSelected) {
+            newFilterResults[field].selectedValues.push(singleFilterLabel);
+          }
         }
-      }
 
-      newFilterResults = removeEmptyFilter(newFilterResults);
-      // update component state
-      return {
-        filterStatus: newFilterStatus,
-        filterResults: newFilterResults,
-      };
-    }, () => {
-      this.callOnFilterChange();
-    });
+        newFilterResults = removeEmptyFilter(newFilterResults);
+        // update component state
+        return {
+          filterStatus: newFilterStatus,
+          filterResults: newFilterResults,
+        };
+      },
+      () => {
+        this.callOnFilterChange();
+      }
+    );
   }
 
-  handleDrag(sectionIndex, lowerBound, upperBound, minValue, maxValue, rangeStep = 1) {
-    this.setState((prevState) => {
-      // update filter status
-      const newFilterStatus = prevState.filterStatus.slice(0);
-      newFilterStatus[prevState.selectedTabIndex][sectionIndex] = [lowerBound, upperBound];
+  handleDrag(
+    sectionIndex,
+    lowerBound,
+    upperBound,
+    minValue,
+    maxValue,
+    rangeStep = 1
+  ) {
+    this.setState(
+      (prevState) => {
+        // update filter status
+        const newFilterStatus = prevState.filterStatus.slice(0);
+        newFilterStatus[prevState.selectedTabIndex][sectionIndex] = [
+          lowerBound,
+          upperBound,
+        ];
 
-      // update filter results
-      let newFilterResults = prevState.filterResults;
-      const field = this.props.filterConfig.tabs[prevState.selectedTabIndex].fields[sectionIndex];
-      newFilterResults[field] = { lowerBound, upperBound };
+        // update filter results
+        let newFilterResults = prevState.filterResults;
+        const field = this.props.filterConfig.tabs[prevState.selectedTabIndex]
+          .fields[sectionIndex];
+        newFilterResults[field] = { lowerBound, upperBound };
 
-      // if lowerbound and upperbound values are min and max,
-      // remove this range from filter
-      const jsEqual = (a, b) => (Math.abs(a - b) < rangeStep);
-      if (jsEqual(lowerBound, minValue) && jsEqual(upperBound, maxValue)) {
-        delete newFilterResults[field];
+        // if lowerbound and upperbound values are min and max,
+        // remove this range from filter
+        const jsEqual = (a, b) => Math.abs(a - b) < rangeStep;
+        if (jsEqual(lowerBound, minValue) && jsEqual(upperBound, maxValue)) {
+          delete newFilterResults[field];
+        }
+
+        newFilterResults = removeEmptyFilter(newFilterResults);
+        return {
+          filterStatus: newFilterStatus,
+          filterResults: newFilterResults,
+        };
+      },
+      () => {
+        this.callOnFilterChange();
       }
-
-      newFilterResults = removeEmptyFilter(newFilterResults);
-      return {
-        filterStatus: newFilterStatus,
-        filterResults: newFilterResults,
-      };
-    }, () => {
-      this.callOnFilterChange();
-    });
+    );
   }
 
   callOnFilterChange() {
@@ -233,11 +292,16 @@ class FilterGroup extends React.Component {
 
   toggleFilters() {
     this.setState((prevState) => {
-      this.currentFilterListRef.current.toggleFilters(!prevState.expandedStatusControl);
+      this.currentFilterListRef.current.toggleFilters(
+        !prevState.expandedStatusControl
+      );
       return {
-        expandedStatus: this.props.filterConfig.tabs
-          .map(t => t.fields.map(() => (!prevState.expandedStatusControl))),
-        expandedStatusText: (!prevState.expandedStatusControl) ? 'Collapse all' : 'Open all',
+        expandedStatus: this.props.filterConfig.tabs.map((t) =>
+          t.fields.map(() => !prevState.expandedStatusControl)
+        ),
+        expandedStatusText: !prevState.expandedStatusControl
+          ? 'Collapse all'
+          : 'Open all',
         expandedStatusControl: !prevState.expandedStatusControl,
       };
     });
@@ -247,22 +311,30 @@ class FilterGroup extends React.Component {
     return (
       <div className={`g3-filter-group ${this.props.className}`}>
         <div className='g3-filter-group__tabs'>
-          {
-            this.props.tabs.map((tab, index) => (
-              <div
-                key={index}
-                role='button'
-                tabIndex={index}
-                className={'g3-filter-group__tab'.concat(this.state.selectedTabIndex === index ? ' g3-filter-group__tab--selected' : '')}
-                onClick={() => this.selectTab(index)}
-                onKeyDown={() => this.selectTab(index)}
+          {this.props.tabs.map((tab, index) => (
+            <div
+              key={index}
+              role='button'
+              tabIndex={index}
+              className={'g3-filter-group__tab'.concat(
+                this.state.selectedTabIndex === index
+                  ? ' g3-filter-group__tab--selected'
+                  : ''
+              )}
+              onClick={() => this.selectTab(index)}
+              onKeyDown={() => this.selectTab(index)}
+            >
+              <p
+                className={`g3-filter-group__tab-title ${
+                  tabHasActiveFilters(this.state.filterStatus[index])
+                    ? 'g3-filter-group__tab-title--has-active-filters'
+                    : ''
+                }`}
               >
-                <p className={`g3-filter-group__tab-title ${tabHasActiveFilters(this.state.filterStatus[index]) ? 'g3-filter-group__tab-title--has-active-filters' : ''}`}>
-                  {this.props.filterConfig.tabs[index].title}
-                </p>
-              </div>
-            ))
-          }
+                {this.props.filterConfig.tabs[index].title}
+              </p>
+            </div>
+          ))}
         </div>
         <div className='g3-filter-group__collapse'>
           <span
@@ -276,29 +348,28 @@ class FilterGroup extends React.Component {
           </span>
         </div>
         <div className='g3-filter-group__filter-area'>
-          {
-            React.cloneElement(
-              this.props.tabs[this.state.selectedTabIndex],
-              {
-                onToggle: (sectionIndex, newSectionExpandedStatus) => this.handleToggle(
-                  this.state.selectedTabIndex,
-                  sectionIndex,
-                  newSectionExpandedStatus,
-                ),
-                onClear: sectionIndex => this.handleSectionClear(
-                  this.state.selectedTabIndex,
-                  sectionIndex,
-                ),
-                expandedStatus: this.state.expandedStatus[this.state.selectedTabIndex],
-                filterStatus: this.state.filterStatus[this.state.selectedTabIndex],
-                onSelect: this.handleSelect.bind(this),
-                onCombineOptionToggle: this.handleCombineOptionToggle.bind(this),
-                onAfterDrag: this.handleDrag.bind(this),
-                hideZero: this.props.hideZero,
-                ref: this.currentFilterListRef,
-              },
-            )
-          }
+          {React.cloneElement(this.props.tabs[this.state.selectedTabIndex], {
+            onToggle: (sectionIndex, newSectionExpandedStatus) =>
+              this.handleToggle(
+                this.state.selectedTabIndex,
+                sectionIndex,
+                newSectionExpandedStatus
+              ),
+            onClear: (sectionIndex) =>
+              this.handleSectionClear(
+                this.state.selectedTabIndex,
+                sectionIndex
+              ),
+            expandedStatus: this.state.expandedStatus[
+              this.state.selectedTabIndex
+            ],
+            filterStatus: this.state.filterStatus[this.state.selectedTabIndex],
+            onSelect: this.handleSelect.bind(this),
+            onCombineOptionToggle: this.handleCombineOptionToggle.bind(this),
+            onAfterDrag: this.handleDrag.bind(this),
+            hideZero: this.props.hideZero,
+            ref: this.currentFilterListRef,
+          })}
         </div>
       </div>
     );
@@ -308,10 +379,12 @@ class FilterGroup extends React.Component {
 FilterGroup.propTypes = {
   tabs: PropTypes.arrayOf(PropTypes.object).isRequired,
   filterConfig: PropTypes.shape({
-    tabs: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.string,
-      fields: PropTypes.arrayOf(PropTypes.string),
-    })),
+    tabs: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        fields: PropTypes.arrayOf(PropTypes.string),
+      })
+    ),
   }).isRequired,
   onFilterChange: PropTypes.func,
   hideZero: PropTypes.bool,

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -105,7 +105,28 @@ class FilterGroup extends React.Component {
       JSON.stringify(this.props.initialAppliedFilters) !==
       JSON.stringify(prevProps.initialAppliedFilters)
     ) {
-      this.callOnFilterChange();
+      const newFilterResults = this.props.initialAppliedFilters;
+      const newFilterStatus = this.props.filterConfig.tabs.map((t) =>
+        t.fields.map((field) => {
+          if (Object.keys(newFilterResults).includes(field)) {
+            const { selectedValues, lowerBound, upperBound } = newFilterResults[
+              field
+            ];
+            if (selectedValues === undefined) {
+              return [lowerBound, upperBound];
+            } else {
+              const status = {};
+              for (const selected of selectedValues) status[selected] = true;
+              return status;
+            }
+          }
+          return {};
+        })
+      );
+      this.setState(
+        { filterStatus: newFilterStatus, filterResults: newFilterResults },
+        () => this.callOnFilterChange()
+      );
     }
   }
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -100,6 +100,15 @@ class FilterGroup extends React.Component {
     this.currentFilterListRef = React.createRef();
   }
 
+  componentDidUpdate(prevProps) {
+    if (
+      JSON.stringify(this.props.initialAppliedFilters) !==
+      JSON.stringify(prevProps.initialAppliedFilters)
+    ) {
+      this.callOnFilterChange();
+    }
+  }
+
   selectTab(index) {
     this.setState({ selectedTabIndex: index });
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,6 +9,10 @@ import {
   faFlask,
   faMicroscope,
   faUser,
+  faFolderOpen,
+  faSave,
+  faPen,
+  faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import {
@@ -42,7 +46,11 @@ library.add(
   faExclamationTriangle,
   faFlask,
   faMicroscope,
-  faUser
+  faUser,
+  faFolderOpen,
+  faSave,
+  faPen,
+  faTrashAlt
 );
 
 // render the app after the store is configured


### PR DESCRIPTION
For [PEDS-256](https://pcdc.atlassian.net/browse/PEDS-256)

This PR is an initial implementation of saved cohort feature, which allows user to save a set of filters on the exploration page as a "cohort" with a name and description. The feature allows the user to open a saved cohort, create a new cohort, update the current cohort, and delete the current cohort.

At the moment, the relevant application state is implemented as a local state for the new `<ExplorerCohort>` component and does not persist. In the next iteration, the cohort-related state will be placed in the backend service.

This PR does not use the component in the exploration page. For that, we need to add `initialAppliedFilter` state to `<GuppyDataExplorer>` and use it to sync the cohort changes between the child components: `<ExplorerCohort>` and `<ExplorerFilter>`.