### PR TITLE
Handle incorrect response data from cohorts backend PEDS-281

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/utils.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/utils.js
@@ -12,6 +12,13 @@ export function fetchCohorts() {
     method: 'GET',
   }).then(({ response, data, status }) => {
     if (status !== 200) throw response.statusText;
+    if (
+      data === null ||
+      typeof data !== 'object' ||
+      !data.hasOwnProperty('searches') ||
+      !Array.isArray(data.searches)
+    )
+      throw 'Error: Incorrect Response Data';
     return data.searches;
   });
 }


### PR DESCRIPTION
Ticket: [PEDS-281](https://pcdc.atlassian.net/browse/PEDS-281)

This PR fixes portal app crashing when cohorts backend sends incorrect data, which leads to an unhandled error in `<ExplorerCohorts>`