### PR TITLE
Update survival results on filter change PEDS-333

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -69,7 +69,18 @@ const ControlForm = ({
 
   const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
-    if (isFilterChanged) setShouldUpdateResults(true);
+    if (isFilterChanged) {
+      onSubmit({
+        factorVariable: factorVariable.value,
+        stratificationVariable: stratificationVariable.value,
+        timeInterval: localTimeInterval,
+        startTime,
+        endTime,
+        efsFlag: survivalType.value === 'efs',
+        shouldUpdateResults: true,
+      });
+      setIsFilterChanged(false);
+    }
   }, [isFilterChanged]);
 
   const validateNumberInput = (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -42,7 +42,6 @@ const survivalTypeOptions = [
  * @param {boolean} prop.isAggsDataLoading
  * @param {boolean} prop.isError
  * @param {boolean} prop.isFilterChanged
- * @param {Function} prop.setIsFilterChanged
  */
 const ControlForm = ({
   factors,
@@ -51,7 +50,6 @@ const ControlForm = ({
   isAggsDataLoading,
   isError,
   isFilterChanged,
-  setIsFilterChanged,
 }) => {
   const [factorVariable, setFactorVariable] = useState(emptySelectOption);
   const [stratificationVariable, setStratificationVariable] = useState(
@@ -69,7 +67,7 @@ const ControlForm = ({
 
   const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
   useEffect(() => {
-    if (isFilterChanged) {
+    if (isFilterChanged)
       onSubmit({
         factorVariable: factorVariable.value,
         stratificationVariable: stratificationVariable.value,
@@ -79,8 +77,6 @@ const ControlForm = ({
         efsFlag: survivalType.value === 'efs',
         shouldUpdateResults: true,
       });
-      setIsFilterChanged(false);
-    }
   }, [isFilterChanged]);
 
   const validateNumberInput = (
@@ -108,7 +104,6 @@ const ControlForm = ({
       shouldUpdateResults,
     });
     setIsInputChanged(false);
-    setIsFilterChanged(false);
     setShouldUpdateResults(false);
   };
 
@@ -232,7 +227,6 @@ ControlForm.propTypes = {
   isAggsDataLoading: PropTypes.bool,
   isError: PropTypes.bool,
   isFilterChanged: PropTypes.bool,
-  setIsFilterChanged: PropTypes.func,
 };
 
 export default ControlForm;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -106,6 +106,15 @@ const ControlForm = ({
   };
 
   const resetUserInput = () => {
+    setIsInputChanged(
+      factorVariable.value !== emptySelectOption.value ||
+        stratificationVariable.value !== emptySelectOption.value ||
+        localTimeInterval !== 2 ||
+        startTime !== 0 ||
+        endTime !== 20 ||
+        survivalType !== survivalTypeOptions[0]
+    );
+
     if (factorVariable.value !== '' || stratificationVariable.value !== '')
       setShouldUpdateResults(true);
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -39,7 +39,6 @@ const survivalTypeOptions = [
  * @param {FactorItem[]} prop.factors
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
- * @param {boolean} prop.isAggsDataLoading
  * @param {boolean} prop.isError
  * @param {boolean} prop.isFilterChanged
  */
@@ -47,7 +46,6 @@ const ControlForm = ({
   factors,
   onSubmit,
   timeInterval,
-  isAggsDataLoading,
   isError,
   isFilterChanged,
 }) => {
@@ -208,7 +206,6 @@ const ControlForm = ({
           buttonType='primary'
           onClick={submitUserInput}
           enabled={isInputChanged || isFilterChanged}
-          isPending={isAggsDataLoading}
         />
       </div>
     </form>
@@ -224,7 +221,6 @@ ControlForm.propTypes = {
   ).isRequired,
   onSubmit: PropTypes.func.isRequired,
   timeInterval: PropTypes.number.isRequired,
-  isAggsDataLoading: PropTypes.bool,
   isError: PropTypes.bool,
   isFilterChanged: PropTypes.bool,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -93,22 +93,16 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
  * @param {Object} prop
  * @param {Object} prop.colorScheme
  * @param {SurvivalData[]} prop.data
- * @param {boolean} prop.notStratified
+ * @param {boolean} prop.isStratified
  * @param {number} prop.timeInterval
  */
-const SurvivalPlot = ({ colorScheme, data, notStratified, timeInterval }) => (
+const SurvivalPlot = ({ colorScheme, data, isStratified, timeInterval }) => (
   <div className='explorer-survival-analysis__survival-plot'>
     {data.length === 0 ? (
       <div className='explorer-survival-analysis__figure-placeholder'>
         Survival plot here
       </div>
-    ) : notStratified ? (
-      <Plot
-        colorScheme={colorScheme}
-        data={formatNames(data)}
-        timeInterval={timeInterval}
-      />
-    ) : (
+    ) : isStratified ? (
       Object.entries(
         data.reduce((acc, { name, data }) => {
           const [factorKey, stratificationKey] = name.split(',');
@@ -130,6 +124,12 @@ const SurvivalPlot = ({ colorScheme, data, notStratified, timeInterval }) => (
           />
         </Fragment>
       ))
+    ) : (
+      <Plot
+        colorScheme={colorScheme}
+        data={formatNames(data)}
+        timeInterval={timeInterval}
+      />
     )}
   </div>
 );
@@ -146,7 +146,7 @@ SurvivalPlot.propTypes = {
       name: PropTypes.string,
     })
   ).isRequired,
-  notStratified: PropTypes.bool.isRequired,
+  isStratified: PropTypes.bool.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -90,6 +90,7 @@ function ExplorerSurvivalAnalysis({
     ...requestBody
   }) => {
     if (isError) setIsError(false);
+    if (isFilterChanged) setIsFilterChanged(false);
     setIsUpdating(true);
     setStratificationVariable(requestBody.stratificationVariable);
     setTimeInterval(timeInterval);
@@ -138,7 +139,6 @@ function ExplorerSurvivalAnalysis({
           isAggsDataLoading={isAggsDataLoading}
           isError={isError}
           isFilterChanged={isFilterChanged}
-          setIsFilterChanged={setIsFilterChanged}
         />
       </div>
       <div className='explorer-survival-analysis__column-right'>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -35,7 +35,7 @@ const fetchResult = (body) => {
  */
 function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [survival, setSurvival] = useState([]);
-  const [stratificationVariable, setStratificationVariable] = useState('');
+  const [isStratified, setIsStratified] = useState(true);
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
@@ -91,7 +91,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
     if (isError) setIsError(false);
     if (isFilterChanged) setIsFilterChanged(false);
     setIsUpdating(true);
-    setStratificationVariable(requestBody.stratificationVariable);
+    setIsStratified(requestBody.stratificationVariable !== '');
     setTimeInterval(timeInterval);
     setStartTime(startTime);
     setEndTime(endTime);
@@ -160,7 +160,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           <SurvivalPlot
             colorScheme={colorScheme}
             data={filterSurvivalByTime(survival, startTime, endTime)}
-            notStratified={stratificationVariable === ''}
+            isStratified={isStratified}
             timeInterval={timeInterval}
           />
         )}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -30,16 +30,10 @@ const fetchResult = (body) => {
 /**
  * @param {Object} prop
  * @param {Object} prop.aggsData
- * @param {boolean} prop.isAggsDataLoading
  * @param {Array} prop.fieldMapping
  * @param {Object} prop.filter
  */
-function ExplorerSurvivalAnalysis({
-  aggsData,
-  isAggsDataLoading,
-  fieldMapping,
-  filter,
-}) {
+function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
   const [survival, setSurvival] = useState([]);
   const [stratificationVariable, setStratificationVariable] = useState('');
   const [timeInterval, setTimeInterval] = useState(2);
@@ -146,7 +140,6 @@ function ExplorerSurvivalAnalysis({
           factors={factors}
           onSubmit={handleSubmit}
           timeInterval={timeInterval}
-          isAggsDataLoading={isAggsDataLoading}
           isError={isError}
           isFilterChanged={isFilterChanged}
         />
@@ -178,7 +171,6 @@ function ExplorerSurvivalAnalysis({
 
 ExplorerSurvivalAnalysis.propTypes = {
   aggsData: PropTypes.object,
-  isAggsDataLoading: PropTypes.bool,
   fieldMapping: PropTypes.array,
   filter: PropTypes.object,
 };

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -238,7 +238,6 @@ class ExplorerVisualization extends React.Component {
         <ViewContainer showIf={this.state.explorerView === 'survival analysis'}>
           <ExplorerSurvivalAnalysis
             aggsData={this.props.aggsData}
-            isAggsDataLoading={this.props.aggsDataIsLoading}
             fieldMapping={this.props.guppyConfig.fieldMapping}
             filter={this.props.filter}
           />

--- a/src/actions.js
+++ b/src/actions.js
@@ -89,8 +89,14 @@ export const fetchCreds = (opts) => {
  * the result promise only includes {data, status} - where JSON data is re-parsed
  * every time to avoid mutation by the client
  *
- * @method fetchWithCreds
- * @param {path,method=GET,body=null,customHeaders?, dispatch?, useCache?} opts
+ * @param {object} opts
+ * @param {string} opts.path
+ * @param {string} [opts.method] Default is "GET"
+ * @param {object} [opts.body] Default is null
+ * @param {object} [opts.customHeaders]
+ * @param {Function} [opts.dispatch] Redux store dispatch
+ * @param {boolean} [opts.useCache]
+ * @param {AbortSignal} [opts.signal]
  * @return Promise<{response,data,status,headers}> or Promise<{data,status}> if useCache specified
  */
 export const fetchWithCreds = (opts) => {
@@ -106,6 +112,7 @@ export const fetchWithCreds = (opts) => {
   if (useCache && method === 'GET' && fetchCache[path]) {
     return Promise.resolve({ status: 200, data: JSON.parse(fetchCache[path]) });
   }
+  /** @type {RequestInit} */
   const request = {
     credentials: 'include',
     headers: { ...headers, ...customHeaders },

--- a/src/actions.js
+++ b/src/actions.js
@@ -101,6 +101,7 @@ export const fetchWithCreds = (opts) => {
     customHeaders,
     dispatch,
     useCache,
+    signal,
   } = opts;
   if (useCache && method === 'GET' && fetchCache[path]) {
     return Promise.resolve({ status: 200, data: JSON.parse(fetchCache[path]) });
@@ -110,6 +111,7 @@ export const fetchWithCreds = (opts) => {
     headers: { ...headers, ...customHeaders },
     method,
     body,
+    signal,
   };
   return fetch(path, request).then(
     (response) => {


### PR DESCRIPTION
Ticket: [PEDS-333](https://pcdc.atlassian.net/browse/PEDS-333)

This PR implements auto-updating survival plot on filter change, a feature originally intended as part of #97. This was enabled by deriving survival plot color scheme from fetched survival result instead of from `aggsData`. This change also eliminated a need for a workaround to the outdated color scheme and thus reverts #102 in effect.

This PR also:
- lets `fetchWithCreds` handle abort signal to enable aborting previous survival `fetchResults` on a subsequent filter change if incomplete.
- refactors state to handle stratified survival result to improve readability
- enables "Apply" button on reset