### PR TITLE
Display saved cohorts filters info PEDS-296

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
+import { stringifyFilters } from './utils';
 import './ExplorerCohort.css';
 import './typedef';
 
@@ -78,6 +79,16 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
               disabled
               placeholder='No description'
               value={selected.value.description}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Filters'
+          input={
+            <textarea
+              disabled
+              placeholder='No filters'
+              value={stringifyFilters(selected.value.filters)}
             />
           }
         />
@@ -162,6 +173,16 @@ function CohortSaveForm({
                 e.persist();
                 setCohort((prev) => ({ ...prev, description: e.target.value }));
               }}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Filters'
+          input={
+            <textarea
+              disabled
+              placeholder='No filters'
+              value={stringifyFilters(cohort.filters)}
             />
           }
         />
@@ -255,6 +276,28 @@ function CohortUpdateForm({
             />
           }
         />
+        <SimpleInputField
+          label='Filters'
+          input={
+            <textarea
+              disabled
+              placeholder='No filters'
+              value={stringifyFilters(cohort.filters)}
+            />
+          }
+        />
+        {isFiltersChanged && (
+          <SimpleInputField
+            label='Filters (changed)'
+            input={
+              <textarea
+                disabled
+                placeholder='No filters'
+                value={stringifyFilters(currentFilters)}
+              />
+            }
+          />
+        )}
       </form>
       <div>
         <CohortButton

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -1,12 +1,15 @@
 /**
  * @typedef {object} OptionFilterItem
  * @property {string[]} selectedValues
+ * @property {never} lowerBound
+ * @property {never} upperBound
  */
 
 /**
  * @typedef {object} RangeFilterItem
  * @property {number} lowerBound
  * @property {number} upperBound
+ * @property {never} selectedValues
  */
 
 /**

--- a/src/GuppyDataExplorer/ExplorerCohort/utils.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/utils.js
@@ -1,4 +1,5 @@
 import { fetchWithCreds } from '../../actions';
+import { capitalizeFirstLetter } from '../../utils';
 import './typedef';
 
 const COHORT_URL = '/amanuensis/cohort';
@@ -83,4 +84,23 @@ export function truncateWithEllipsis(string, maxLength) {
   return string.length > maxLength
     ? string.slice(0, maxLength - 3) + '...'
     : string;
+}
+
+/**
+ * @param {ExplorerFilters} filters
+ */
+export function stringifyFilters(filters) {
+  if (Object.keys(filters).length == 0) return '';
+
+  let filterStr = '';
+  for (const [key, value] of Object.entries(filters)) {
+    filterStr += `* ${capitalizeFirstLetter(key)}\n`;
+    if (value.hasOwnProperty('selectedValues'))
+      for (const selected of value.selectedValues)
+        filterStr += `\t- '${selected}'\n`;
+    else
+      filterStr += `\t- from: ${value.lowerBound}\n\t- to: ${value.upperBound}\n`;
+  }
+
+  return filterStr;
 }

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -30,6 +30,10 @@
   width: 100%;
 }
 
+.simple-input-field__input > textarea {
+  resize: none;
+}
+
 .simple-input-field__input--error > input {
   border-color: red;
 }


### PR DESCRIPTION
Ticket: [PEDS-296](https://pcdc.atlassian.net/browse/PEDS-296)

This PR enables users to view formatted filter information for saved cohorts.

The following is the filter data display format:

```
* {optionFilterName}
	- '{selectedValue}'
	- '{selectedValue}'
* {rangeFiltername}
	- from: {lowerBound}
	- to: {upperBound}
```

And here's an example in text:
```
* Data Contributor Id
	- 'COG'
* Sex
	- 'Male'
	- 'Female'
* Year At Disease Phase
	- from: 2008
	- to: 2013
```

And here is a screenshot example using an Update form
<img width="582" alt="image" src="https://user-images.githubusercontent.com/22449454/107790006-e8107480-6d17-11eb-9c61-0f1486830c39.png">
