### PR TITLE
Use accessible count to lock Explorer visualization components PEDS-366

### DIFF
--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -250,7 +250,6 @@ ExplorerVisualization.propTypes = {
   downloadRawDataByTypeAndFilter: PropTypes.func, // inherited from GuppyWrapper
   rawData: PropTypes.array, // inherited from GuppyWrapper
   allFields: PropTypes.array, // inherited from GuppyWrapper
-  accessibleFieldObject: PropTypes.object, // inherited from GuppyWrapper
   history: PropTypes.object.isRequired,
   className: PropTypes.string,
   chartConfig: ChartConfigType,
@@ -274,7 +273,6 @@ ExplorerVisualization.defaultProps = {
   downloadRawDataByTypeAndFilter: () => {},
   rawData: [],
   allFields: [],
-  accessibleFieldObject: {},
   className: '',
   chartConfig: {},
   tableConfig: {},

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -4,7 +4,6 @@ import SummaryChartGroup from '../../gen3-ui-component/components/charts/Summary
 import PercentageStackedBarChart from '../../gen3-ui-component/components/charts/PercentageStackedBarChart';
 import Spinner from '../../gen3-ui-component/components/Spinner/Spinner';
 import { components } from '../../params';
-import { tierAccessLevel } from '../../localconf';
 import DataSummaryCardGroup from '../../components/cards/DataSummaryCardGroup';
 import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
@@ -15,7 +14,6 @@ import {
   ChartConfigType,
   GuppyConfigType,
 } from '../configTypeDef';
-import { checkForAnySelectedUnaccessibleField } from '../GuppyDataExplorerHelper';
 import './ExplorerVisualization.css';
 
 function ViewContainer({ showIf, children, isLoading }) {
@@ -115,15 +113,7 @@ class ExplorerVisualization extends React.Component {
       this.props.tableConfig.fields && this.props.tableConfig.fields.length > 0
         ? this.props.tableConfig.fields
         : this.props.allFields;
-    // don't lock components for libre commons
-    const isComponentLocked =
-      tierAccessLevel !== 'regular'
-        ? false
-        : checkForAnySelectedUnaccessibleField(
-            this.props.aggsData,
-            this.props.accessibleFieldObject,
-            this.props.guppyConfig.accessibleValidationField
-          );
+    const isComponentLocked = this.props.accessibleCount === 0;
     const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${
       this.props.tierAccessLimit
     } ${
@@ -248,6 +238,7 @@ class ExplorerVisualization extends React.Component {
 }
 
 ExplorerVisualization.propTypes = {
+  accessibleCount: PropTypes.number, // inherited from GuppyWrapper
   totalCount: PropTypes.number, // inherited from GuppyWrapper
   aggsData: PropTypes.object, // inherited from GuppyWrapper
   aggsDataIsLoading: PropTypes.bool, // inherited from GuppyWrapper
@@ -271,6 +262,7 @@ ExplorerVisualization.propTypes = {
 };
 
 ExplorerVisualization.defaultProps = {
+  accessibleCount: 0,
   totalCount: 0,
   aggsData: {},
   aggsDataIsLoading: false,

--- a/src/GuppyDataExplorer/GuppyDataExplorerHelper.js
+++ b/src/GuppyDataExplorer/GuppyDataExplorerHelper.js
@@ -4,35 +4,6 @@ function difference(a, b) {
   return [...new Set([...setA].filter((x) => !setB.has(x)))];
 }
 
-// if true, means user has unaccessible fields in aggsData
-export function checkForAnySelectedUnaccessibleField(
-  aggsData,
-  accessibleFieldObject,
-  fieldToCheck
-) {
-  let accessValuesInAggregationList = [];
-  if (!accessibleFieldObject || !accessibleFieldObject[fieldToCheck]) {
-    return false;
-  }
-
-  const accessibleValues = accessibleFieldObject[fieldToCheck];
-  if (aggsData && aggsData[fieldToCheck] && aggsData[fieldToCheck].histogram) {
-    accessValuesInAggregationList = aggsData[fieldToCheck].histogram.map(
-      (entry) => entry.key
-    );
-    const outOfScopeValues = difference(
-      accessValuesInAggregationList,
-      accessibleValues
-    );
-    if (outOfScopeValues.length > 0) {
-      // trying to get unaccessible data is forbidden
-      return true;
-    }
-    return false;
-  }
-  return false;
-}
-
 // if true, means user don't have access to any project
 export function checkForNoAccessibleProject(
   accessibleFieldObject,


### PR DESCRIPTION
Ticket: [PEDS-366](https://pcdc.atlassian.net/browse/PEDS-366)

This PR replaces the use of access-related environment variables/config values with `accessibleCount` prop to set `isComponentLocked` value in `<ExplorerVisualization>` component. If`isComponentLocked` is `true`, the following child components in `<ExplorerVisualization>` are disabled:

* `<ExplorerButtonGroup>`
*  `<ExplorerTable>`

**This is a breaking change** in a sense that the following environment variables/config values no longer have impact on the <ExplorerVisualization> component's behavior:

* environment variables:
    * `TIER_ACCESS_LEVEL`
* configuration values:
    * `dataExplorerConfig.guppyConfig.accessibleFieldCheckList`
    * `dataExplorerConfig.guppyConfig.accessibleValidationField`

This PR relies on a new `accessibleCount` value provided by `<GuppyWrapper>`, which is only available on the `pcdc_dev branch` version of `@pcdc/guppy` as of this PR. I.e. `isComponentLocked` is set to true if `accessibleCount` value is equal to 0 (user has no accessible data).
