### PR TITLE
Fix IndexBarChart tick labels getting cut off PEDS-283

### DIFF
--- a/src/components/charts/Tick.jsx
+++ b/src/components/charts/Tick.jsx
@@ -1,35 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Tick extends React.Component {
-  render() {
-    const { x, y, payload } = this.props;
-    const [countNumber, countName] = payload.value.split('#');
-    return (
-      <g>
-        <text textAnchor='end' x={x} y={y} dy={0}>
-          <tspan className='special-number' fill='var(--pcdc-color__primary)'>
-            {countNumber}
-          </tspan>
-        </text>
-        <text textAnchor='end' x={x} y={y} dy={20}>
-          <tspan className='h4-typo'>{countName}</tspan>
-        </text>
-      </g>
-    );
-  }
+function Tick({ x = 0, y = 0, payload = {} }) {
+  const [countNumber, countName] = payload.value.split('#');
+  return (
+    <g>
+      <text textAnchor='end' x={x} y={y} dy={0}>
+        <tspan className='special-number' fill='var(--pcdc-color__primary)'>
+          {countNumber}
+        </tspan>
+      </text>
+      <text textAnchor='end' x={x} y={y} dy={20}>
+        <tspan className='h4-typo'>{countName}</tspan>
+      </text>
+    </g>
+  );
 }
 
 Tick.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   payload: PropTypes.object,
-};
-
-Tick.defaultProps = {
-  x: 0,
-  y: 0,
-  payload: {},
 };
 
 export default Tick;

--- a/src/components/charts/Tick.jsx
+++ b/src/components/charts/Tick.jsx
@@ -12,6 +12,8 @@ class Tick extends React.Component {
             className='special-number'
             fill='var(--pcdc-color__primary)'
           >{`${texts[0]} `}</tspan>
+        </text>
+        <text textAnchor='end' x={x} y={y} dy={20}>
           <tspan className='h4-typo'>{`${texts[1]}`}</tspan>
         </text>
       </g>

--- a/src/components/charts/Tick.jsx
+++ b/src/components/charts/Tick.jsx
@@ -4,17 +4,16 @@ import PropTypes from 'prop-types';
 class Tick extends React.Component {
   render() {
     const { x, y, payload } = this.props;
-    const texts = payload.value.split('#');
+    const [countNumber, countName] = payload.value.split('#');
     return (
       <g>
         <text textAnchor='end' x={x} y={y} dy={0}>
-          <tspan
-            className='special-number'
-            fill='var(--pcdc-color__primary)'
-          >{`${texts[0]} `}</tspan>
+          <tspan className='special-number' fill='var(--pcdc-color__primary)'>
+            {countNumber}
+          </tspan>
         </text>
         <text textAnchor='end' x={x} y={y} dy={20}>
-          <tspan className='h4-typo'>{`${texts[1]}`}</tspan>
+          <tspan className='h4-typo'>{countName}</tspan>
         </text>
       </g>
     );


### PR DESCRIPTION
Ticket: [PEDS-283](https://pcdc.atlassian.net/browse/PEDS-283)

This PR fixes the `<IndexBarChart>` tick labels getting cut off if the count is large and/or count name is long. The fix involves making each tick label multi-line (count at top, name at bottom). This PR also lightly refactors `<Tick>` component.

See the following images for comparison:

**Before:**
<img width="640" alt="image" src="https://user-images.githubusercontent.com/22449454/107827251-042e0900-6d4c-11eb-9a0d-98b3e3466a1c.png">

**After:**
<img width="640" alt="image" src="https://user-images.githubusercontent.com/22449454/107827262-0a23ea00-6d4c-11eb-8ffc-854622ea47fd.png">

Note the following limitations:

* When there are more than 4 bars, ticks start looking crowded and possibly overlap.
* Each tick label can still get cut off if the count is way too large or count name is way too long