### PR TITLE
Indicate guppy data loading on filter change PEDS-316

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -77,7 +77,18 @@ const ControlForm = ({
 
   const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
-    if (isFilterChanged) setShouldUpdateResults(true);
+    if (isFilterChanged) {
+      onSubmit({
+        factorVariable: factorVariable.value,
+        stratificationVariable: stratificationVariable.value,
+        timeInterval: localTimeInterval,
+        startTime,
+        endTime,
+        efsFlag: survivalType.value === 'efs',
+        shouldUpdateResults: true,
+      });
+      setIsFilterChanged(false);
+    }
   }, [isFilterChanged]);
 
   const validateNumberInput = (
@@ -105,7 +116,6 @@ const ControlForm = ({
       shouldUpdateResults,
     });
     setIsInputChanged(false);
-    setIsFilterChanged(false);
     setShouldUpdateResults(false);
   };
 
@@ -197,7 +207,7 @@ const ControlForm = ({
           label='Apply'
           buttonType='primary'
           onClick={submitUserInput}
-          enabled={isInputChanged || isFilterChanged}
+          enabled={isInputChanged}
         />
       </div>
     </form>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -62,16 +62,6 @@ const ControlForm = ({
 
   const [isInputChanged, setIsInputChanged] = useState(false);
   useEffect(() => {
-    setIsInputChanged(true);
-  }, [
-    factorVariable.value,
-    stratificationVariable.value,
-    localTimeInterval,
-    startTime,
-    endTime,
-    survivalType,
-  ]);
-  useEffect(() => {
     if (!isInputChanged && isError) setIsInputChanged(true);
   }, [isInputChanged, isError]);
 
@@ -142,6 +132,7 @@ const ControlForm = ({
 
           setFactorVariable(e);
           setShouldUpdateResults(true);
+          setIsInputChanged(true);
         }}
         value={factorVariable}
       />
@@ -154,6 +145,7 @@ const ControlForm = ({
         onChange={(e) => {
           setStratificationVariable(e);
           setShouldUpdateResults(true);
+          setIsInputChanged(true);
         }}
         value={stratificationVariable}
       />
@@ -164,7 +156,10 @@ const ControlForm = ({
         max={5}
         step={1}
         onBlur={validateNumberInput}
-        onChange={(e) => setLocalTimeInterval(Number.parseInt(e.target.value))}
+        onChange={(e) => {
+          setLocalTimeInterval(Number.parseInt(e.target.value));
+          setIsInputChanged(true);
+        }}
         value={localTimeInterval}
       />
       <ControlFormInput
@@ -175,7 +170,10 @@ const ControlForm = ({
         max={endTime - 1}
         step={1}
         onBlur={validateNumberInput}
-        onChange={(e) => setStartTime(Number.parseInt(e.target.value))}
+        onChange={(e) => {
+          setStartTime(Number.parseInt(e.target.value));
+          setIsInputChanged(true);
+        }}
         value={startTime}
       />
       <ControlFormInput
@@ -185,7 +183,10 @@ const ControlForm = ({
         max={99}
         step={1}
         onBlur={validateNumberInput}
-        onChange={(e) => setEndTime(Number.parseInt(e.target.value))}
+        onChange={(e) => {
+          setEndTime(Number.parseInt(e.target.value));
+          setIsInputChanged(true);
+        }}
         value={endTime}
       />
       <ControlFormSelect
@@ -198,6 +199,7 @@ const ControlForm = ({
         onChange={(e) => {
           setSurvivalType(e);
           setShouldUpdateResults(true);
+          setIsInputChanged(true);
         }}
         value={survivalType}
       />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -67,18 +67,7 @@ const ControlForm = ({
 
   const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
-    if (isFilterChanged) {
-      onSubmit({
-        factorVariable: factorVariable.value,
-        stratificationVariable: stratificationVariable.value,
-        timeInterval: localTimeInterval,
-        startTime,
-        endTime,
-        efsFlag: survivalType.value === 'efs',
-        shouldUpdateResults: true,
-      });
-      setIsFilterChanged(false);
-    }
+    if (isFilterChanged) setShouldUpdateResults(true);
   }, [isFilterChanged]);
 
   const validateNumberInput = (
@@ -106,6 +95,7 @@ const ControlForm = ({
       shouldUpdateResults,
     });
     setIsInputChanged(false);
+    setIsFilterChanged(false);
     setShouldUpdateResults(false);
   };
 
@@ -209,7 +199,7 @@ const ControlForm = ({
           label='Apply'
           buttonType='primary'
           onClick={submitUserInput}
-          enabled={isInputChanged}
+          enabled={isInputChanged || isFilterChanged}
         />
       </div>
     </form>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -69,7 +69,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   };
 
   const [isUpdating, setIsUpdating] = useState(false);
-  const [isError, setIsError] = useState(true);
+  const [isError, setIsError] = useState(false);
   /** @type {UserInputSubmitHandler} */
   const handleSubmit = ({
     timeInterval,

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -24,7 +24,6 @@ class ExplorerTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      loading: false,
       pageSize: props.defaultPageSize,
       currentPage: 0,
     };
@@ -242,7 +241,6 @@ class ExplorerTable extends React.Component {
   };
 
   fetchData = (state) => {
-    this.setState({ loading: true });
     const offset = state.page * state.pageSize;
     const sort = state.sorted.map((i) => ({
       [i.id]: i.desc ? 'desc' : 'asc',
@@ -257,7 +255,6 @@ class ExplorerTable extends React.Component {
       .then(() => {
         // Guppy fetched and loaded raw data into "this.props.rawData" already
         this.setState({
-          loading: false,
           pageSize: size,
           currentPage: state.page,
         });
@@ -371,7 +368,6 @@ class ExplorerTable extends React.Component {
           showPageSizeOptions={!this.props.isLocked}
           // eslint-disable-next-line max-len
           pages={this.props.isLocked ? 0 : visiblePages} // Total number of pages, don't show 10000+ records in table
-          loading={this.state.loading}
           onFetchData={this.fetchData}
           defaultPageSize={this.props.defaultPageSize}
           className={'-striped -highlight '}

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -22,6 +22,22 @@
   justify-content: space-between;
 }
 
+.guppy-explorer-visualization__view {
+  position: relative;
+}
+
+.guppy-explorer-visualization__view--hidden {
+  display: none;
+}
+
+.guppy-explorer-visualization__view__loading {
+  background-color: #fffc;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  z-index: 10;
+}
+
 .guppy-explorer-visualization__view-group > button {
   background-color: transparent;
   border: none;

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -217,7 +217,10 @@ class ExplorerVisualization extends React.Component {
           )}
         </ViewContainer>
         {this.props.tableConfig.enabled && (
-          <ViewContainer showIf={this.state.explorerView === 'table view'}>
+          <ViewContainer
+            showIf={this.state.explorerView === 'table view'}
+            isLoading={this.props.aggsDataIsLoading}
+          >
             <ExplorerTable
               className='guppy-explorer-visualization__table'
               tableConfig={{

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SummaryChartGroup from '../../gen3-ui-component/components/charts/SummaryChartGroup';
 import PercentageStackedBarChart from '../../gen3-ui-component/components/charts/PercentageStackedBarChart';
+import Spinner from '../../gen3-ui-component/components/Spinner/Spinner';
 import { components } from '../../params';
 import { tierAccessLevel } from '../../localconf';
 import DataSummaryCardGroup from '../../components/cards/DataSummaryCardGroup';
@@ -17,8 +18,18 @@ import {
 import { checkForAnySelectedUnaccessibleField } from '../GuppyDataExplorerHelper';
 import './ExplorerVisualization.css';
 
-function ViewContainer({ showIf, children }) {
-  return <div style={showIf ? null : { display: 'none' }}>{children}</div>;
+function ViewContainer({ showIf, children, isLoading }) {
+  const baseClassName = 'guppy-explorer-visualization__view';
+  return (
+    <div className={baseClassName + (showIf ? '' : '--hidden')}>
+      {isLoading && (
+        <div className={baseClassName + '__loading'}>
+          <Spinner />
+        </div>
+      )}
+      {children}
+    </div>
+  );
 }
 
 class ExplorerVisualization extends React.Component {
@@ -157,7 +168,10 @@ class ExplorerVisualization extends React.Component {
             />
           </div>
         </div>
-        <ViewContainer showIf={this.state.explorerView === 'summary view'}>
+        <ViewContainer
+          showIf={this.state.explorerView === 'summary view'}
+          isLoading={this.props.aggsDataIsLoading}
+        >
           {chartData.countItems.length > 0 && (
             <div className='guppy-explorer-visualization__summary-cards'>
               <DataSummaryCardGroup


### PR DESCRIPTION
Ticket: [PEDS-316](https://pcdc.atlassian.net/browse/PEDS-316)

This PR implements a visual indicator for data loading on filter change for the Exploration page visualizations. The visual indicator consists of a semi-transparent overlay with a spinner element on top of the current view--as in the image below:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/110169852-ea1d9e80-7dbe-11eb-9e3f-65909aea2975.png">



For "table view", this new indicator replaces an existing solution provided by `react-table`.

For "survival view", new indicator is not used, but filter change now automatically trigger updating survival curve.