### PR TITLE
Update survival response format pt.2 PEDS-387

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -18,7 +18,12 @@ import './typedef';
 const parseRisktable = (data, timeInterval) => {
   const minTime = data[0].data[0].time;
   return data
-    .flatMap(({ group, data }) => data.map((d) => ({ group, ...d })))
+    .flatMap(({ group, data }) =>
+      data.map((d) => ({
+        group: group.length === 0 ? 'All' : group[0].value,
+        ...d,
+      }))
+    )
     .filter(({ time }) => (time - minTime) % timeInterval === 0);
 };
 
@@ -26,7 +31,7 @@ const getMaxTime = (/** @type {RisktableData[]} */ data) =>
   Math.max(...data.flatMap(({ data }) => data.map(({ time }) => time)));
 
 const CustomYAxisTick = (/** @type {Object} */ { x, y, payload }) => {
-  const name = payload.value.length === 0 ? 'All' : payload.value[0].value;
+  const name = payload.value;
 
   return (
     <g transform={`translate(${x},${y})`}>
@@ -84,10 +89,10 @@ const Table = ({ data, isLast, timeInterval }) => (
 /**
  * @param {Object} prop
  * @param {RisktableData[]} prop.data
- * @param {boolean} prop.notStratified
+ * @param {boolean} prop.isStratified
  * @param {number} prop.timeInterval
  */
-const RiskTable = ({ data, notStratified, timeInterval }) => (
+const RiskTable = ({ data, isStratified, timeInterval }) => (
   <div className='explorer-survival-analysis__risk-table'>
     {data.length === 0 ? (
       <div className='explorer-survival-analysis__figure-placeholder'>
@@ -101,9 +106,7 @@ const RiskTable = ({ data, notStratified, timeInterval }) => (
         >
           Number at risk
         </div>
-        {notStratified ? (
-          <Table data={data} timeInterval={timeInterval} isLast />
-        ) : (
+        {isStratified ? (
           Object.entries(
             data.reduce((acc, { group, data }) => {
               const [factor, stratification] = group;
@@ -126,6 +129,8 @@ const RiskTable = ({ data, notStratified, timeInterval }) => (
               />
             </Fragment>
           ))
+        ) : (
+          <Table data={data} timeInterval={timeInterval} isLast />
         )}
       </>
     )}
@@ -149,6 +154,7 @@ RiskTable.propTypes = {
       ),
     })
   ).isRequired,
+  isStratified: PropTypes.bool.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -12,12 +12,6 @@ import {
 import { getXAxisTicks } from './utils';
 import './typedef';
 
-const formatNames = (/** @type {SurvivalData[]} */ data) =>
-  data.map(({ data, name }) => ({
-    name: name === 'All' ? name : name.split('=')[1],
-    data,
-  }));
-
 /**
  * @param {Object} prop
  * @param {Object} prop.colorScheme
@@ -28,7 +22,7 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
   const [opacity, setOpacity] = useState({});
   useEffect(() => {
     const initOpacity = {};
-    for (const { name } of data) initOpacity[name] = 1;
+    for (const { group } of data) initOpacity[group[0].value] = 1;
     setOpacity(initOpacity);
   }, [data]);
 
@@ -72,16 +66,16 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
           onMouseEnter={handleLegendMouseEnter}
           onMouseLeave={handleLegendMouseLeave}
         />
-        {data.map(({ data, name }, i) => (
+        {data.map(({ group, data }) => (
           <Line
-            key={name}
+            key={group[0].value}
             data={data}
             dataKey='prob'
             dot={false}
-            name={name}
+            name={group[0].value}
             type='stepAfter'
-            stroke={colorScheme[name]}
-            strokeOpacity={opacity[name]}
+            stroke={colorScheme[group[0].value]}
+            strokeOpacity={opacity[group[0].value]}
           />
         ))}
       </LineChart>
@@ -104,32 +98,25 @@ const SurvivalPlot = ({ colorScheme, data, isStratified, timeInterval }) => (
       </div>
     ) : isStratified ? (
       Object.entries(
-        data.reduce((acc, { name, data }) => {
-          const [factorKey, stratificationKey] = name.split(',');
+        data.reduce((acc, { group, data }) => {
+          const [factor, stratification] = group;
+          const stratificationKey = JSON.stringify(stratification);
           const stratificationValue = acc.hasOwnProperty(stratificationKey)
-            ? [...acc[stratificationKey], { name: factorKey, data }]
-            : [{ name: factorKey, data }];
+            ? [...acc[stratificationKey], { group: [factor], data }]
+            : [{ group: [factor], data }];
 
           return { ...acc, [stratificationKey]: stratificationValue };
         }, {})
       ).map(([key, data]) => (
         <Fragment key={key}>
           <div className='explorer-survival-analysis__figure-title'>
-            {key.split('=')[1]}
+            {JSON.parse(key).value}
           </div>
-          <Plot
-            colorScheme={colorScheme}
-            data={formatNames(data)}
-            timeInterval={timeInterval}
-          />
+          <Plot {...{ colorScheme, data, timeInterval }} />
         </Fragment>
       ))
     ) : (
-      <Plot
-        colorScheme={colorScheme}
-        data={formatNames(data)}
-        timeInterval={timeInterval}
-      />
+      <Plot {...{ colorScheme, data, timeInterval }} />
     )}
   </div>
 );
@@ -143,7 +130,12 @@ SurvivalPlot.propTypes = {
           time: PropTypes.number,
         })
       ),
-      name: PropTypes.string,
+      group: PropTypes.arrayOf(
+        PropTypes.exact({
+          variable: PropTypes.string,
+          value: PropTypes.string,
+        })
+      ),
     })
   ).isRequired,
   isStratified: PropTypes.bool.isRequired,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -22,7 +22,8 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
   const [opacity, setOpacity] = useState({});
   useEffect(() => {
     const initOpacity = {};
-    for (const { group } of data) initOpacity[group[0].value] = 1;
+    for (const { group } of data)
+      initOpacity[group.length === 0 ? 'All' : group[0].value] = 1;
     setOpacity(initOpacity);
   }, [data]);
 
@@ -66,18 +67,21 @@ const Plot = ({ colorScheme, data, timeInterval }) => {
           onMouseEnter={handleLegendMouseEnter}
           onMouseLeave={handleLegendMouseLeave}
         />
-        {data.map(({ group, data }) => (
-          <Line
-            key={group[0].value}
-            data={data}
-            dataKey='prob'
-            dot={false}
-            name={group[0].value}
-            type='stepAfter'
-            stroke={colorScheme[group[0].value]}
-            strokeOpacity={opacity[group[0].value]}
-          />
-        ))}
+        {data.map(({ group, data }) => {
+          const factorValue = group.length === 0 ? 'All' : group[0].value;
+          return (
+            <Line
+              key={factorValue}
+              data={data}
+              dataKey='prob'
+              dot={false}
+              name={factorValue}
+              type='stepAfter'
+              stroke={colorScheme[factorValue]}
+              strokeOpacity={opacity[factorValue]}
+            />
+          );
+        })}
       </LineChart>
     </ResponsiveContainer>
   );

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -77,13 +77,12 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
     /** @type {ColorScheme} */
     const newScheme = {};
     let factorValueCount = 0;
-    for (const { name } of survival) {
-      const factorValue = name.split(',')[0].split('=')[1];
-      if (!newScheme.hasOwnProperty(factorValue)) {
-        newScheme[factorValue] = schemeCategory10[factorValueCount % 9];
+    for (const { group } of survival)
+      if (!newScheme.hasOwnProperty(group[0].value)) {
+        newScheme[group[0].value] = schemeCategory10[factorValueCount % 9];
         factorValueCount++;
       }
-    }
+
     return newScheme;
   };
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -44,7 +44,7 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
   const [pval, setPval] = useState(-1); // -1 is a placeholder for no p-value
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
-  const [isStratified, setIsStratified] = useState(true);
+  const [isStratified, setIsStratified] = useState(false);
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
@@ -199,7 +199,7 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
             {config.result.risktable && (
               <RiskTable
                 data={filterRisktableByTime(risktable, startTime, endTime)}
-                notStratified={!isStratified}
+                isStratified={isStratified}
                 timeInterval={timeInterval}
               />
             )}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -7,7 +7,7 @@
 /**
  * @typedef {Object} RisktableData
  * @property {RisktableDataPoint[]} data
- * @property {string} name
+ * @property {{ variable: string; value: string; }[]} group
  */
 
 /**
@@ -19,7 +19,7 @@
 /**
  * @typedef {Object} SurvivalData
  * @property {SurvivalDataPoint[]} data
- * @property {string} name
+ * @property {{ variable: string; value: string; }[]} group
  */
 
 /**

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -62,9 +62,9 @@ export const getXAxisTicks = (data, step = 2) => {
  * @returns {SurvivalData[]}
  */
 export const filterSurvivalByTime = (data, startTime, endTime) =>
-  data.map(({ data, name }) => ({
+  data.map(({ data, group }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    name,
+    group,
   }));
 
 /**
@@ -75,7 +75,7 @@ export const filterSurvivalByTime = (data, startTime, endTime) =>
  * @returns {RisktableData[]}
  */
 export const filterRisktableByTime = (data, startTime, endTime) =>
-  data.map(({ data, name }) => ({
+  data.map(({ data, group }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    name,
+    group,
   }));


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

- Implemented XXX

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes

***

[Description by @bobaekang]

This PR completes what was originally meant for #127, which had to be prematurely merged to facilitate build on quay. See the following description copied from #127:

> Ticket: [PEDS-387](https://pcdc.atlassian.net/browse/PEDS-387)
>
> This PR modifies `<ExplorerSurvivalAnalysis>` to use  updated response API format for `/survival` endpoint.  Refer to [this commit](https://github.com/chicagopcdc/Documents/commit/bdf63c63426baaea195617407a9ca48b190935e6) for update details. T
>
> The update is motivated by the bug where the stratified survival results fails to render as intended when factor/stratification variable's value includes a delimiter symbol (i.e. comma `,`). See PEDS-387 description.
>
> For deploying, the portal app with this PR will need the `PcdcAnalysisTools` after https://github.com/chicagopcdc/PcdcAnalysisTools/pull/20 to handle `/survival` requests.
