### PR TITLE
Find cohort in external commons for NIH demo PEDS-355 PEDS-363

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -347,15 +347,85 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
 
 /**
  * @param {Object} prop
+ * @param {ExplorerFilters} prop.currentFilters
+ * @param {{ label: string; value: string }[]} prop.externalCommonsOptions
+ * @param {(commons: string, filters: ExplorerFilters) => void} prop.onAction
+ * @param {() => void} prop.onClose
+ */
+function CohortFindForm({
+  currentFilters,
+  externalCommonsOptions,
+  onAction,
+  onClose,
+}) {
+  const emptyOption = {
+    label: 'Select data commons',
+    value: '',
+  };
+  const [selected, setSelected] = useState(emptyOption);
+  return (
+    <div className='guppy-explorer-cohort__form'>
+      <h4>Find Cohort in An External Data Commons</h4>
+      <form onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}>
+        <SimpleInputField
+          label='Data Commons'
+          input={
+            <Select
+              options={[emptyOption, ...externalCommonsOptions]}
+              value={selected}
+              autoFocus
+              clearable={false}
+              theme={(theme) => ({
+                ...theme,
+                colors: {
+                  ...theme.colors,
+                  primary: 'var(--pcdc-color__primary)',
+                },
+              })}
+              onChange={(e) => setSelected(e)}
+            />
+          }
+        />
+        <SimpleInputField
+          label='Filters'
+          input={
+            <textarea
+              disabled
+              placeholder='No filters'
+              value={stringifyFilters(currentFilters)}
+            />
+          }
+        />
+      </form>
+      <div>
+        <CohortButton
+          buttonType='default'
+          label='Back to page'
+          onClick={onClose}
+        />
+        <CohortButton
+          label='Open in new tab'
+          enabled={selected.value !== ''}
+          onClick={() => onAction(selected.value, currentFilters)}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * @param {Object} prop
  * @param {ExplorerCohortActionType} prop.actionType
  * @param {ExplorerCohort} prop.currentCohort
  * @param {ExplorerFilters} prop.currentFilters
  * @param {ExplorerCohort[]} prop.cohorts
+ * @param {{ label: string; value: string }[]} prop.externalCommonsOptions
  * @param {object} prop.handlers
  * @param {(opened: ExplorerCohort) => void} prop.handlers.handleOpen
  * @param {(saved: ExplorerCohort) => void} prop.handlers.handleSave
  * @param {(updated: ExplorerCohort) => void} prop.handlers.handleUpdate
  * @param {(deleted: ExplorerCohort) => void} prop.handlers.handleDelete
+ * @param {(commons: string, filter: ExplorerFilters) => void} prop.handlers.handleFind
  * @param {() => void} prop.handlers.handleClose
  * @param {boolean} prop.isFiltersChanged
  */
@@ -364,6 +434,7 @@ export function CohortActionForm({
   currentCohort,
   currentFilters,
   cohorts,
+  externalCommonsOptions,
   handlers,
   isFiltersChanged,
 }) {
@@ -372,6 +443,7 @@ export function CohortActionForm({
     handleSave,
     handleUpdate,
     handleDelete,
+    handleFind,
     handleClose,
   } = handlers;
 
@@ -412,6 +484,15 @@ export function CohortActionForm({
         <CohortDeleteForm
           currentCohort={currentCohort}
           onAction={handleDelete}
+          onClose={handleClose}
+        />
+      );
+    case 'find':
+      return (
+        <CohortFindForm
+          currentFilters={currentFilters}
+          externalCommonsOptions={externalCommonsOptions}
+          onAction={handleFind}
           onClose={handleClose}
         />
       );

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -13,6 +13,7 @@ import {
   saveCohort,
   updateCohort,
   deleteCohort,
+  fetchFindCohortRedirectUrl,
 } from './utils';
 import './ExplorerCohort.css';
 import './typedef';
@@ -84,6 +85,21 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
       setCohort(createEmptyCohort());
       setCohorts(await fetchCohorts());
       onDeleteCohort(createEmptyCohort());
+    } catch (e) {
+      setIsError(true);
+    } finally {
+      closeActionForm();
+    }
+  }
+
+  /**
+   * @param {string} common
+   * @param {ExplorerFilters} filters
+   */
+  async function handleFind(common, filters) {
+    try {
+      const { link } = await fetchFindCohortRedirectUrl(common, filters);
+      window.open(link, '_blank');
     } catch (e) {
       setIsError(true);
     } finally {
@@ -176,6 +192,12 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
               enabled={cohort.name !== ''}
               onClick={() => openActionForm('delete')}
             />
+            <CohortActionButton
+              labelIcon='external-link-alt'
+              labelText='Find Cohort in...'
+              buttonType='secondary'
+              onClick={() => openActionForm('find')}
+            />
           </div>
         </>
       )}
@@ -187,11 +209,15 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
               currentCohort={cohort}
               currentFilters={filter}
               cohorts={cohorts}
+              externalCommonsOptions={[
+                { label: 'Genomic Data Commons', value: 'gdc' },
+              ]}
               handlers={{
                 handleOpen,
                 handleSave,
                 handleUpdate,
                 handleDelete,
+                handleFind,
                 handleClose: closeActionForm,
               }}
               isFiltersChanged={isFiltersChanged}

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -29,5 +29,5 @@
  */
 
 /**
- * @typedef {'open' | 'save' | 'update' | 'delete'} ExplorerCohortActionType
+ * @typedef {'open' | 'save' | 'update' | 'delete' | 'find'} ExplorerCohortActionType
  */

--- a/src/GuppyDataExplorer/ExplorerCohort/utils.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/utils.js
@@ -1,5 +1,6 @@
 import { fetchWithCreds } from '../../actions';
 import { capitalizeFirstLetter } from '../../utils';
+import { getGQLFilter } from '@pcdc/guppy/dist/components/Utils/queries';
 import './typedef';
 
 const COHORT_URL = '/amanuensis/cohort';
@@ -62,6 +63,21 @@ export function deleteCohort(cohort) {
     method: 'DELETE',
   }).then(({ response, status }) => {
     if (status !== 200) throw response.statusText;
+  });
+}
+
+/**
+ * @param {string} commons
+ * @param {ExplorerFilters} filters
+ */
+export function fetchFindCohortRedirectUrl(commons, filters) {
+  return fetchWithCreds({
+    path: `/analysis/tools/${commons}`,
+    method: 'POST',
+    body: JSON.stringify({ filter: getGQLFilter(filters) }),
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    return data;
   });
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,6 +13,7 @@ import {
   faSave,
   faPen,
   faTrashAlt,
+  faExternalLinkAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import getReduxStore from './reduxStore';
@@ -36,6 +37,7 @@ library.add(
   faAngleDown,
   faCheckCircle,
   faExclamationTriangle,
+  faExternalLinkAlt,
   faFlask,
   faMicroscope,
   faUser,


### PR DESCRIPTION
Ticket: [PEDS-355](https://pcdc.atlassian.net/browse/PEDS-355), [PEDS-363](https://pcdc.atlassian.net/browse/PEDS-363)

This PR implements "find cohort (i.e. the current set of applied filters) in an external data commons" feature for NIH demo. 

This feature will eventually land in the main development branch after further discussions on the following points:

* button location and label
* UX details
* code organization
* ... and more