### PR TITLE
Use prefetched copies for dictionary and schema PEDS-323

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -8,12 +8,13 @@ import {
   submissionApiPath,
   graphqlPath,
   guppyGraphQLUrl,
-  graphqlSchemaUrl,
   authzPath,
   authzMappingPath,
 } from './localconf';
 import { config } from './params';
 import sessionMonitor from './SessionMonitor';
+import dictionary from '../data/dictionary.json';
+import schema from '../data/schema.json';
 
 export const updatePopup = (state) => ({
   type: 'UPDATE_POPUP',
@@ -372,41 +373,10 @@ export const fetchProjects = () => (dispatch) =>
  * handled by router
  */
 export const fetchSchema = (dispatch) =>
-  fetchWithCreds({ path: graphqlSchemaUrl, dispatch }).then(
-    ({ status, data }) => {
-      switch (status) {
-        case 200:
-          return dispatch({
-            type: 'RECEIVE_SCHEMA',
-            schema: data,
-          });
-        default:
-          return Promise.resolve('NOOP');
-      }
-    }
-  );
+  dispatch({ type: 'RECEIVE_SCHEMA', schema });
 
 export const fetchDictionary = (dispatch) =>
-  fetchWithCreds({
-    path: `${submissionApiPath}_dictionary/_all`,
-    method: 'GET',
-    useCache: true,
-  })
-    .then(({ status, data }) => {
-      switch (status) {
-        case 200:
-          return {
-            type: 'RECEIVE_DICTIONARY',
-            data,
-          };
-        default:
-          return {
-            type: 'FETCH_ERROR',
-            error: data,
-          };
-      }
-    })
-    .then((msg) => dispatch(msg));
+  dispatch({ type: 'RECEIVE_DICTIONARY', data: dictionary });
 
 export const fetchVersionInfo = (dispatch) =>
   fetchWithCreds({


### PR DESCRIPTION
Ticket: [PEDS-323](https://pcdc.atlassian.net/browse/PEDS-323)

This PR uses local copies for `dictionary.json` and `schema.json` files that are prefetched during the app build time, rather than fetching them over the network on the runtime. This fixes the bug reported by PEDS-323.

The bug was seemingly caused by the network latency from fetching `dictionary.json` on the runtime combined with missing error handling in the code consuming the resource. Originally this was not a concern as the `dictionary.json` was always fetched before rendering the app at the root level (`src/index.jsx`). This changed with #90 which implemented fetching resources on-demand based on routes, opening the door for the aforementioned app crash.

Switching to using prefetched local copies of the resources eliminates the condition for the bug. This relies on the current process that any update to data dictionary is always followed by re-building the portal app, during which these resources were fetched and written to the disk. The process looks like the following:

1. generate new `dictionary.json`
2. upload new `dictionary.json` on S3
3. restart `sheepdog` service
4. restart `peregrine` service
5. restart `windmill` service
6. restart `guppy` service

The prefetching of `dictionary.json` and `schema.json` takes place during 5, which involves executing `dockerStart.sh`, which then executes `runWebpack.sh`, which includes running `npm run schema`, an npm script that runs `data/getSchema.js` that fetches the resources (`dictionary.json` from `sheepdog`, and `schema.json` from `peregrine`) and writing them to disk.

Accordingly, as long as the order is preserved, the portal app can directly consume the up-to-date `dictionary.json` and `schema.json`, without runtime API calls.
