### PR TITLE
Load schema on demand PEDS-227

### DIFF
--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -3,7 +3,8 @@ import { buildClientSchema } from 'graphql/utilities';
 import Button from '../gen3-ui-component/components/Button';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fetchGraphQL, fetchFlatGraphQL } from '../actions';
+import getReduxStore from '../reduxStore';
+import { fetchGraphQL, fetchFlatGraphQL, fetchSchema } from '../actions';
 import Spinner from '../components/Spinner';
 import { config } from '../params';
 import './GqlEditor.less';
@@ -21,6 +22,9 @@ class GqlEditor extends React.Component {
   }
 
   componentDidMount() {
+    if (!this.props.schema)
+      getReduxStore().then(({ dispatch }) => dispatch(fetchSchema));
+
     if (
       this.props.endpointIndex &&
       this.state.selectedEndpointIndex !== this.props.endpointIndex
@@ -108,7 +112,7 @@ class GqlEditor extends React.Component {
 }
 
 GqlEditor.propTypes = {
-  schema: PropTypes.object.isRequired,
+  schema: PropTypes.object,
   endpointIndex: PropTypes.number,
 };
 

--- a/src/GraphQLEditor/reducers.js
+++ b/src/GraphQLEditor/reducers.js
@@ -1,6 +1,6 @@
 const graphiql = (state = {}, action) => {
   switch (action.type) {
-    case 'RECEIVE_SCHEMA_LOGIN':
+    case 'RECEIVE_SCHEMA':
       return { ...state, schema: action.schema };
     default:
       return state;

--- a/src/actions.js
+++ b/src/actions.js
@@ -377,7 +377,7 @@ export const fetchSchema = (dispatch) =>
       switch (status) {
         case 200:
           return dispatch({
-            type: 'RECEIVE_SCHEMA_LOGIN',
+            type: 'RECEIVE_SCHEMA',
             schema: data,
           });
         default:

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,7 +18,6 @@ import ReactGA from 'react-ga';
 import {
   fetchDictionary,
   fetchProjects,
-  fetchSchema,
   fetchUserAccess,
   fetchUserAuthMapping,
 } from './actions';
@@ -58,7 +57,6 @@ async function init() {
 
   // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   await Promise.all([
-    store.dispatch(fetchSchema),
     store.dispatch(fetchDictionary),
     // resources can be open to anonymous users, so fetch access:
     store.dispatch(fetchUserAccess),


### PR DESCRIPTION
Ticket: [PEDS-227](https://pcdc.atlassian.net/browse/PEDS-227)

This PR moves fetching `schema.json` from on initializing the entire app to on mounting component for the `/query` page (`<GQLEditor>`), which is the only location that consumes `schema.json` data.

The PR also renames the related Redux action type to avoid confusion.