### PR TITLE
Update survival response format PEDS-387

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -12,12 +12,6 @@ import {
 import { getXAxisTicks } from './utils';
 import './typedef';
 
-const formatNames = (/** @type {SurvivalData[]} */ data) =>
-  data.map(({ data, name }) => ({
-    name: name === 'All' ? name : name.split('=')[1],
-    data,
-  }));
-
 /**
  * @param {Object} prop
  * @param {Object} prop.colorScheme
@@ -28,7 +22,7 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
   const [opacity, setOpacity] = useState({});
   useEffect(() => {
     const initOpacity = {};
-    for (const { name } of data) initOpacity[name] = 1;
+    for (const { group } of data) initOpacity[group[0].value] = 1;
     setOpacity(initOpacity);
   }, [data]);
 
@@ -72,16 +66,16 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
           onMouseEnter={handleLegendMouseEnter}
           onMouseLeave={handleLegendMouseLeave}
         />
-        {data.map(({ data, name }, i) => (
+        {data.map(({ group, data }) => (
           <Line
-            key={name}
+            key={group[0].value}
             data={data}
             dataKey='prob'
             dot={false}
-            name={name}
+            name={group[0].value}
             type='stepAfter'
-            stroke={colorScheme[name]}
-            strokeOpacity={opacity[name]}
+            stroke={colorScheme[group[0].value]}
+            strokeOpacity={opacity[group[0].value]}
           />
         ))}
       </LineChart>
@@ -104,32 +98,25 @@ const SurvivalPlot = ({ colorScheme, data, isStratified, timeInterval }) => (
       </div>
     ) : isStratified ? (
       Object.entries(
-        data.reduce((acc, { name, data }) => {
-          const [factorKey, stratificationKey] = name.split(',');
+        data.reduce((acc, { group, data }) => {
+          const [factor, stratification] = group;
+          const stratificationKey = JSON.stringify(stratification);
           const stratificationValue = acc.hasOwnProperty(stratificationKey)
-            ? [...acc[stratificationKey], { name: factorKey, data }]
-            : [{ name: factorKey, data }];
+            ? [...acc[stratificationKey], { group: [factor], data }]
+            : [{ group: [factor], data }];
 
           return { ...acc, [stratificationKey]: stratificationValue };
         }, {})
       ).map(([key, data]) => (
         <Fragment key={key}>
           <div className='explorer-survival-analysis__figure-title'>
-            {key.split('=')[1]}
+            {JSON.parse(key).value}
           </div>
-          <Plot
-            colorScheme={colorScheme}
-            data={formatNames(data)}
-            timeInterval={timeInterval}
-          />
+          <Plot {...{ colorScheme, data, timeInterval }} />
         </Fragment>
       ))
     ) : (
-      <Plot
-        colorScheme={colorScheme}
-        data={formatNames(data)}
-        timeInterval={timeInterval}
-      />
+      <Plot {...{ colorScheme, data, timeInterval }} />
     )}
   </div>
 );
@@ -143,7 +130,12 @@ SurvivalPlot.propTypes = {
           time: PropTypes.number,
         })
       ),
-      name: PropTypes.string,
+      group: PropTypes.arrayOf(
+        PropTypes.exact({
+          variable: PropTypes.string,
+          value: PropTypes.string,
+        })
+      ),
     })
   ).isRequired,
   isStratified: PropTypes.bool.isRequired,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -77,13 +77,12 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
     /** @type {ColorScheme} */
     const newScheme = {};
     let factorValueCount = 0;
-    for (const { name } of survival) {
-      const factorValue = name.split(',')[0].split('=')[1];
-      if (!newScheme.hasOwnProperty(factorValue)) {
-        newScheme[factorValue] = schemeCategory10[factorValueCount % 9];
+    for (const { group } of survival)
+      if (!newScheme.hasOwnProperty(group[0].value)) {
+        newScheme[group[0].value] = schemeCategory10[factorValueCount % 9];
         factorValueCount++;
       }
-    }
+
     return newScheme;
   };
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {Object} RisktableData
  * @property {RisktableDataPoint[]} data
- * @property {string} name
+ * @property {{ variable: string; value: string; }[]} group
  */
 
 /**
@@ -19,7 +19,7 @@
 /**
  * @typedef {Object} SurvivalData
  * @property {SurvivalDataPoint[]} data
- * @property {string} name
+ * @property {{ variable: string; value: string; }[]} group
  */
 
 /**

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -62,9 +62,9 @@ export const getXAxisTicks = (data, step = 2) => {
  * @returns {SurvivalData[]}
  */
 export const filterSurvivalByTime = (data, startTime, endTime) =>
-  data.map(({ data, name }) => ({
+  data.map(({ data, group }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    name,
+    group,
   }));
 
 /**
@@ -75,7 +75,7 @@ export const filterSurvivalByTime = (data, startTime, endTime) =>
  * @returns {RisktableData[]}
  */
 export const filterRisktableByTime = (data, startTime, endTime) =>
-  data.map(({ data, name }) => ({
+  data.map(({ data, group }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    name,
+    group,
   }));


### PR DESCRIPTION
Ticket: [PEDS-387](https://pcdc.atlassian.net/browse/PEDS-387)

This PR modifies `<ExplorerSurvivalAnalysis>` to use  updated response API format for `/survival` endpoint.  Refer to [this commit](https://github.com/chicagopcdc/Documents/commit/bdf63c63426baaea195617407a9ca48b190935e6) for update details. T

The update is motivated by the bug where the stratified survival results fails to render as intended when factor/stratification variable's value includes a delimiter symbol (i.e. comma `,`). See PEDS-387 description.

For deploying, the portal app with this PR will need the `PcdcAnalysisTools` after https://github.com/chicagopcdc/PcdcAnalysisTools/pull/20 to handle `/survival` requests.