### PR TITLE
Remove version info on footer PEDS-240

### DIFF
--- a/src/Layout/reduxer.js
+++ b/src/Layout/reduxer.js
@@ -5,7 +5,6 @@ import Footer from '../components/layout/Footer';
 import dictIcons from '../img/icons/index';
 import { logoutAPI } from '../actions';
 import { components } from '../params';
-import { portalVersion } from '../versions';
 
 export const ReduxNavBar = (() => {
   const mapStateToProps = (state) => ({
@@ -36,10 +35,7 @@ export const ReduxTopBar = (() => {
 
 export const ReduxFooter = (() => {
   const mapStateToProps = (state) => ({
-    portalVersion,
     links: components.footer ? components.footer.links : [],
-    dictionaryVersion: state.versionInfo.dictionaryVersion,
-    apiVersion: state.versionInfo.apiVersion,
   });
 
   return connect(mapStateToProps)(Footer);

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -3,33 +3,13 @@ import PropTypes from 'prop-types';
 import { useRouteMatch } from 'react-router-dom';
 import './Footer.less';
 
-function Footer({
-  dictionaryVersion,
-  apiVersion,
-  portalVersion,
-  links,
-  logos,
-  privacyPolicy,
-}) {
+function Footer({ links, logos, privacyPolicy }) {
   const isFooterHidden = useRouteMatch('/dd');
 
   return isFooterHidden ? null : (
     <footer className='footer-container'>
       <nav className='footer__nav'>
-        <div className='footer__version-area'>
-          {[
-            { name: 'Dictionary', version: dictionaryVersion },
-            { name: 'Submission', version: apiVersion },
-            { name: 'Portal', version: portalVersion },
-          ].map((item) => (
-            <div className='footer__version' key={item.name}>
-              <div className='h4-typo footer__version-name'>{item.name}</div>
-              <div className='body-typo footer__version-value'>
-                v{item.version}
-              </div>
-            </div>
-          ))}
-        </div>
+        <div className='footer__spacer-area' />
         {privacyPolicy && privacyPolicy.text ? (
           <div className='footer__privacy-policy-area'>
             <a

--- a/src/components/layout/Footer.less
+++ b/src/components/layout/Footer.less
@@ -24,25 +24,14 @@
   }
 }
 
-.footer__version-area {
+.footer__spacer-area {
   display: flex;
   flex-basis: 50%;
 }
 
 @media screen and (max-width: 1090px) {
-  .footer__version-area {
-    width: 100%;
-    justify-content: stretch;
-    text-align: center;
-  }
-}
-
-@media screen and (max-width: 820px) {
-  .footer__version-area {
-    width: 100%;
-    justify-content: center;
-    flex-flow: wrap;
-    text-align: center;
+  .footer__spacer-area {
+    display: none;
   }
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,6 @@ import {
   fetchDictionary,
   fetchProjects,
   fetchSchema,
-  fetchVersionInfo,
   fetchUserAccess,
   fetchUserAuthMapping,
 } from './actions';
@@ -61,7 +60,6 @@ async function init() {
   await Promise.all([
     store.dispatch(fetchSchema),
     store.dispatch(fetchDictionary),
-    store.dispatch(fetchVersionInfo),
     // resources can be open to anonymous users, so fetch access:
     store.dispatch(fetchUserAccess),
     store.dispatch(fetchUserAuthMapping),


### PR DESCRIPTION
For [PEDS-240](https://pcdc.atlassian.net/browse/PEDS-240)

This PR removes version info displayed on footer and stops fetching version info when portal app starts.

While no longer in use, Redux setup for version info did not get completely removed since we may bring version info back in future to display in other locations.