### PR TITLE
Display accessible count where relevant PEDS-363 PEDS-360 PEDS-351

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -522,6 +522,9 @@ class ExplorerButtonGroup extends React.Component {
     if (this.props.isLocked) {
       return !this.props.isLocked;
     }
+    if (buttonConfig.type === 'data') {
+      return this.props.accessibleCount > 0;
+    }
     if (buttonConfig.type === 'manifest') {
       return this.state.manifestEntryCount > 0;
     }

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -608,7 +608,7 @@ class ExplorerButtonGroup extends React.Component {
     let buttonTitle = buttonConfig.title;
     if (buttonConfig.type === 'data') {
       const buttonCount =
-        this.props.totalCount >= 0 ? this.props.totalCount : 0;
+        this.props.accessibleCount >= 0 ? this.props.accessibleCount : 0;
       buttonTitle = `${buttonConfig.title} (${buttonCount})`;
     } else if (
       buttonConfig.type === 'manifest' &&
@@ -757,6 +757,7 @@ ExplorerButtonGroup.propTypes = {
   downloadRawDataByFields: PropTypes.func.isRequired, // from GuppyWrapper
   getTotalCountsByTypeAndFilter: PropTypes.func.isRequired, // from GuppyWrapper
   downloadRawDataByTypeAndFilter: PropTypes.func.isRequired, // from GuppyWrapper
+  accessibleCount: PropTypes.number.isRequired, // from GuppyWrapper
   totalCount: PropTypes.number.isRequired, // from GuppyWrapper
   filter: PropTypes.object.isRequired, // from GuppyWrapper
   isPending: PropTypes.bool,

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -248,6 +248,7 @@ class ExplorerVisualization extends React.Component {
 }
 
 ExplorerVisualization.propTypes = {
+  accessibleCount: PropTypes.number, // inherited from GuppyWrapper
   totalCount: PropTypes.number, // inherited from GuppyWrapper
   aggsData: PropTypes.object, // inherited from GuppyWrapper
   aggsDataIsLoading: PropTypes.bool, // inherited from GuppyWrapper
@@ -271,6 +272,7 @@ ExplorerVisualization.propTypes = {
 };
 
 ExplorerVisualization.defaultProps = {
+  accessibleCount: 0,
   totalCount: 0,
   aggsData: {},
   aggsDataIsLoading: false,

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -230,7 +230,7 @@ class ExplorerVisualization extends React.Component {
               }}
               fetchAndUpdateRawData={this.props.fetchAndUpdateRawData}
               rawData={this.props.rawData}
-              totalCount={this.props.totalCount}
+              totalCount={this.props.accessibleCount}
               guppyConfig={this.props.guppyConfig}
               isLocked={isComponentLocked}
             />

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -152,6 +152,7 @@ class ExplorerVisualization extends React.Component {
             <ReduxExplorerButtonGroup
               buttonConfig={this.props.buttonConfig}
               guppyConfig={this.props.guppyConfig}
+              accessibleCount={this.props.accessibleCount}
               totalCount={this.props.totalCount}
               downloadRawData={this.props.downloadRawData}
               downloadRawDataByFields={this.props.downloadRawDataByFields}


### PR DESCRIPTION
Tickets: [PEDS-363](https://pcdc.atlassian.net/browse/PEDS-363), [PEDS-360](https://pcdc.atlassian.net/browse/PEDS-360), [PEDS-351](https://pcdc.atlassian.net/browse/PEDS-351)

This PR displays `accessibleCount` prop value from `<GuppyWrapper>` in the following places for NIH demo:

* In Table View top left caption
* In Download Data button

These changes will later land in the main development branch with more refinement to provide relevant context and minimize user confusion.