### PR TITLE
Use accessible count to hide Explorer banner PEDS-366

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerTopMessageBanner.css';
-import { GuppyConfigType } from '../configTypeDef';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
@@ -45,20 +44,13 @@ ExplorerTopMessageBanner.propTypes = {
   getAccessButtonLink: PropTypes.string,
   hideBanner: PropTypes.bool,
   hideGetAccessButton: PropTypes.bool,
-  tierAccessLevel: PropTypes.string.isRequired,
-  tierAccessLimit: PropTypes.number,
-  accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
-  guppyConfig: GuppyConfigType,
 };
 
 ExplorerTopMessageBanner.defaultProps = {
   className: '',
-  tierAccessLimit: undefined,
-  accessibleFieldObject: {},
   getAccessButtonLink: undefined,
   hideBanner: true,
   hideGetAccessButton: false,
-  guppyConfig: {},
 };
 
 export default ExplorerTopMessageBanner;

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerTopMessageBanner.css';
-import { checkForNoAccessibleProject } from '../GuppyDataExplorerHelper';
 import { GuppyConfigType } from '../configTypeDef';
 
 class ExplorerTopMessageBanner extends React.Component {
@@ -10,11 +9,7 @@ class ExplorerTopMessageBanner extends React.Component {
     const hideGetAccessButton = this.props.hideGetAccessButton;
     return (
       <div className={this.props.className}>
-        {this.props.tierAccessLevel === 'regular' &&
-        checkForNoAccessibleProject(
-          this.props.accessibleFieldObject,
-          this.props.guppyConfig.accessibleValidationField
-        ) ? (
+        {this.props.hideBanner ? null : (
           <div className='top-message-banner'>
             <div className='top-message-banner__space-column' />
             <div className='top-message-banner__text-column'>
@@ -47,8 +42,6 @@ class ExplorerTopMessageBanner extends React.Component {
               </div>
             </div>
           </div>
-        ) : (
-          <React.Fragment />
         )}
       </div>
     );
@@ -58,6 +51,7 @@ class ExplorerTopMessageBanner extends React.Component {
 ExplorerTopMessageBanner.propTypes = {
   className: PropTypes.string,
   getAccessButtonLink: PropTypes.string,
+  hideBanner: PropTypes.bool,
   hideGetAccessButton: PropTypes.bool,
   tierAccessLevel: PropTypes.string.isRequired,
   tierAccessLimit: PropTypes.number,
@@ -70,6 +64,7 @@ ExplorerTopMessageBanner.defaultProps = {
   tierAccessLimit: undefined,
   accessibleFieldObject: {},
   getAccessButtonLink: undefined,
+  hideBanner: true,
   hideGetAccessButton: false,
   guppyConfig: {},
 };

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -6,37 +6,35 @@ import { GuppyConfigType } from '../configTypeDef';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
-    return (
+    return this.props.hideBanner ? null : (
       <div className={this.props.className}>
-        {this.props.hideBanner ? null : (
-          <div className='top-message-banner'>
-            <div className='top-message-banner__space-column' />
-            <div className='top-message-banner__text-column'>
-              <div className='top-message-banner__button-wrapper'>
-                {this.props.hideGetAccessButton ? null : (
-                  <Button
-                    label='Get Access'
-                    className='top-message-banner__button'
-                    buttonType='default'
-                    enabled={!!this.props.getAccessButtonLink}
-                    tooltipEnabled={!this.props.getAccessButtonLink}
-                    tooltipText='Coming soon'
-                    onClick={
-                      this.props.getAccessButtonLink &&
-                      window.open(this.props.getAccessButtonLink)
-                    }
-                  />
-                )}
-              </div>
-              <div className='top-message-banner__text-wrapper'>
-                <span className='top-message-banner__normal-text'>
-                  You do not have permissions to view line-level data. To
-                  request access please reach out to the PCDC team.
-                </span>
-              </div>
+        <div className='top-message-banner'>
+          <div className='top-message-banner__space-column' />
+          <div className='top-message-banner__text-column'>
+            <div className='top-message-banner__button-wrapper'>
+              {this.props.hideGetAccessButton ? null : (
+                <Button
+                  label='Get Access'
+                  className='top-message-banner__button'
+                  buttonType='default'
+                  enabled={!!this.props.getAccessButtonLink}
+                  tooltipEnabled={!this.props.getAccessButtonLink}
+                  tooltipText='Coming soon'
+                  onClick={
+                    this.props.getAccessButtonLink &&
+                    window.open(this.props.getAccessButtonLink)
+                  }
+                />
+              )}
+            </div>
+            <div className='top-message-banner__text-wrapper'>
+              <span className='top-message-banner__normal-text'>
+                You do not have permissions to view line-level data. To request
+                access please reach out to the PCDC team.
+              </span>
             </div>
           </div>
-        )}
+        </div>
       </div>
     );
   }

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -3,40 +3,42 @@ import PropTypes from 'prop-types';
 import Button from '../../gen3-ui-component/components/Button';
 import './ExplorerTopMessageBanner.css';
 
-class ExplorerTopMessageBanner extends React.Component {
-  render() {
-    return this.props.hideBanner ? null : (
-      <div className={this.props.className}>
-        <div className='top-message-banner'>
-          <div className='top-message-banner__space-column' />
-          <div className='top-message-banner__text-column'>
-            <div className='top-message-banner__button-wrapper'>
-              {this.props.hideGetAccessButton ? null : (
-                <Button
-                  label='Get Access'
-                  className='top-message-banner__button'
-                  buttonType='default'
-                  enabled={!!this.props.getAccessButtonLink}
-                  tooltipEnabled={!this.props.getAccessButtonLink}
-                  tooltipText='Coming soon'
-                  onClick={() =>
-                    this.props.getAccessButtonLink &&
-                    window.open(this.props.getAccessButtonLink)
-                  }
-                />
-              )}
-            </div>
-            <div className='top-message-banner__text-wrapper'>
-              <span className='top-message-banner__normal-text'>
-                You do not have permissions to view line-level data. To request
-                access please reach out to the PCDC team.
-              </span>
-            </div>
+function ExplorerTopMessageBanner({
+  className = '',
+  getAccessButtonLink,
+  hideBanner = true,
+  hideGetAccessButton = false,
+}) {
+  return hideBanner ? null : (
+    <div className={className}>
+      <div className='top-message-banner'>
+        <div className='top-message-banner__space-column' />
+        <div className='top-message-banner__text-column'>
+          <div className='top-message-banner__button-wrapper'>
+            {hideGetAccessButton ? null : (
+              <Button
+                label='Get Access'
+                className='top-message-banner__button'
+                buttonType='default'
+                enabled={!!getAccessButtonLink}
+                tooltipEnabled={!getAccessButtonLink}
+                tooltipText='Coming soon'
+                onClick={() =>
+                  getAccessButtonLink && window.open(getAccessButtonLink)
+                }
+              />
+            )}
+          </div>
+          <div className='top-message-banner__text-wrapper'>
+            <span className='top-message-banner__normal-text'>
+              You do not have permissions to view line-level data. To request
+              access please reach out to the PCDC team.
+            </span>
           </div>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 ExplorerTopMessageBanner.propTypes = {
@@ -44,13 +46,6 @@ ExplorerTopMessageBanner.propTypes = {
   getAccessButtonLink: PropTypes.string,
   hideBanner: PropTypes.bool,
   hideGetAccessButton: PropTypes.bool,
-};
-
-ExplorerTopMessageBanner.defaultProps = {
-  className: '',
-  getAccessButtonLink: undefined,
-  hideBanner: true,
-  hideGetAccessButton: false,
 };
 
 export default ExplorerTopMessageBanner;

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -6,7 +6,6 @@ import { GuppyConfigType } from '../configTypeDef';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
-    const hideGetAccessButton = this.props.hideGetAccessButton;
     return (
       <div className={this.props.className}>
         {this.props.hideBanner ? null : (
@@ -14,9 +13,7 @@ class ExplorerTopMessageBanner extends React.Component {
             <div className='top-message-banner__space-column' />
             <div className='top-message-banner__text-column'>
               <div className='top-message-banner__button-wrapper'>
-                {hideGetAccessButton ? (
-                  <React.Fragment />
-                ) : (
+                {this.props.hideGetAccessButton ? null : (
                   <Button
                     label='Get Access'
                     className='top-message-banner__button'
@@ -25,11 +22,8 @@ class ExplorerTopMessageBanner extends React.Component {
                     tooltipEnabled={!this.props.getAccessButtonLink}
                     tooltipText='Coming soon'
                     onClick={
-                      this.props.getAccessButtonLink
-                        ? () => {
-                            window.open(this.props.getAccessButtonLink);
-                          }
-                        : () => {}
+                      this.props.getAccessButtonLink &&
+                      window.open(this.props.getAccessButtonLink)
                     }
                   />
                 )}

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -19,7 +19,7 @@ class ExplorerTopMessageBanner extends React.Component {
                   enabled={!!this.props.getAccessButtonLink}
                   tooltipEnabled={!this.props.getAccessButtonLink}
                   tooltipText='Coming soon'
-                  onClick={
+                  onClick={() =>
                     this.props.getAccessButtonLink &&
                     window.open(this.props.getAccessButtonLink)
                   }

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -73,6 +73,7 @@ class GuppyDataExplorer extends React.Component {
               tierAccessLimit={this.props.tierAccessLimit}
               guppyConfig={this.props.guppyConfig}
               getAccessButtonLink={this.props.getAccessButtonLink}
+              hideBanner={this.props.acccessibleCount === this.props.totalCount}
               hideGetAccessButton={this.props.hideGetAccessButton}
             />
             <ExplorerCohort

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -69,9 +69,6 @@ class GuppyDataExplorer extends React.Component {
           >
             <ExplorerTopMessageBanner
               className='guppy-data-explorer__top-banner'
-              tierAccessLevel={this.props.tierAccessLevel}
-              tierAccessLimit={this.props.tierAccessLimit}
-              guppyConfig={this.props.guppyConfig}
               getAccessButtonLink={this.props.getAccessButtonLink}
               hideBanner={this.props.acccessibleCount === this.props.totalCount}
               hideGetAccessButton={this.props.hideGetAccessButton}


### PR DESCRIPTION
Ticket: [PEDS-366](https://pcdc.atlassian.net/browse/PEDS-366)

This PR replaces the use of access-related environment variables/config values with a simple boolean prop `hideBanner` to show/hide the `<ExplorerTopMessageBanner>` component.

**This is a breaking change** in a sense that the following environment variables/config values no longer have impact on the `<ExplorerTopMessageBanner>` component's behavior:

* environment variables:
    * `TIER_ACCESS_LEVEL`
    * `TIER_ACCESS_LIMIT`
* configuration values:
    * `dataExplorerConfig.guppyConfig.accessibleFieldCheckList`
    * `dataExplorerConfig.guppyConfig.accessibleValidationField`

This PR relies on a new `accessibleCount` value provided by `<GuppyWrapper>`, which is only available on the `pcdc_dev` branch version of `@pcdc/guppy` as of this PR. I.e. `hideBanner` is set to `true` if `accessibleCount` value is equal to `totalCount` value.

The PR also refactors the `<ExplorerTopMessageBanner>` component to simplify code and improve maintainability.