### PR TITLE
Set which survival result to use in portal config PEDS-375

### DIFF
--- a/data/config/pcdc.json
+++ b/data/config/pcdc.json
@@ -194,6 +194,13 @@
     "table": {
       "enabled": true
     },
+    "survivalAnalysis": {
+      "result": {
+        "pval": false,
+        "risktable": false,
+        "survival": true
+      }
+    },
     "guppyConfig": {
       "dataType": "subject",
       "nodeCountTitle": "Subjects",

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -48,9 +48,25 @@
   justify-content: space-between;
 }
 
+.explorer-survival-analysis__pval {
+  margin-left: 12px;
+  padding: 0.5rem 1rem;
+  height: 1.25rem;
+  font-size: 1rem;
+}
+
 .explorer-survival-analysis__survival-plot {
   margin: 12px;
   min-height: 300px;
+}
+
+.explorer-survival-analysis__risk-table {
+  margin: 12px;
+  min-height: 150px;
+}
+
+.explorer-survival-analysis__risk-table .yAxis tspan {
+  font-size: 0.8rem;
 }
 
 .explorer-survival-analysis__figure-title {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -32,6 +32,14 @@ const fetchResult = (body) => {
   });
 };
 
+const config = {
+  result: {
+    pval: true,
+    risktable: true,
+    survival: true,
+  },
+};
+
 /**
  * @param {Object} prop
  * @param {Object} prop.aggsData
@@ -107,7 +115,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
       fetchResult({
         filter: transformedFilter,
         parameter: requestParameter,
-        result: { pval: true, risktable: true, survival: true },
+        result: config.result,
       })
         .then((result) => {
           setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
@@ -137,7 +145,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           stratificationVariable: '',
           efsFlag: false,
         },
-        result: { pval: true, risktable: true, survival: true },
+        result: config.result,
       })
         .then((result) => {
           if (isMounted) {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -112,10 +112,13 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
         result: config.result,
       })
         .then((result) => {
-          setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-          setRisktable(result.risktable);
-          setSurvival(result.survival);
-          setColorScheme(getNewColorScheme(result.survival));
+          if (config.result.pval)
+            setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
+          if (config.result.risktable) setRisktable(result.risktable);
+          if (config.result.survival) {
+            setSurvival(result.survival);
+            setColorScheme(getNewColorScheme(result.survival));
+          }
           setIsUpdating(false);
         })
         .catch((e) => {
@@ -143,9 +146,10 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
       })
         .then((result) => {
           if (isMounted) {
-            setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-            setRisktable(result.risktable);
-            setSurvival(result.survival);
+            if (config.result.pval)
+              setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
+            if (config.result.risktable) setRisktable(result.risktable);
+            if (config.result.survival) setSurvival(result.survival);
           }
         })
         .catch((e) => isMounted && setIsError(true))

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -5,6 +5,7 @@ import { schemeCategory10 } from 'd3-scale-chromatic';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 import { enumFilterList } from '../../params';
 import Spinner from '../../components/Spinner';
+import { SurvivalAnalysisConfigType } from '../configTypeDef';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
 import RiskTable from './RiskTable';
@@ -32,21 +33,14 @@ const fetchResult = (body) => {
   });
 };
 
-const config = {
-  result: {
-    pval: true,
-    risktable: true,
-    survival: true,
-  },
-};
-
 /**
  * @param {Object} prop
  * @param {Object} prop.aggsData
+ * @param {SurvivalAnalysisConfig} prop.config
  * @param {Array} prop.fieldMapping
  * @param {Object} prop.filter
  */
-function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
+function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
   const [pval, setPval] = useState(-1); // -1 is a placeholder for no p-value
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
@@ -215,6 +209,7 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
 
 ExplorerSurvivalAnalysis.propTypes = {
   aggsData: PropTypes.object,
+  config: SurvivalAnalysisConfigType,
   fieldMapping: PropTypes.array,
   filter: PropTypes.object,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -186,20 +186,26 @@ function ExplorerSurvivalAnalysis({ aggsData, fieldMapping, filter }) {
           </div>
         ) : (
           <>
-            <div className='explorer-survival-analysis__pval'>
-              {pval >= 0 && `Log-rank test p-value: ${pval}`}
-            </div>
-            <SurvivalPlot
-              colorScheme={colorScheme}
-              data={filterSurvivalByTime(survival, startTime, endTime)}
-              isStratified={isStratified}
-              timeInterval={timeInterval}
-            />
-            <RiskTable
-              data={filterRisktableByTime(risktable, startTime, endTime)}
-              notStratified={!isStratified}
-              timeInterval={timeInterval}
-            />
+            {config.result.pval && (
+              <div className='explorer-survival-analysis__pval'>
+                {pval >= 0 && `Log-rank test p-value: ${pval}`}
+              </div>
+            )}
+            {config.result.survival && (
+              <SurvivalPlot
+                colorScheme={colorScheme}
+                data={filterSurvivalByTime(survival, startTime, endTime)}
+                isStratified={isStratified}
+                timeInterval={timeInterval}
+              />
+            )}
+            {config.result.risktable && (
+              <RiskTable
+                data={filterRisktableByTime(risktable, startTime, endTime)}
+                notStratified={!isStratified}
+                timeInterval={timeInterval}
+              />
+            )}
           </>
         )}
       </div>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import cloneDeep from 'lodash.clonedeep';
 import { schemeCategory10 } from 'd3-scale-chromatic';
