### PR TITLE
Stop using tier access level in explorer PEDS-366

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ConnectedFilter from '@pcdc/guppy/dist/components/ConnectedFilter';
-import TierAccessSelector from '../TierAccessSelector';
 import { FilterConfigType, GuppyConfigType } from '../configTypeDef';
 import FilterGroup from '../../gen3-ui-component/components/filters/FilterGroup';
 import FilterList from '../../gen3-ui-component/components/filters/FilterList';
@@ -64,15 +63,6 @@ class ExplorerFilter extends React.Component {
     };
     return (
       <div className={this.props.className}>
-        {this.state.showTierAccessSelector ? (
-          <TierAccessSelector
-            onSelectorChange={this.handleAccessSelectorChange}
-            getAccessButtonLink={this.props.getAccessButtonLink}
-            hideGetAccessButton={this.props.hideGetAccessButton}
-          />
-        ) : (
-          <React.Fragment />
-        )}
         <h4>Filters</h4>
         <ConnectedFilter {...filterProps} />
       </div>

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -5,10 +5,6 @@ import AccessibleFilter from '@pcdc/guppy/dist/components/ConnectedFilter/Access
 import UnaccessibleFilter from '@pcdc/guppy/dist/components/ConnectedFilter/UnaccessibleFilter';
 import TierAccessSelector from '../TierAccessSelector';
 import { FilterConfigType, GuppyConfigType } from '../configTypeDef';
-import {
-  checkForNoAccessibleProject,
-  checkForFullAccessibleProject,
-} from '../GuppyDataExplorerHelper';
 import FilterGroup from '../../gen3-ui-component/components/filters/FilterGroup';
 import FilterList from '../../gen3-ui-component/components/filters/FilterList';
 
@@ -26,48 +22,6 @@ class ExplorerFilter extends React.Component {
       showTierAccessSelector: false,
     };
   }
