### PR TITLE
Fix applying "Explorer More" filter to explorer PEDS-302

### DIFF
--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -28,6 +28,13 @@ class GuppyDataExplorer extends React.Component {
 
   componentDidMount() {
     this._isMounted = true;
+
+    const overviewFilter =
+      this.props.history.location.state &&
+      this.props.history.location.state.filter
+        ? this.props.history.location.state.filter
+        : {};
+    this.updateInitialAppliedFilters({ filters: overviewFilter });
   }
 
   componentWillUnmount() {

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -71,12 +71,6 @@ class Explorer extends React.Component {
       </React.Fragment>
     );
 
-    const overviewFilter =
-      this.props.history.location.state &&
-      this.props.history.location.state.filter
-        ? this.props.history.location.state.filter
-        : {};
-
     return (
       <div className='guppy-explorer'>
         {explorerConfig.length > 1 ? tabFragment : null}
@@ -86,7 +80,6 @@ class Explorer extends React.Component {
           <GuppyDataExplorer
             adminAppliedPreFilters={{
               ...explorerConfig[this.state.tab].adminAppliedPreFilters,
-              ...overviewFilter,
             }}
             chartConfig={explorerConfig[this.state.tab].charts}
             filterConfig={explorerConfig[this.state.tab].filters}


### PR DESCRIPTION
Ticket: [PEDS-302](https://pcdc.atlassian.net/browse/PEDS-302)

Currently, filter for using "Explorer More" button in `<IndexOverview>` component is applied using `adminAppliedPreFilters` prop to `<GuppyWrapper>` component (9a9ee6b9284157ce17988a757454eb9bcf099c4f in #20). This leads to poor UX as `adminAppliedPreFilters` act differently from normal, user-applied filters.

This PR switches to using `initialAppliedFilter` of guppy component (introduced in https://github.com/chicagopcdc/guppy/pull/10) that handles filters for saved cohorts (see https://github.com/chicagopcdc/data-portal/pull/68) for applying filter from Overview "Explore More" button. This change ensures more consistent UX re: applying explorer filters.