### PR TITLE
Add external links column to Explorer table PEDS-349

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://localhost:9443; frame-src 'self';"
+      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://localhost:9443; frame-src 'self';"
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/png" href="/src/img/favicon.ico" />

--- a/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
+++ b/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
@@ -79,6 +79,10 @@
   fill: #3283c8;
 }
 
+.explorer-table-external-links img {
+  display: block;
+}
+
 .explorer-nested-table {
   padding: 10px;
   width: 75vw;

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -30,6 +30,8 @@ class ExplorerTable extends React.Component {
   }
 
   getWidthForColumn = (field, columnName) => {
+    if (field === 'external_links') return 200;
+
     if (this.props.tableConfig.linkFields.includes(field)) {
       return 80;
     }

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -173,6 +173,20 @@ class ExplorerTable extends React.Component {
                 isExternal
               />
             ) : null;
+          case 'external_links':
+            if (row.value === null) return null;
+            const [
+              resourceName,
+              resourceIconPath,
+              subjectUrl,
+            ] = row.value.split('|');
+            return (
+              <div className='explorer-table-external-links'>
+                <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
+                  <img src={resourceIconPath} alt={resourceName} />
+                </a>
+              </div>
+            );
           default:
             return (
               <div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; font-src 'self' data:; connect-src 'self' https://login.bionimbus.org  https://*.s3.amazonaws.com https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';;"
+      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; font-src 'self' data:; connect-src 'self' https://login.bionimbus.org  https://*.s3.amazonaws.com https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';;"
     />
     <meta name="viewport" content="width=device-width" />
     <link


### PR DESCRIPTION
Ticket: [PEDS-349](https://pcdc.atlassian.net/browse/PEDS-349)

This PR adds special field type `external_links` to Explorer table column configuration. `external_links` value is currently a single string with a special format to hold three different values delimited by the pipe (`|`) symbol: `resource_name|resource_icon_path|subject_url`.

See the following image for how it looks:

![image](https://user-images.githubusercontent.com/22449454/114064341-267d6800-985f-11eb-9ca4-3672facb8ae6.png)


This is only an initial iteration mainly for demo purposes and a number of improvements to handling the `external_links` field will follow, including:

* receiving an array of objects `external_links` value
* serving `resource_icon` image files locally
* ... maybe more
