### PR TITLE
Exclude filter with no data from survival variable option PEDS-380

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -16,7 +16,14 @@ export const getFactors = (aggsData, fieldMapping, enumFilterList) => {
 
   const fields = Object.keys(aggsData);
   for (const field of fields)
-    if (enumFilterList.includes(field) && !exceptions.includes(field))
+    if (
+      enumFilterList.includes(field) &&
+      !exceptions.includes(field) &&
+      !(
+        aggsData[field].histogram.length === 1 &&
+        aggsData[field].histogram[0].key === 'no data'
+      )
+    )
       factors.push({
         label: fieldNameMap.hasOwnProperty(field)
           ? fieldNameMap[field]


### PR DESCRIPTION
Ticket: [PEDS-380](https://pcdc.atlassian.net/browse/PEDS-380)

This PR modifies `getFactors()` util function for survival analysis to ensure that all options for survival analysis factor/stratification variable has relevant data. It makes the following assumptions:

* Any filter will have at least one option/attribute for "no data"
* The filter option/attribute for "no data" is always called `"no data"`
