### PR TITLE
Omit survival on missing config PEDS-389

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -111,10 +111,10 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
         result: config.result,
       })
         .then((result) => {
-          if (config.result.pval)
+          if (config.result?.pval)
             setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-          if (config.result.risktable) setRisktable(result.risktable);
-          if (config.result.survival) {
+          if (config.result?.risktable) setRisktable(result.risktable);
+          if (config.result?.survival) {
             setSurvival(result.survival);
             setColorScheme(getNewColorScheme(result.survival));
           }
@@ -145,10 +145,10 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
       })
         .then((result) => {
           if (isMounted) {
-            if (config.result.pval)
+            if (config.result?.pval)
               setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-            if (config.result.risktable) setRisktable(result.risktable);
-            if (config.result.survival) setSurvival(result.survival);
+            if (config.result?.risktable) setRisktable(result.risktable);
+            if (config.result?.survival) setSurvival(result.survival);
           }
         })
         .catch((e) => isMounted && setIsError(true))
@@ -183,12 +183,12 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
           </div>
         ) : (
           <>
-            {config.result.pval && (
+            {config.result?.pval && (
               <div className='explorer-survival-analysis__pval'>
                 {pval >= 0 && `Log-rank test p-value: ${pval}`}
               </div>
             )}
-            {config.result.survival && (
+            {config.result?.survival && (
               <SurvivalPlot
                 colorScheme={colorScheme}
                 data={filterSurvivalByTime(survival, startTime, endTime)}
@@ -196,7 +196,7 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
                 timeInterval={timeInterval}
               />
             )}
-            {config.result.risktable && (
+            {config.result?.risktable && (
               <RiskTable
                 data={filterRisktableByTime(risktable, startTime, endTime)}
                 isStratified={isStratified}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -51,8 +51,8 @@
 
 /**
  * @typedef {Object} SurvivalAnalysisConfig
- * @property {Object} result
- * @property {boolean} result.pval
- * @property {boolean} result.risktable
- * @property {boolean} result.survival
+ * @property {Object} [result]
+ * @property {boolean} [result.pval]
+ * @property {boolean} [result.risktable]
+ * @property {boolean} [result.survival]
  */

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -38,7 +38,8 @@ class ExplorerVisualization extends React.Component {
 
     const explorerViews = ['summary view'];
     if (props.tableConfig.enabled) explorerViews.push('table view');
-    explorerViews.push('survival analysis');
+    if (props.survivalAnalysisConfig.hasOwnProperty('result'))
+      explorerViews.push('survival analysis');
 
     this.state = {
       explorerView: explorerViews[0],
@@ -228,14 +229,18 @@ class ExplorerVisualization extends React.Component {
             />
           </ViewContainer>
         )}
-        <ViewContainer showIf={this.state.explorerView === 'survival analysis'}>
-          <ExplorerSurvivalAnalysis
-            aggsData={this.props.aggsData}
-            config={this.props.survivalAnalysisConfig}
-            fieldMapping={this.props.guppyConfig.fieldMapping}
-            filter={this.props.filter}
-          />
-        </ViewContainer>
+        {this.props.survivalAnalysisConfig.hasOwnProperty('result') && (
+          <ViewContainer
+            showIf={this.state.explorerView === 'survival analysis'}
+          >
+            <ExplorerSurvivalAnalysis
+              aggsData={this.props.aggsData}
+              config={this.props.survivalAnalysisConfig}
+              fieldMapping={this.props.guppyConfig.fieldMapping}
+              filter={this.props.filter}
+            />
+          </ViewContainer>
+        )}
       </div>
     );
   }

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -31,6 +31,14 @@ function ViewContainer({ showIf, children, isLoading }) {
   );
 }
 
+function isSurvivalAnalysisEnabled(survivalAnalysisConfig) {
+  if (survivalAnalysisConfig.hasOwnProperty('result'))
+    for (const resultOption of ['pval', 'risktable', 'survival'])
+      if (survivalAnalysisConfig.result[resultOption]) return true;
+
+  return false;
+}
+
 class ExplorerVisualization extends React.Component {
   constructor(props) {
     super(props);
@@ -38,7 +46,7 @@ class ExplorerVisualization extends React.Component {
 
     const explorerViews = ['summary view'];
     if (props.tableConfig.enabled) explorerViews.push('table view');
-    if (props.survivalAnalysisConfig.hasOwnProperty('result'))
+    if (isSurvivalAnalysisEnabled(props.survivalAnalysisConfig))
       explorerViews.push('survival analysis');
 
     this.state = {
@@ -229,7 +237,7 @@ class ExplorerVisualization extends React.Component {
             />
           </ViewContainer>
         )}
-        {this.props.survivalAnalysisConfig.hasOwnProperty('result') && (
+        {isSurvivalAnalysisEnabled(this.props.survivalAnalysisConfig) && (
           <ViewContainer
             showIf={this.state.explorerView === 'survival analysis'}
           >


### PR DESCRIPTION
Ticket: [PEDS-389](https://pcdc.atlassian.net/browse/PEDS-389)

This PR allows the Exploration page to omit "survival analysis" tab when
* `dataExplorerConfig` in portal configuration file is missing `survivalAnalysis` option;
* `survivalAnalysis` is missing `result` property; or
* `result` as no valid result option (`pval`, `risktable`, or `survival`) set to `true`.