### PR TITLE
Fix cohort tools PEDS-361

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -182,7 +182,7 @@ function CohortSaveForm({
             <textarea
               disabled
               placeholder='No filters'
-              value={stringifyFilters(cohort.filters)}
+              value={stringifyFilters(currentFilters)}
             />
           }
         />

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -44,6 +44,10 @@ class GuppyDataExplorer extends React.Component {
     this._isMounted && this.setState({ aggsData: newAggsData });
   };
 
+  updateInitialAppliedFilters = ({ filters }) => {
+    this.setState({ initialAppliedFilters: filters });
+  };
+
   render() {
     return (
       <ExplorerErrorBoundary>


### PR DESCRIPTION
Ticket: [PEDS-361](https://pcdc.atlassian.net/browse/PEDS-361)

This PR fixes a couple of bugs in <ExplorerCohort> component:

* "Open" cohort action fails with error `Uncaught TypeError: r is not a function` error
* "Save" cohort form does not display the current filter