### PR TITLE
Customize login page appearance PEDS-240

### DIFF
--- a/src/Login/Login.jsx
+++ b/src/Login/Login.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'; // see https://github.com/facebook/prop-type
 import Select, { createFilter } from 'react-select';
 import Button from '../gen3-ui-component/components/Button';
 import { basename, loginPath } from '../localconf';
-import { components } from '../params';
 
 import './Login.less';
 
@@ -62,13 +61,6 @@ class Login extends React.Component {
     if (queryParams.next) {
       next = basename === '/' ? queryParams.next : basename + queryParams.next;
     }
-    const customImage =
-      components.login && components.login.image
-        ? components.login.image
-        : 'gene';
-    const customImageStyle = {
-      backgroundImage: `url(/src/img/icons/${customImage}.svg)`,
-    };
 
     const loginOptions = {}; // one for each login provider
     this.props.providers.forEach((provider, i) => {
@@ -102,10 +94,7 @@ class Login extends React.Component {
 
     return (
       <div className='login-page'>
-        <div
-          className='login-page__side-box login-page__side-box--left'
-          style={customImageStyle}
-        />
+        <div className='login-page__spacer'></div>
         <div className='login-page__central-content'>
           <div className='h1-typo login-page__title'>
             {this.props.data.title}
@@ -181,10 +170,20 @@ class Login extends React.Component {
             {'.'}
           </div>
         </div>
-        <div
-          className='login-page__side-box login-page__side-box--right'
-          style={customImageStyle}
-        />
+        <div className='login-page__side-bars'>
+          <div
+            className='login-page__side-bar'
+            style={{ background: 'var(--pcdc-color__primary-light)' }}
+          />
+          <div
+            className='login-page__side-bar'
+            style={{ background: 'var(--pcdc-color__primary-dark)' }}
+          />
+          <div
+            className='login-page__side-bar'
+            style={{ background: 'var(--pcdc-color__secondary)' }}
+          />
+        </div>
       </div>
     );
   }

--- a/src/Login/Login.less
+++ b/src/Login/Login.less
@@ -1,6 +1,7 @@
 .login-page {
   display: flex;
   justify-content: space-around;
+  min-height: calc(100vh - 160px);
 }
 
 @media screen and (max-width: 820px) {

--- a/src/Login/Login.less
+++ b/src/Login/Login.less
@@ -1,6 +1,6 @@
 .login-page {
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   min-height: calc(100vh - 160px);
 }
 
@@ -8,12 +8,6 @@
   .login-page {
     justify-content: center;
   }
-}
-
-.login-page__side-box {
-  width: 200px;
-  min-height: ~'calc(100vh - 221px)';
-  background-size: 200px;
 }
 
 .login-page__central-content {
@@ -28,12 +22,39 @@
   padding-bottom: 15px;
 }
 
+.login-page__spacer {
+  width: 120px;
+}
+
+.login-page__side-bars {
+  width: 120px;
+  display: flex;
+}
+
+.login-page__side-bar {
+  width: 33.34%;
+}
+
 @media screen and (max-width: 820px) {
   .login-page__central-content {
-    padding: 40px 10px;
+    padding: 80px 0 40px 0;
   }
-  .login-page__side-box {
+
+  .login-page__spacer {
     display: none;
+  }
+
+  .login-page__side-bars {
+    position: absolute;
+    top: 40px;
+    width: 100%;
+    height: 40px;
+    flex-direction: column;
+  }
+
+  .login-page__side-bar {
+    width: 100%;
+    height: 33.34%;
   }
 }
 

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -73,6 +73,8 @@ class NavBar extends Component {
   }
 
   render() {
+    if (this.props.location.pathname === '/login') return null;
+
     const navItems = this.props.navItems.map((item, index) => {
       const navButton = (
         <div


### PR DESCRIPTION
For [PEDS-240](https://pcdc.atlassian.net/browse/PEDS-240)

This PR modifies the login page based on PCDC aesthetics and internal feedback. The biggest changes include:

* hiding navigation bar on /login
* replacing "gene" image with PCDC color strips
  * this is a breaking change that ignores `components.login.image` config setting

See the below images for a quick visual comparison

Before:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/104647774-fb2c1800-5677-11eb-9233-1bc0f8bf7bd9.png">


After:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/104647837-0da65180-5678-11eb-8928-a1f6ece0a45b.png">


