### PR TITLE
Hide "n more" button during filter search PEDS-392

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -509,7 +509,10 @@ class FilterSection extends React.Component {
                 />
               );
             })}
-          {isTextFilter && this.state.isExpanded && this.getShowMoreButton()}
+          {isTextFilter &&
+            this.state.isExpanded &&
+            this.state.searchInputEmpty &&
+            this.getShowMoreButton()}
         </div>
       </div>
     );


### PR DESCRIPTION
Ticket: [PEDS-392](https://pcdc.atlassian.net/browse/PEDS-392)

This PR is a follow-up to #131 and fixes the issue of displaying misleading/inaccurate "_n_ more" button while using filter search, where _n_ remains to be based on the total filter options & `initVisibleItemNumber` prop value regardless of the search input/result. The fix is to simply hide the "_n_ more" button if filter search input is provided.
