### PR TITLE
Use error boundary in the exploration page PEDS-336

### DIFF
--- a/src/GuppyDataExplorer/ExplorerErrorBoundary/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerErrorBoundary/index.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import NotFoundSVG from '../../img/not-found.svg';
+
+class ExplorerErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+  componentDidCatch(error, errorInfo) {
+    console.error('Explorer has error:', error, errorInfo);
+  }
+  render() {
+    return this.state.hasError ? (
+      <div className='guppy-data-explorer__error'>
+        <h1>Error opening the Exploration page...</h1>
+        <p>
+          The Exploration page is not working correctly. Please try refreshing
+          the page. If the problem continues, please contact administrator for
+          more information.
+        </p>
+        <NotFoundSVG />
+      </div>
+    ) : (
+      this.props.children
+    );
+  }
+}
+
+export default ExplorerErrorBoundary;

--- a/src/GuppyDataExplorer/GuppyDataExplorer.css
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.css
@@ -4,6 +4,10 @@
   padding: 0 20px 20px 20px;
 }
 
+.guppy-data-explorer__error {
+  text-align: center;
+}
+
 .guppy-data-explorer__filter {
   width: 20%;
   margin-top: 20px;

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GuppyWrapper from '@pcdc/guppy/dist/components/GuppyWrapper';
+import ExplorerErrorBoundary from './ExplorerErrorBoundary';
 import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
@@ -51,58 +52,60 @@ class GuppyDataExplorer extends React.Component {
 
   render() {
     return (
-      <div className='guppy-data-explorer'>
-        <GuppyWrapper
-          adminAppliedPreFilters={this.props.adminAppliedPreFilters}
-          filterConfig={this.props.filterConfig}
-          guppyConfig={{
-            type: this.props.guppyConfig.dataType,
-            ...this.props.guppyConfig,
-          }}
-          onReceiveNewAggsData={this.handleReceiveNewAggsData}
-          onFilterChange={this.handleFilterChange}
-          rawDataFields={this.props.tableConfig.fields}
-          accessibleFieldCheckList={
-            this.props.guppyConfig.accessibleFieldCheckList
-          }
-        >
-          <ExplorerTopMessageBanner
-            className='guppy-data-explorer__top-banner'
-            tierAccessLevel={this.props.tierAccessLevel}
-            tierAccessLimit={this.props.tierAccessLimit}
-            guppyConfig={this.props.guppyConfig}
-            getAccessButtonLink={this.props.getAccessButtonLink}
-            hideGetAccessButton={this.props.hideGetAccessButton}
-          />
-          <ExplorerCohort
-            className='guppy-data-explorer__cohort'
-            onOpenCohort={this.updateInitialAppliedFilters}
-            onDeleteCohort={this.updateInitialAppliedFilters}
-          />
-          <ExplorerFilter
-            className='guppy-data-explorer__filter'
-            guppyConfig={this.props.guppyConfig}
-            getAccessButtonLink={this.props.getAccessButtonLink}
-            hideGetAccessButton={this.props.hideGetAccessButton}
-            tierAccessLevel={this.props.tierAccessLevel}
-            tierAccessLimit={this.props.tierAccessLimit}
-            initialAppliedFilters={this.state.initialAppliedFilters}
-          />
-          <ExplorerVisualization
-            className='guppy-data-explorer__visualization'
-            chartConfig={this.props.chartConfig}
-            tableConfig={this.props.tableConfig}
-            buttonConfig={this.props.buttonConfig}
-            guppyConfig={this.props.guppyConfig}
-            history={this.props.history}
-            nodeCountTitle={
-              this.props.guppyConfig.nodeCountTitle ||
-              capitalizeFirstLetter(this.props.guppyConfig.dataType)
+      <ExplorerErrorBoundary>
+        <div className='guppy-data-explorer'>
+          <GuppyWrapper
+            adminAppliedPreFilters={this.props.adminAppliedPreFilters}
+            filterConfig={this.props.filterConfig}
+            guppyConfig={{
+              type: this.props.guppyConfig.dataType,
+              ...this.props.guppyConfig,
+            }}
+            onReceiveNewAggsData={this.handleReceiveNewAggsData}
+            onFilterChange={this.handleFilterChange}
+            rawDataFields={this.props.tableConfig.fields}
+            accessibleFieldCheckList={
+              this.props.guppyConfig.accessibleFieldCheckList
             }
-            tierAccessLimit={this.props.tierAccessLimit}
-          />
-        </GuppyWrapper>
-      </div>
+          >
+            <ExplorerTopMessageBanner
+              className='guppy-data-explorer__top-banner'
+              tierAccessLevel={this.props.tierAccessLevel}
+              tierAccessLimit={this.props.tierAccessLimit}
+              guppyConfig={this.props.guppyConfig}
+              getAccessButtonLink={this.props.getAccessButtonLink}
+              hideGetAccessButton={this.props.hideGetAccessButton}
+            />
+            <ExplorerCohort
+              className='guppy-data-explorer__cohort'
+              onOpenCohort={this.updateInitialAppliedFilters}
+              onDeleteCohort={this.updateInitialAppliedFilters}
+            />
+            <ExplorerFilter
+              className='guppy-data-explorer__filter'
+              guppyConfig={this.props.guppyConfig}
+              getAccessButtonLink={this.props.getAccessButtonLink}
+              hideGetAccessButton={this.props.hideGetAccessButton}
+              tierAccessLevel={this.props.tierAccessLevel}
+              tierAccessLimit={this.props.tierAccessLimit}
+              initialAppliedFilters={this.state.initialAppliedFilters}
+            />
+            <ExplorerVisualization
+              className='guppy-data-explorer__visualization'
+              chartConfig={this.props.chartConfig}
+              tableConfig={this.props.tableConfig}
+              buttonConfig={this.props.buttonConfig}
+              guppyConfig={this.props.guppyConfig}
+              history={this.props.history}
+              nodeCountTitle={
+                this.props.guppyConfig.nodeCountTitle ||
+                capitalizeFirstLetter(this.props.guppyConfig.dataType)
+              }
+              tierAccessLimit={this.props.tierAccessLimit}
+            />
+          </GuppyWrapper>
+        </div>
+      </ExplorerErrorBoundary>
     );
   }
 }


### PR DESCRIPTION
Ticket: [PEDS-336](https://pcdc.atlassian.net/browse/PEDS-336)

This PR puts a error boundary in `<GuppyDataExplorer>` to avoid crashing from an unhandled error in the Exploration page. Instead, it displays the following error page:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/112539690-4dc43780-8d7f-11eb-9b8c-c0a23ebf1726.png">

This is only a temporary band-aid for a bug on the `guppy` backend.