### PR TITLE
Fix Dockerfile arg app PEDS-273

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-ARG APP=inrg
+ARG APP=pcdc
 ARG BASENAME
 
 RUN mkdir -p /data-portal


### PR DESCRIPTION
Ticket: [PEDS-273](https://pcdc.atlassian.net/browse/PEDS-273)

This PR fixes an error introduced by 4a1e3a615ed10eb1bd4fba58a51388f094605b97 in https://github.com/chicagopcdc/data-portal/pull/79, which removed the `inrg` config file and thus broke building Docker image. Using the `pcdc` config file fixes it.