-
-  getSnapshotBeforeUpdate(prevProps) {
-    if (
-      prevProps.accessibleFieldObject !== this.props.accessibleFieldObject ||
-      prevProps.unaccessibleFieldObject !== this.props.unaccessibleFieldObject
-    ) {
-      if (this.props.tierAccessLevel === 'libre') {
-        this.setState({ selectedAccessFilter: 'all-data' });
-        return null;
-      }
-      if (this.props.tierAccessLevel === 'regular') {
-        if (
-          checkForNoAccessibleProject(
-            this.props.accessibleFieldObject,
-            this.props.guppyConfig.accessibleValidationField
-          ) ||
-          checkForFullAccessibleProject(
-            this.props.unaccessibleFieldObject,
-            this.props.guppyConfig.accessibleValidationField
-          )
-        ) {
-          // don't show this selector if user have full access, or none access
-          this.setState({ showTierAccessSelector: false });
-          // if user don't have access to any projects
-          // apply 'all-data' filter so agg data is available
-          if (
-            checkForNoAccessibleProject(
-              this.props.accessibleFieldObject,
-              this.props.guppyConfig.accessibleValidationField
-            )
-          ) {
-            this.setState({ selectedAccessFilter: 'all-data' });
-          }
-        } else {
-          this.setState({ showTierAccessSelector: true });
-        }
-      }
-    }
-    return null;
-  }
-
-  componentDidUpdate() {}
 
   /**
    * For "regular" tier access level commons, we use this function parse

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -5,11 +5,6 @@ import { FilterConfigType, GuppyConfigType } from '../configTypeDef';
 import FilterGroup from '../../gen3-ui-component/components/filters/FilterGroup';
 import FilterList from '../../gen3-ui-component/components/filters/FilterList';
 
-/**
- * For selectedAccessFilter the default value is 'Data with Access'
- * if TIER_ACCESS_LEVEL is 'regular'
- * Otherwise 'All Data' is selected
- */
 function ExplorerFilter({
   className = '',
   filterConfig = {},

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -21,26 +21,17 @@ class ExplorerFilter extends React.Component {
       fieldMapping: this.props.guppyConfig.fieldMapping,
       onFilterChange: this.props.onFilterChange,
       onReceiveNewAggsData: this.props.onReceiveNewAggsData,
-      tierAccessLimit:
-        this.props.tierAccessLevel === 'regular'
-          ? this.props.tierAccessLimit
-          : undefined,
+      tierAccessLimit: this.props.tierAccessLimit,
       onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
       initialAppliedFilters: this.props.initialAppliedFilters,
-      lockedTooltipMessage:
-        this.props.tierAccessLevel === 'regular'
-          ? `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.`
-          : '',
-      disabledTooltipMessage:
-        this.props.tierAccessLevel === 'regular'
-          ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${
-              this.props.tierAccessLimit
-            } ${
-              this.props.guppyConfig.nodeCountTitle.toLowerCase() ||
-              this.props.guppyConfig.dataType
-            } or more.`
-          : '',
+      lockedTooltipMessage: `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.`,
+      disabledTooltipMessage: `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${
+        this.props.tierAccessLimit
+      } ${
+        this.props.guppyConfig.nodeCountTitle.toLowerCase() ||
+        this.props.guppyConfig.dataType
+      } or more.`,
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
       filterComponents: {
         FilterGroup,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ConnectedFilter from '@pcdc/guppy/dist/components/ConnectedFilter';
-import AccessibleFilter from '@pcdc/guppy/dist/components/ConnectedFilter/AccessibleFilter';
-import UnaccessibleFilter from '@pcdc/guppy/dist/components/ConnectedFilter/UnaccessibleFilter';
 import TierAccessSelector from '../TierAccessSelector';
 import { FilterConfigType, GuppyConfigType } from '../configTypeDef';
 import FilterGroup from '../../gen3-ui-component/components/filters/FilterGroup';
@@ -64,36 +62,6 @@ class ExplorerFilter extends React.Component {
         FilterList,
       },
     };
-    let filterFragment;
-    switch (this.state.selectedAccessFilter) {
-      case 'all-data':
-        filterFragment = (
-          <React.Fragment>
-            <h4>Filters</h4>
-            <ConnectedFilter {...filterProps} />
-          </React.Fragment>
-        );
-        break;
-      case 'with-access':
-        filterFragment = (
-          <React.Fragment>
-            <h4>Filters</h4>
-            <AccessibleFilter {...filterProps} />
-          </React.Fragment>
-        );
-        break;
-      case 'without-access':
-        filterFragment = (
-          <React.Fragment>
-            <h4>Filters</h4>
-            <UnaccessibleFilter {...filterProps} />
-          </React.Fragment>
-        );
-        break;
-      default:
-        filterFragment = <React.Fragment />;
-        break;
-    }
     return (
       <div className={this.props.className}>
         {this.state.showTierAccessSelector ? (
@@ -105,7 +73,8 @@ class ExplorerFilter extends React.Component {
         ) : (
           <React.Fragment />
         )}
-        {filterFragment}
+        <h4>Filters</h4>
+        <ConnectedFilter {...filterProps} />
       </div>
     );
   }

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -23,55 +23,6 @@ class ExplorerFilter extends React.Component {
     };
   }
 
-  /**
-   * For "regular" tier access level commons, we use this function parse
-   * aggsData and returned parsed aggregation for Guppy's ConnectedFilter.
-   * We do following steps for tier access fields/values (currently, field="project")
-   * 1. According to selected access filter (with, without, or all data access),
-   *    we hide accessible or unaccessible items
-   * 2. We add "accessible" property to items so that filter component will show lock icon
-   */
-  onProcessFilterAggsData = (aggsData) => {
-    if (this.props.tierAccessLevel !== 'regular') {
-      return aggsData;
-    }
-    if (aggsData === null) {
-      return aggsData;
-    }
-    const newAggsData = Object.keys(aggsData).reduce((res, field) => {
-      // if the field is not in accessibleFieldObject, no need to process it
-      if (!Object.keys(this.props.accessibleFieldObject).includes(field)) {
-        res[field] = aggsData[field];
-        return res;
-      }
-      // if the field is in accessibleFieldObject, add "accessible=false"
-      // to those items which are unaccessible
-      const accessibleValues = this.props.accessibleFieldObject[field];
-      const newHistogram = aggsData[field].histogram
-        .filter(({ key }) => {
-          const accessible = accessibleValues.includes(key);
-          switch (this.state.selectedAccessFilter) {
-            case 'all-data':
-              return true; // always show all items if 'all-data'
-            case 'with-access':
-              return accessible; // only show accessible items if 'with-access'
-            case 'without-access':
-              return !accessible; // only show unaccessible items if 'without-access'
-            default:
-              throw new Error('Invalid access filter option');
-          }
-        })
-        .map(({ key, count }) => ({
-          key,
-          count,
-          accessible: accessibleValues.includes(key),
-        }));
-      res[field] = { histogram: newHistogram };
-      return res;
-    }, {});
-    return newAggsData;
-  };
-
   handleAccessSelectorChange = (selectedAccessFilter) => {
     // selectedAccessFilter will be one of: 'with-access', 'without-access', or 'all-data'
     this.setState({ selectedAccessFilter });
@@ -91,7 +42,6 @@ class ExplorerFilter extends React.Component {
         this.props.tierAccessLevel === 'regular'
           ? this.props.tierAccessLimit
           : undefined,
-      onProcessFilterAggsData: this.onProcessFilterAggsData,
       onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
       initialAppliedFilters: this.props.initialAppliedFilters,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -22,7 +22,6 @@ class ExplorerFilter extends React.Component {
       onFilterChange: this.props.onFilterChange,
       onReceiveNewAggsData: this.props.onReceiveNewAggsData,
       tierAccessLimit: this.props.tierAccessLimit,
-      onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
       initialAppliedFilters: this.props.initialAppliedFilters,
       lockedTooltipMessage: `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.`,
@@ -53,7 +52,6 @@ ExplorerFilter.propTypes = {
   guppyConfig: GuppyConfigType, // inherit from GuppyWrapper
   fieldMapping: PropTypes.array, // inherit from GuppyWrapper
   onFilterChange: PropTypes.func, // inherit from GuppyWrapper
-  onUpdateAccessLevel: PropTypes.func, // inherit from GuppyWrapper
   onReceiveNewAggsData: PropTypes.func, // inherit from GuppyWrapper
   tierAccessLimit: PropTypes.number, // inherit from GuppyWrapper
   accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
@@ -71,7 +69,6 @@ ExplorerFilter.defaultProps = {
   guppyConfig: {},
   fieldMapping: [],
   onFilterChange: () => {},
-  onUpdateAccessLevel: () => {},
   onReceiveNewAggsData: () => {},
   tierAccessLimit: undefined,
   accessibleFieldObject: {},

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -11,20 +11,6 @@ import FilterList from '../../gen3-ui-component/components/filters/FilterList';
  * Otherwise 'All Data' is selected
  */
 class ExplorerFilter extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedAccessFilter:
-        this.props.tierAccessLevel === 'regular' ? 'with-access' : 'all-data', // default value of selectedAccessFilter
-      showTierAccessSelector: false,
-    };
-  }
-
-  handleAccessSelectorChange = (selectedAccessFilter) => {
-    // selectedAccessFilter will be one of: 'with-access', 'without-access', or 'all-data'
-    this.setState({ selectedAccessFilter });
-  };
-
   render() {
     const filterProps = {
       filterConfig: this.props.filterConfig,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -32,7 +32,6 @@ class ExplorerFilter extends React.Component {
         this.props.guppyConfig.nodeCountTitle.toLowerCase() ||
         this.props.guppyConfig.dataType
       } or more.`,
-      accessibleFieldCheckList: this.props.accessibleFieldCheckList,
       filterComponents: {
         FilterGroup,
         FilterList,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -47,37 +47,24 @@ class ExplorerFilter extends React.Component {
 
 ExplorerFilter.propTypes = {
   className: PropTypes.string,
-  tierAccessLevel: PropTypes.string.isRequired,
   filterConfig: FilterConfigType, // inherit from GuppyWrapper
   guppyConfig: GuppyConfigType, // inherit from GuppyWrapper
-  fieldMapping: PropTypes.array, // inherit from GuppyWrapper
   onFilterChange: PropTypes.func, // inherit from GuppyWrapper
   onReceiveNewAggsData: PropTypes.func, // inherit from GuppyWrapper
   tierAccessLimit: PropTypes.number, // inherit from GuppyWrapper
-  accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
-  unaccessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
   initialAppliedFilters: PropTypes.object,
-  accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string), // inherit from GuppyWrapper
-  getAccessButtonLink: PropTypes.string,
-  hideGetAccessButton: PropTypes.bool,
 };
 
 ExplorerFilter.defaultProps = {
   className: '',
   filterConfig: {},
   guppyConfig: {},
-  fieldMapping: [],
   onFilterChange: () => {},
   onReceiveNewAggsData: () => {},
   tierAccessLimit: undefined,
-  accessibleFieldObject: {},
-  unaccessibleFieldObject: {},
   adminAppliedPreFilters: {},
   initialAppliedFilters: {},
-  accessibleFieldCheckList: [],
-  getAccessButtonLink: undefined,
-  hideGetAccessButton: false,
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -10,39 +10,43 @@ import FilterList from '../../gen3-ui-component/components/filters/FilterList';
  * if TIER_ACCESS_LEVEL is 'regular'
  * Otherwise 'All Data' is selected
  */
-class ExplorerFilter extends React.Component {
-  render() {
-    const filterProps = {
-      filterConfig: this.props.filterConfig,
-      guppyConfig: {
-        type: this.props.guppyConfig.dataType,
-        ...this.props.guppyConfig,
-      },
-      fieldMapping: this.props.guppyConfig.fieldMapping,
-      onFilterChange: this.props.onFilterChange,
-      onReceiveNewAggsData: this.props.onReceiveNewAggsData,
-      tierAccessLimit: this.props.tierAccessLimit,
-      adminAppliedPreFilters: this.props.adminAppliedPreFilters,
-      initialAppliedFilters: this.props.initialAppliedFilters,
-      lockedTooltipMessage: `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.`,
-      disabledTooltipMessage: `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${
-        this.props.tierAccessLimit
-      } ${
-        this.props.guppyConfig.nodeCountTitle.toLowerCase() ||
-        this.props.guppyConfig.dataType
-      } or more.`,
-      filterComponents: {
-        FilterGroup,
-        FilterList,
-      },
-    };
-    return (
-      <div className={this.props.className}>
-        <h4>Filters</h4>
-        <ConnectedFilter {...filterProps} />
-      </div>
-    );
-  }
+function ExplorerFilter({
+  className = '',
+  filterConfig = {},
+  guppyConfig = {},
+  onFilterChange = () => {},
+  onReceiveNewAggsData = () => {},
+  tierAccessLimit,
+  adminAppliedPreFilters = {},
+  initialAppliedFilters = {},
+}) {
+  const filterProps = {
+    filterConfig,
+    guppyConfig: {
+      type: guppyConfig.dataType,
+      ...guppyConfig,
+    },
+    fieldMapping: guppyConfig.fieldMapping,
+    onFilterChange,
+    onReceiveNewAggsData,
+    tierAccessLimit,
+    adminAppliedPreFilters,
+    initialAppliedFilters,
+    lockedTooltipMessage: `You may only view summary information for this project. You do not have ${guppyConfig.dataType}-level access.`,
+    disabledTooltipMessage: `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${tierAccessLimit} ${
+      guppyConfig.nodeCountTitle.toLowerCase() || guppyConfig.dataType
+    } or more.`,
+    filterComponents: {
+      FilterGroup,
+      FilterList,
+    },
+  };
+  return (
+    <div className={className}>
+      <h4>Filters</h4>
+      <ConnectedFilter {...filterProps} />
+    </div>
+  );
 }
 
 ExplorerFilter.propTypes = {
@@ -54,17 +58,6 @@ ExplorerFilter.propTypes = {
   tierAccessLimit: PropTypes.number, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
   initialAppliedFilters: PropTypes.object,
-};
-
-ExplorerFilter.defaultProps = {
-  className: '',
-  filterConfig: {},
-  guppyConfig: {},
-  onFilterChange: () => {},
-  onReceiveNewAggsData: () => {},
-  tierAccessLimit: undefined,
-  adminAppliedPreFilters: {},
-  initialAppliedFilters: {},
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -83,7 +83,6 @@ class GuppyDataExplorer extends React.Component {
               guppyConfig={this.props.guppyConfig}
               getAccessButtonLink={this.props.getAccessButtonLink}
               hideGetAccessButton={this.props.hideGetAccessButton}
-              tierAccessLevel={this.props.tierAccessLevel}
               tierAccessLimit={this.props.tierAccessLimit}
               initialAppliedFilters={this.props.initialAppliedFilters}
             />
@@ -115,7 +114,6 @@ GuppyDataExplorer.propTypes = {
   buttonConfig: ButtonConfigType.isRequired,
   nodeCountTitle: PropTypes.string,
   history: PropTypes.object.isRequired,
-  tierAccessLevel: PropTypes.string.isRequired,
   tierAccessLimit: PropTypes.number.isRequired,
   getAccessButtonLink: PropTypes.string,
   hideGetAccessButton: PropTypes.bool,

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import GuppyDataExplorer from './GuppyDataExplorer';
-import {
-  guppyUrl,
-  tierAccessLevel,
-  tierAccessLimit,
-  explorerConfig,
-} from '../localconf';
+import { guppyUrl, tierAccessLimit, explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import './GuppyExplorer.css';
 
@@ -97,7 +92,6 @@ class Explorer extends React.Component {
                 explorerConfig[this.state.tab].sevenBridgesExportURL,
             }}
             history={this.props.history}
-            tierAccessLevel={tierAccessLevel}
             tierAccessLimit={tierAccessLimit}
             getAccessButtonLink={
               explorerConfig[this.state.tab].getAccessButtonLink


### PR DESCRIPTION
Ticket: [PEDS-366](https://pcdc.atlassian.net/browse/PEDS-366)

This PR removes the use of `tierAccessLevel` config value in `<ExplorerFilter>` and greatly simplifies how `<ExplorerFilter>` works based on the PCDC use case where no change of `tierAccessLevel` is needed. This PR also removes the use of `<TierAccessSelector>` in `<ExplorerFilter>` as dictated by the PCDC use case.

**This is a breaking change** in a sense that the following environment variables/config values no longer have impact on the component's behavior:

* environment variables:
    * `TIER_ACCESS_LEVEL`
* configuration values:
    * `dataExplorerConfig.guppyConfig.accessibleFieldCheckList`
    * `dataExplorerConfig.guppyConfig.accessibleValidationField`

This PR relies on the `pcdc_dev` branch version of `@pcdc/guppy` as of this PR.
