### PR TITLE
Fix download button PEDS-359

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -304,7 +304,7 @@ class ExplorerButtonGroup extends React.Component {
   };
 
   downloadData = (filename) => () => {
-    this.props.downloadRawData().then((res) => {
+    this.props.downloadRawData({}).then((res) => {
       if (res) {
         const blob = new Blob([JSON.stringify(res, null, 2)], {
           type: 'text/json',


### PR DESCRIPTION
Ticket: [PEDS-359](https://pcdc.atlassian.net/browse/PEDS-359)

This PR fixes the broken "Download Data" button on the Exploration page. The bug was caused by passing no parameter to `this.props.downloadRawData()` in `<ExplorerButtonGroup>`.

`downloadRawData()` prop is passed down from `<GuppyWrapper>` and expects an object with properties: `sort` and `format`. While these are both optional, not passing anything to `downloadRawData()` leads to `Uncaught TypeError: Cannot read property 'sort' of undefined` error.

The fix involves passing an empty object to `downloadRawData()` to avoid the error.