### PR TITLE
Remove deprecated babel polyfill PEDS-347

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,9 @@
       "@babel/preset-env",
       {
         "targets": "> 0.25%, not dead",
-        "shippedProposals": true
+        "shippedProposals": true,
+        "useBuiltIns": "usage",
+        "corejs": "3.10"
       }
     ],
     "@babel/preset-react"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15165,6 +15165,11 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -15245,6 +15250,11 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -16716,9 +16726,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
     },
     "core-js-compat": {
       "version": "3.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4350,24 +4350,6 @@
         }
       }
     },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-          "dev": true
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.13.12",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "webpack-node-externals": "^2.5.2"
   },
   "devDependencies": {
-    "@babel/polyfill": "^7.12.1",
     "@storybook/addon-actions": "^6.2.3",
     "@storybook/addon-essentials": "^6.2.3",
     "@storybook/addon-links": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-relay": "^1.3.0",
     "clipboard-plus": "^1.0.0",
+    "core-js": "^3.10.0",
     "css-loader": "^5.2.0",
     "d3-array": "^1.2.0",
     "d3-ease": "^1.0.7",

--- a/src/setupJest.js
+++ b/src/setupJest.js
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { library } from '@fortawesome/fontawesome-svg-core';

--- a/src/stories/index.jsx
+++ b/src/stories/index.jsx
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import '@fontsource/raleway';
 import '../gen3-ui-component/css/base.css';
 import '../gen3-ui-component/css/icon.css';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,7 @@ if (isProduction) {
 }
 
 module.exports = {
-  entry: ['babel-polyfill', './src/index.jsx'],
+  entry: './src/index.jsx',
   target: 'web',
   bail: isProduction,
   externals: [


### PR DESCRIPTION
Ticket: [PEDS-347](https://pcdc.atlassian.net/browse/PEDS-347)

This PR updates `babel` setup to remove the use of now deprecated `babel-polyfill`/`@babel/polyfill` and replace it with configuring `@babel/preset-env` with `core-js`. See [this documentation page](https://babeljs.io/docs/en/babel-preset-env) for relevant details.