### PR TITLE
Self host font for portal PEDS-230

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,0 @@
-<link
-  href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro"
-  rel="stylesheet"
-/>

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
         loaders: ['babel-loader', 'react-svg-loader'],
       },
       {
-        test: /\.(png|jpg|eot|ttf|woff)$/,
+        test: /\.(png|jpg|eot|ttf|woff|woff2)$/,
         loader: 'url-loader',
       },
       { test: /\.flow$/, loader: 'ignore-loader' },

--- a/dev.html
+++ b/dev.html
@@ -4,13 +4,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; frame-src 'self';"
+      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' localhost https://localhost:9443; object-src 'none'; font-src 'self' data:; frame-src 'self';"
     />
     <meta name="viewport" content="width=device-width" />
-    <link
-      href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro"
-      rel="stylesheet"
-    />
     <link
       rel="stylesheet/less"
       type="text/css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3239,6 +3239,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@fontsource/source-sans-pro": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-4.1.0.tgz",
+      "integrity": "sha512-kybYq6GRXjKeTIJyhvHAcUxn2tpSCqSqmpRClIe8HpXhv6TcT1TkBsxWDnPy8V47KHbkuXWO2C4ZsD9NR9aHMg=="
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.32",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
@@ -4418,7 +4423,7 @@
       }
     },
     "@pcdc/guppy": {
-      "version": "github:chicagopcdc/guppy#c91684ca603953dc48706f968d79b500a019e4eb",
+      "version": "github:chicagopcdc/guppy#f8840b904d9e7feacf04be22a3f80f1e68cf820f",
       "from": "github:chicagopcdc/guppy#pcdc_dev",
       "requires": {
         "@elastic/elasticsearch": "^7.9.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Gen3 Data Portal",
   "main": "index.js",
   "dependencies": {
+    "@fontsource/source-sans-pro": "^4.1.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.12",

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,13 +4,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https://login.bionimbus.org  https://*.s3.amazonaws.com https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';;"
+      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; font-src 'self' data:; connect-src 'self' https://login.bionimbus.org  https://*.s3.amazonaws.com https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';;"
     />
     <meta name="viewport" content="width=device-width" />
-    <link
-      href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro"
-      rel="stylesheet"
-    />
     <link
       rel="stylesheet/less"
       type="text/css"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,6 +23,7 @@ import getReduxStore from './reduxStore';
 import { gaTracking } from './params';
 import App from './App';
 import sessionMonitor from './SessionMonitor';
+import '@fontsource/source-sans-pro';
 import './gen3-ui-component/css/base.css';
 import './gen3-ui-component/css/base.less';
 import './gen3-ui-component/css/icon.css';

--- a/src/stories/index.jsx
+++ b/src/stories/index.jsx
@@ -1,4 +1,5 @@
 import '@babel/polyfill';
+import '@fontsource/source-sans-pro';
 import '../gen3-ui-component/css/base.css';
 import '../gen3-ui-component/css/icon.css';
 import '../gen3-ui-component/css/base.less';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,7 +140,7 @@ module.exports = {
         loaders: ['babel-loader', 'react-svg-loader'],
       },
       {
-        test: /\.(png|jpg|gif|woff|ttf|eot)$/,
+        test: /\.(png|jpg|gif|woff|ttf|eot|woff2)$/,
         loaders: 'url-loader',
         query: {
           limit: 8192,


### PR DESCRIPTION
For [PEDS-230](https://pcdc.atlassian.net/browse/PEDS-230).

This PR replaces fetching font files from Google Fonts CDN with self-hosting via [`@fontsource/source-sans-pro`](https://github.com/fontsource/fontsource/tree/master/packages/source-sans-pro).