### PR TITLE
Fix outdated color scheme in survival plot PEDS-318

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -218,6 +218,10 @@ ControlForm.propTypes = {
   ).isRequired,
   onSubmit: PropTypes.func.isRequired,
   timeInterval: PropTypes.number.isRequired,
+  isAggsDataLoading: PropTypes.bool,
+  isError: PropTypes.bool,
+  isFilterChanged: PropTypes.bool,
+  setIsFilterChanged: PropTypes.func,
 };
 
 export default ControlForm;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -39,9 +39,9 @@ const survivalTypeOptions = [
  * @param {FactorItem[]} prop.factors
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
+ * @param {boolean} prop.isAggsDataLoading
  * @param {boolean} prop.isError
  * @param {boolean} prop.isFilterChanged
- * @param {boolean} prop.isAggsDataLoading
  * @param {Function} prop.setIsFilterChanged
  */
 const ControlForm = ({

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -41,12 +41,14 @@ const survivalTypeOptions = [
  * @param {number} prop.timeInterval
  * @param {boolean} prop.isError
  * @param {boolean} prop.isFilterChanged
+ * @param {boolean} prop.isAggsDataLoading
  * @param {Function} prop.setIsFilterChanged
  */
 const ControlForm = ({
   factors,
   onSubmit,
   timeInterval,
+  isAggsDataLoading,
   isError,
   isFilterChanged,
   setIsFilterChanged,
@@ -200,6 +202,7 @@ const ControlForm = ({
           buttonType='primary'
           onClick={submitUserInput}
           enabled={isInputChanged || isFilterChanged}
+          isPending={isAggsDataLoading}
         />
       </div>
     </form>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -25,10 +25,16 @@ const fetchResult = (body) =>
 /**
  * @param {Object} prop
  * @param {Object} prop.aggsData
+ * @param {boolean} prop.isAggsDataLoading
  * @param {Array} prop.fieldMapping
  * @param {Object} prop.filter
  */
-function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
+function ExplorerSurvivalAnalysis({
+  aggsData,
+  isAggsDataLoading,
+  fieldMapping,
+  filter,
+}) {
   const [survival, setSurvival] = useState([]);
   const [stratificationVariable, setStratificationVariable] = useState('');
   const [timeInterval, setTimeInterval] = useState(2);
@@ -122,6 +128,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           factors={factors}
           onSubmit={handleSubmit}
           timeInterval={timeInterval}
+          isAggsDataLoading={isAggsDataLoading}
           isError={isError}
           isFilterChanged={isFilterChanged}
           setIsFilterChanged={setIsFilterChanged}
@@ -154,6 +161,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
 
 ExplorerSurvivalAnalysis.propTypes = {
   aggsData: PropTypes.object,
+  isGuppyDataLoading: PropTypes.bool,
   fieldMapping: PropTypes.array,
   filter: PropTypes.object,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -161,7 +161,7 @@ function ExplorerSurvivalAnalysis({
 
 ExplorerSurvivalAnalysis.propTypes = {
   aggsData: PropTypes.object,
-  isGuppyDataLoading: PropTypes.bool,
+  isAggsDataLoading: PropTypes.bool,
   fieldMapping: PropTypes.array,
   filter: PropTypes.object,
 };

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -238,6 +238,7 @@ class ExplorerVisualization extends React.Component {
         <ViewContainer showIf={this.state.explorerView === 'survival analysis'}>
           <ExplorerSurvivalAnalysis
             aggsData={this.props.aggsData}
+            isAggsDataLoading={this.props.aggsDataIsLoading}
             fieldMapping={this.props.guppyConfig.fieldMapping}
             filter={this.props.filter}
           />


### PR DESCRIPTION
Ticket: [PEDS-318](https://pcdc.atlassian.net/browse/PEDS-318)

This PR implements a fix for outdated color scheme in survival plot when updating survival plot after the filter change and before completing guppy data update. The bug is first noted in https://github.com/chicagopcdc/data-portal/pull/97#issuecomment-791773277.

This is achieved by preventing users from updating survival plots before completing guppy data update on filter change. This change is accompanied by a visual feedback to users that _something_ is loading via `isPending` prop of `<Button>`:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/22449454/111537389-5ee6c600-8739-11eb-938a-82b4706f7a5c.png">
