### PR TITLE
Load resources on demand PEDS-228

### DIFF
--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -3,8 +3,7 @@ import { buildClientSchema } from 'graphql/utilities';
 import Button from '../gen3-ui-component/components/Button';
 import React from 'react';
 import PropTypes from 'prop-types';
-import getReduxStore from '../reduxStore';
-import { fetchGraphQL, fetchFlatGraphQL, fetchSchema } from '../actions';
+import { fetchGraphQL, fetchFlatGraphQL } from '../actions';
 import Spinner from '../components/Spinner';
 import { config } from '../params';
 import './GqlEditor.less';
@@ -22,9 +21,6 @@ class GqlEditor extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.props.schema)
-      getReduxStore().then(({ dispatch }) => dispatch(fetchSchema));
-
     if (
       this.props.endpointIndex &&
       this.state.selectedEndpointIndex !== this.props.endpointIndex

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { fetchDictionary, fetchProjects, fetchUser } from '../actions';
+import {
+  fetchDictionary,
+  fetchProjects,
+  fetchSchema,
+  fetchUser,
+} from '../actions';
 import Spinner from '../components/Spinner';
 import getReduxStore from '../reduxStore';
 import { requiredCerts } from '../localconf';
@@ -28,6 +33,7 @@ const LOCATIONS_DICTIONARY = [
   '/:project',
 ];
 const LOCATIONS_PROJECTS = ['/files/*'];
+const LOCATIONS_SCHEMA = ['/query'];
 
 /**
  * Redux listener - just clears auth-cache on logout
@@ -240,11 +246,13 @@ class ProtectedContent extends React.Component {
    * @param {ReduxStore} store
    */
   fetchResources(store) {
-    const { project, submission } = store.getState();
+    const { graphiql, project, submission } = store.getState();
     if (LOCATIONS_DICTIONARY.includes(this.props.match.path)) {
       if (!submission.dictionary) store.dispatch(fetchDictionary);
     } else if (LOCATIONS_PROJECTS.includes(this.props.match.path)) {
       if (!project.projects) store.dispatch(fetchProjects);
+    } else if (LOCATIONS_SCHEMA.includes(this.props.match.path)) {
+      if (!graphiql.schema) store.dispatch(fetchSchema);
     }
   }
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -243,16 +243,19 @@ class ProtectedContent extends React.Component {
   };
 
   /**
+   * Fetch resources on demand based on path
    * @param {ReduxStore} store
    */
-  fetchResources(store) {
-    const { graphiql, project, submission } = store.getState();
-    if (LOCATIONS_DICTIONARY.includes(this.props.match.path)) {
-      if (!submission.dictionary) store.dispatch(fetchDictionary);
-    } else if (LOCATIONS_PROJECTS.includes(this.props.match.path)) {
-      if (!project.projects) store.dispatch(fetchProjects);
-    } else if (LOCATIONS_SCHEMA.includes(this.props.match.path)) {
-      if (!graphiql.schema) store.dispatch(fetchSchema);
+  fetchResources({ dispatch, getState }) {
+    const { graphiql, project, submission } = getState();
+    const path = this.props.match.path;
+
+    if (LOCATIONS_DICTIONARY.includes(path) && !submission.dictionary) {
+      dispatch(fetchDictionary);
+    } else if (LOCATIONS_PROJECTS.includes(path) && !project.projects) {
+      dispatch(fetchProjects);
+    } else if (LOCATIONS_SCHEMA.includes(path) && !graphiql.schema) {
+      dispatch(fetchSchema);
     }
   }
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { fetchDictionary, fetchUser } from '../actions';
+import { fetchDictionary, fetchProjects, fetchUser } from '../actions';
 import Spinner from '../components/Spinner';
 import getReduxStore from '../reduxStore';
 import { requiredCerts } from '../localconf';
@@ -27,6 +27,7 @@ const LOCATIONS_DICTIONARY = [
   '/submission/map',
   '/:project',
 ];
+const LOCATIONS_PROJECTS = ['/files/*'];
 
 /**
  * Redux listener - just clears auth-cache on logout
@@ -239,9 +240,12 @@ class ProtectedContent extends React.Component {
    * @param {ReduxStore} store
    */
   fetchResources(store) {
-    const { submission } = store.getState();
-    if (LOCATIONS_DICTIONARY.includes(this.props.match.path))
+    const { project, submission } = store.getState();
+    if (LOCATIONS_DICTIONARY.includes(this.props.match.path)) {
       if (!submission.dictionary) store.dispatch(fetchDictionary);
+    } else if (LOCATIONS_PROJECTS.includes(this.props.match.path)) {
+      if (!project.projects) store.dispatch(fetchProjects);
+    }
   }
 
   render() {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,7 +16,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import {
-  fetchDictionary,
   fetchProjects,
   fetchUserAccess,
   fetchUserAuthMapping,
@@ -57,7 +56,6 @@ async function init() {
 
   // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   await Promise.all([
-    store.dispatch(fetchDictionary),
     // resources can be open to anonymous users, so fetch access:
     store.dispatch(fetchUserAccess),
     store.dispatch(fetchUserAuthMapping),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,11 +15,7 @@ import {
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
-import {
-  fetchProjects,
-  fetchUserAccess,
-  fetchUserAuthMapping,
-} from './actions';
+import { fetchUserAccess, fetchUserAuthMapping } from './actions';
 import getReduxStore from './reduxStore';
 import { gaTracking } from './params';
 import App from './App';
@@ -59,7 +55,6 @@ async function init() {
     // resources can be open to anonymous users, so fetch access:
     store.dispatch(fetchUserAccess),
     store.dispatch(fetchUserAuthMapping),
-    store.dispatch(fetchProjects()),
   ]);
 
   render(<App store={store} />, document.getElementById('root'));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,7 +15,6 @@ import {
   faTrashAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
-import { fetchUserAccess, fetchUserAuthMapping } from './actions';
 import getReduxStore from './reduxStore';
 import { gaTracking } from './params';
 import App from './App';
@@ -49,14 +48,6 @@ library.add(
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
-
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
-  await Promise.all([
-    // resources can be open to anonymous users, so fetch access:
-    store.dispatch(fetchUserAccess),
-    store.dispatch(fetchUserAuthMapping),
-  ]);
-
   render(<App store={store} />, document.getElementById('root'));
 }
 


### PR DESCRIPTION
Ticket: [PEDS-228](https://pcdc.atlassian.net/browse/PEDS-228)

This PR makes the portal app to load resources on demand (dictionary, projects, and schema) based on routes.

The PR also replaces the previous component-based solution from #88 for loading `schema.json` on demand with a more general route-based one (4c79184152d70b88db92e3f51cd5b0e5037ba95c). The PR removes fetching user resources unnecessarily as well (23185f229a636a3804b409f8ac134425f464f940).