-import { getGQLFilter } from '@pcdc/guppy/dist/components/Utils/queries';
+import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 import { enumFilterList } from '../../params';
 import Spinner from '../../components/Spinner';
 import SurvivalPlot from './SurvivalPlot';

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -48,3 +48,11 @@
 /**
  * @typedef {{ [key: string]: string }} ColorScheme
  */
+
+/**
+ * @typedef {Object} SurvivalAnalysisConfig
+ * @property {Object} result
+ * @property {boolean} result.pval
+ * @property {boolean} result.risktable
+ * @property {boolean} result.survival
+ */

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -13,6 +13,7 @@ import {
   ButtonConfigType,
   ChartConfigType,
   GuppyConfigType,
+  SurvivalAnalysisConfigType,
 } from '../configTypeDef';
 import './ExplorerVisualization.css';
 
@@ -230,6 +231,7 @@ class ExplorerVisualization extends React.Component {
         <ViewContainer showIf={this.state.explorerView === 'survival analysis'}>
           <ExplorerSurvivalAnalysis
             aggsData={this.props.aggsData}
+            config={this.props.survivalAnalysisConfig}
             fieldMapping={this.props.guppyConfig.fieldMapping}
             filter={this.props.filter}
           />
@@ -257,6 +259,7 @@ ExplorerVisualization.propTypes = {
   className: PropTypes.string,
   chartConfig: ChartConfigType,
   tableConfig: TableConfigType,
+  survivalAnalysisConfig: SurvivalAnalysisConfigType,
   buttonConfig: ButtonConfigType,
   guppyConfig: GuppyConfigType,
   nodeCountTitle: PropTypes.string.isRequired,
@@ -280,6 +283,7 @@ ExplorerVisualization.defaultProps = {
   className: '',
   chartConfig: {},
   tableConfig: {},
+  survivalAnalysisConfig: {},
   buttonConfig: {},
   guppyConfig: {},
 };

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -13,6 +13,7 @@ import {
   TableConfigType,
   ButtonConfigType,
   ChartConfigType,
+  SurvivalAnalysisConfigType,
 } from './configTypeDef';
 import './GuppyDataExplorer.css';
 
@@ -82,6 +83,7 @@ class GuppyDataExplorer extends React.Component {
               className='guppy-data-explorer__visualization'
               chartConfig={this.props.chartConfig}
               tableConfig={this.props.tableConfig}
+              survivalAnalysisConfig={this.props.survivalAnalysisConfig}
               buttonConfig={this.props.buttonConfig}
               guppyConfig={this.props.guppyConfig}
               history={this.props.history}
@@ -102,6 +104,7 @@ GuppyDataExplorer.propTypes = {
   guppyConfig: GuppyConfigType.isRequired,
   filterConfig: FilterConfigType.isRequired,
   tableConfig: TableConfigType.isRequired,
+  survivalAnalysisConfig: SurvivalAnalysisConfigType.isRequired,
   chartConfig: ChartConfigType.isRequired,
   buttonConfig: ButtonConfigType.isRequired,
   nodeCountTitle: PropTypes.string,

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -53,3 +53,11 @@ export const ButtonConfigType = PropTypes.shape({
 });
 
 export const ChartConfigType = PropTypes.object;
+
+export const SurvivalAnalysisConfigType = PropTypes.shape({
+  result: PropTypes.shape({
+    pval: PropTypes.bool,
+    risktable: PropTypes.bool,
+    survival: PropTypes.bool,
+  }),
+});

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -79,6 +79,9 @@ class Explorer extends React.Component {
             chartConfig={explorerConfig[this.state.tab].charts}
             filterConfig={explorerConfig[this.state.tab].filters}
             tableConfig={explorerConfig[this.state.tab].table}
+            survivalAnalysisConfig={
+              explorerConfig[this.state.tab].survivalAnalysis
+            }
             guppyConfig={{
               path: guppyUrl,
               ...explorerConfig[this.state.tab].guppyConfig,


### PR DESCRIPTION
Ticket: [PEDS-375](https://pcdc.atlassian.net/browse/PEDS-375)

This PR allows for setting which part of the survival result (p-value, number-at-risk table, and survival function estimates) to use/display on the Exploration page in the portal configuration file.

The new configuration option is placed under `dataExplorerConfig` and looks like the following:

```json
{
  "dataExplorerConfig": {
    "survivalAnalysis": {
      "result": {
        "survival": true,
        "pval": false,
        "risktable": false
      }
    }
  }
}
```

The PR also bring in changes from `demo-nih` branch re: using the updated survival request API, which ultimately enables the use of this configuration setting. On this, refer to the request API spec in [the "requirements" doc](https://github.com/chicagopcdc/Documents/blob/master/GEN3/survival-analysis-tool/requirements.md#request-api) for survival analysis tool.