### PR TITLE
Fix state update after unmount PEDS-306

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -32,10 +32,13 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
   const [cohorts, setCohorts] = useState(emptyCohorts);
   const [isError, setIsError] = useState(false);
   useEffect(() => {
+    let isMounted = true;
     if (!isError)
       fetchCohorts()
-        .then(setCohorts)
+        .then((cohorts) => isMounted && setCohorts(cohorts))
         .catch(() => setIsError(true));
+
+    return () => (isMounted = false);
   }, [isError]);
 
   /** @type {[ExplorerCohortActionType, React.Dispatch<React.SetStateAction<ExplorerCohortActionType>>]} */


### PR DESCRIPTION
Ticket: [PEDS-306](https://pcdc.atlassian.net/browse/PEDS-306)

This PR fixes the same problem described in #58 (`Warning: Can't perform a React state update on an unmounted component`) for a newer component, `<ExplorerCohort>`.