### PR TITLE
Match Exploration page URL to applied filter state PEDS-373

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,38 +78,53 @@ function App({ store }) {
                 <ProtectedContent
                   isPublic
                   filter={() => store.dispatch(fetchLogin())}
-                  component={ReduxLogin}
                   {...props}
-                />
+                >
+                  <ReduxLogin
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               exact
               path='/'
               component={(props) => (
-                <ProtectedContent component={IndexPage} {...props} />
+                <ProtectedContent {...props}>
+                  <IndexPage
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               exact
               path='/submission'
               component={(props) => (
-                <ProtectedContent
-                  isAdminOnly
-                  component={SubmissionPage}
-                  {...props}
-                />
+                <ProtectedContent isAdminOnly {...props}>
+                  <SubmissionPage
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               exact
               path='/submission/files'
               component={(props) => (
-                <ProtectedContent
-                  isAdminOnly
-                  component={ReduxMapFiles}
-                  {...props}
-                />
+                <ProtectedContent isAdminOnly {...props}>
+                  <ReduxMapFiles
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
@@ -120,20 +135,38 @@ function App({ store }) {
                   isAdminOnly
                   component={ReduxMapDataModel}
                   {...props}
-                />
+                >
+                  <ReduxMapDataModel
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               exact
               path='/document'
               component={(props) => (
-                <ProtectedContent component={DocumentPage} {...props} />
+                <ProtectedContent {...props}>
+                  <DocumentPage
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/query'
               component={(props) => (
-                <ProtectedContent component={GraphQLQuery} {...props} />
+                <ProtectedContent {...props}>
+                  <GraphQLQuery
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
@@ -141,33 +174,62 @@ function App({ store }) {
               component={(props) => (
                 <ProtectedContent
                   filter={() => store.dispatch(fetchAccess())}
-                  component={UserProfile}
                   {...props}
-                />
+                >
+                  <UserProfile
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/indexing'
               component={(props) => (
-                <ProtectedContent component={Indexing} {...props} />
+                <ProtectedContent {...props}>
+                  <Indexing
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/quiz'
               component={(props) => (
-                <ProtectedContent component={UserAgreementCert} {...props} />
+                <ProtectedContent {...props}>
+                  <UserAgreementCert
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/dd/:node'
               component={(props) => (
-                <ProtectedContent component={DataDictionary} {...props} />
+                <ProtectedContent {...props}>
+                  <DataDictionary
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/dd'
               component={(props) => (
-                <ProtectedContent component={DataDictionary} {...props} />
+                <ProtectedContent {...props}>
+                  <DataDictionary
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
@@ -178,21 +240,38 @@ function App({ store }) {
                   filter={() =>
                     store.dispatch(fetchCoreMetadata(props.match.params[0]))
                   }
-                  component={CoreMetadataPage}
                   {...props}
-                />
+                >
+                  <CoreMetadataPage
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/files'
               component={(props) => (
-                <ProtectedContent component={GuppyDataExplorer} {...props} />
+                <ProtectedContent {...props}>
+                  <GuppyDataExplorer
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route
               path='/workspace'
               component={(props) => (
-                <ProtectedContent component={Workspace} {...props} />
+                <ProtectedContent {...props}>
+                  <Workspace
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
             <Route path={workspaceUrl} component={ErrorWorkspacePlaceholder} />
@@ -221,11 +300,13 @@ function App({ store }) {
                   return Promise.resolve('ok');
                 };
                 return (
-                  <ProtectedContent
-                    filter={queryFilter}
-                    component={ReduxQueryNode}
-                    {...props}
-                  />
+                  <ProtectedContent filter={queryFilter} {...props}>
+                    <ReduxQueryNode
+                      history={props.history}
+                      location={props.location}
+                      params={props.match.params}
+                    />
+                  </ProtectedContent>
                 );
               }}
             />
@@ -233,7 +314,13 @@ function App({ store }) {
               <Route
                 path='/explorer'
                 component={(props) => (
-                  <ProtectedContent component={GuppyDataExplorer} {...props} />
+                  <ProtectedContent {...props}>
+                    <GuppyDataExplorer
+                      history={props.history}
+                      location={props.location}
+                      params={props.match.params}
+                    />
+                  </ProtectedContent>
                 )}
               />
             )}
@@ -246,14 +333,26 @@ function App({ store }) {
               <Route
                 path='/resource-browser'
                 component={(props) => (
-                  <ProtectedContent component={ResourceBrowser} {...props} />
+                  <ProtectedContent {...props}>
+                    <ResourceBrowser
+                      history={props.history}
+                      location={props.location}
+                      params={props.match.params}
+                    />
+                  </ProtectedContent>
                 )}
               />
             )}
             <Route
               path='/:project'
               component={(props) => (
-                <ProtectedContent component={ProjectSubmission} {...props} />
+                <ProtectedContent {...props}>
+                  <ProjectSubmission
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
               )}
             />
           </Switch>

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -6,7 +6,6 @@ import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
 import ExplorerCohort from './ExplorerCohort';
-import { mergeFilters } from '../GuppyComponents/Utils/filters';
 import { capitalizeFirstLetter } from '../utils';
 import { validateFilter } from './utils';
 import {
@@ -37,16 +36,8 @@ class GuppyDataExplorer extends React.Component {
       }
     }
 
-    const overviewFilter =
-      props.history.location.state && props.history.location.state.filter
-        ? props.history.location.state.filter
-        : {};
-
     this.state = {
-      initialAppliedFilters: mergeFilters(
-        initialAppliedFilters,
-        overviewFilter
-      ),
+      initialAppliedFilters,
     };
     this._isMounted = false;
   }

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -6,7 +6,9 @@ import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
 import ExplorerCohort from './ExplorerCohort';
+import { mergeFilters } from '../GuppyComponents/Utils/filters';
 import { capitalizeFirstLetter } from '../utils';
+import { validateFilter } from './utils';
 import {
   GuppyConfigType,
   FilterConfigType,
@@ -20,13 +22,31 @@ import './GuppyDataExplorer.css';
 class GuppyDataExplorer extends React.Component {
   constructor(props) {
     super(props);
+
+    let initialAppliedFilters = {};
+    const searchParams = new URLSearchParams(props.history.location.search);
+    if (searchParams.has('filter')) {
+      try {
+        const filterInUrl = JSON.parse(decodeURI(searchParams.get('filter')));
+        if (validateFilter(filterInUrl, props.filterConfig))
+          initialAppliedFilters = filterInUrl;
+        else throw undefined;
+      } catch (e) {
+        console.error('Invalid filter value in URL.', e);
+        props.history.push({ search: '' });
+      }
+    }
+
     const overviewFilter =
       props.history.location.state && props.history.location.state.filter
         ? props.history.location.state.filter
         : {};
 
     this.state = {
-      initialAppliedFilters: { ...overviewFilter },
+      initialAppliedFilters: mergeFilters(
+        initialAppliedFilters,
+        overviewFilter
+      ),
     };
     this._isMounted = false;
   }

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -54,9 +54,26 @@ class GuppyDataExplorer extends React.Component {
     if (this._isMounted) this.setState({ initialAppliedFilters: filters });
   };
 
-  handleFilterChange = (e) => {
-    const search =
-      e && Object.keys(e).length > 0 ? `filter=${JSON.stringify(e)}` : '';
+  handleFilterChange = (filter) => {
+    let search = '';
+    if (filter && Object.keys(filter).length > 0) {
+      const allSearchFields = [];
+      for (const { searchFields } of this.props.filterConfig.tabs)
+        if (searchFields?.length > 0) allSearchFields.push(...searchFields);
+
+      if (allSearchFields.length === 0) {
+        search = `filter=${JSON.stringify(filter)}`;
+      } else {
+        const allSearchFieldSet = new Set(allSearchFields);
+        const filterWithoutSearchFields = {};
+        for (const field of Object.keys(filter))
+          if (!allSearchFieldSet.has(field))
+            filterWithoutSearchFields[field] = filter[field];
+
+        search = `filter=${JSON.stringify(filterWithoutSearchFields)}`;
+      }
+    }
+
     this.props.history.push({ search });
   };
 

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -54,6 +54,12 @@ class GuppyDataExplorer extends React.Component {
     if (this._isMounted) this.setState({ initialAppliedFilters: filters });
   };
 
+  handleFilterChange = (e) => {
+    const search =
+      e && Object.keys(e).length > 0 ? `filter=${JSON.stringify(e)}` : '';
+    this.props.history.push({ search });
+  };
+
   render() {
     return (
       <ExplorerErrorBoundary>

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -62,3 +62,21 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
   // 10^15+, number is too large
   return Number.parseFloat(number).toExponential(fixedPoint);
 };
+
+/**
+ * Validates the provide filter value based on configuration.
+ * Performs the following checks:
+ * - filter value is a plain object
+ * - filter keys include only fields specified in the configuration
+ * @param {*} value
+ * @param {{ tabs: { fields: string[] }[] }} filterConfig
+ */
+export function validateFilter(value, filterConfig) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    return false;
+
+  const allFields = filterConfig.tabs.flatMap(({ fields }) => fields);
+  const testFieldSet = new Set(allFields);
+  for (const key of Object.keys(value)) testFieldSet.add(key);
+  return allFields.length === testFieldSet.size;
+}

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -63,6 +63,28 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
   return Number.parseFloat(number).toExponential(fixedPoint);
 };
 
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isTextFilter(value) {
+  return (
+    Object.keys(value).length === 1 &&
+    Array.isArray(value?.selectedValues) &&
+    value?.selectedValues.length > 0 &&
+    typeof value?.selectedValues[0] === 'string'
+  );
+}
+
+function isRangeFilter(value) {
+  return (
+    Object.keys(value).length === 2 &&
+    typeof value?.lowerBound === 'number' &&
+    typeof value?.upperBound === 'number' &&
+    value?.lowerBound < value?.upperBound
+  );
+}
+
 /**
  * Validates the provide filter value based on configuration.
  * Performs the following checks:
@@ -72,11 +94,17 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
  * @param {{ tabs: { fields: string[] }[] }} filterConfig
  */
 export function validateFilter(value, filterConfig) {
-  if (typeof value !== 'object' || value === null || Array.isArray(value))
-    return false;
+  if (!isPlainObject(value)) return false;
 
   const allFields = filterConfig.tabs.flatMap(({ fields }) => fields);
   const testFieldSet = new Set(allFields);
-  for (const key of Object.keys(value)) testFieldSet.add(key);
+  for (const filterContent of Object.values(value))
+    if (
+      isPlainObject(filterContent) &&
+      (isTextFilter(filterContent) || isRangeFilter(filterContent))
+    )
+      testFieldSet.add(key);
+    else return false;
+
   return allFields.length === testFieldSet.size;
 }

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -20,10 +20,12 @@ function IndexOverview({ overviewCounts }) {
 
   let history = useHistory();
   function ButtonToExplorer() {
-    const filter =
+    const search =
       consortium.value === 'total'
-        ? {}
-        : { consortium: { selectedValues: [consortium.value] } };
+        ? undefined
+        : `filter=${JSON.stringify({
+            consortium: { selectedValues: [consortium.value] },
+          })}`;
 
     const enabled =
       overviewCounts !== undefined &&
@@ -34,12 +36,7 @@ function IndexOverview({ overviewCounts }) {
         label='Explore more'
         buttonType='primary'
         enabled={enabled}
-        onClick={() =>
-          history.push({
-            pathname: '/explorer',
-            state: { filter },
-          })
-        }
+        onClick={() => history.push({ pathname: '/explorer', search })}
       />
     );
   }

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -63,7 +63,7 @@ export function logoutListener(state = {}, action) {
  */
 class ProtectedContent extends React.Component {
   static propTypes = {
-    component: PropTypes.elementType.isRequired,
+    children: PropTypes.node.isRequired,
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     match: PropTypes.shape({

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -272,28 +272,20 @@ class ProtectedContent extends React.Component {
         />
       );
 
-    const Component = this.props.component;
-    const ComponentWithProps = () => (
-      <Component
-        params={this.props.match ? this.props.match.params : {}} // router params
-        location={this.props.location}
-        history={this.props.history}
-      />
-    );
-
-    let content = <Spinner />;
+    let content;
+    content = <Spinner />;
     if (
       this.props.isPublic &&
       (this.state.dataLoaded ||
         !this.props.filter ||
         typeof this.props.filter !== 'function')
     )
-      content = <ComponentWithProps />;
+      content = this.props.children;
     else if (!this.props.isPublic && this.state.authenticated)
       content = (
         <>
           <ReduxAuthTimeoutPopup />
-          <ComponentWithProps />
+          {this.props.children}
         </>
       );
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -272,27 +272,23 @@ class ProtectedContent extends React.Component {
         />
       );
 
-    let content;
-    content = <Spinner />;
-    if (
-      this.props.isPublic &&
-      (this.state.dataLoaded ||
-        !this.props.filter ||
-        typeof this.props.filter !== 'function')
-    )
-      content = this.props.children;
-    else if (!this.props.isPublic && this.state.authenticated)
-      content = (
-        <>
-          <ReduxAuthTimeoutPopup />
-          {this.props.children}
-        </>
-      );
-
     const pageClassName = isPageFullScreen(this.props.location.pathname)
       ? 'protected-content protected-content--full-screen'
       : 'protected-content';
-    return <div className={pageClassName}>{content}</div>;
+    return (
+      <div className={pageClassName}>
+        {(this.props.isPublic
+          ? (this.state.dataLoaded ||
+              typeof this.props.filter !== 'function') &&
+            this.props.children
+          : this.state.authenticated && (
+              <>
+                <ReduxAuthTimeoutPopup />
+                {this.props.children}
+              </>
+            )) || <Spinner />}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Ticket: [PEDS-373](https://pcdc.atlassian.net/browse/PEDS-373)

This PR matches applied filter state for Exploration page to its URL using `?filter` search parameter (query string). The filters used in URL only includes those listed in `fields` option in data portal filter configuration (no search fields). If the provided value for `?filter` search parameter is not valid, it will be simply ignored and removed from the URL. The URL value gets updated when users update text/range filters via UI as well.

See the following image for an example using generated data:

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/22449454/117171532-90226080-ad90-11eb-957b-0044af75a41b.png">

This PR can be considered as a modified implementation of https://github.com/uc-cdis/data-portal/pull/807 where the most notable differences include:

* Our version does not add a configuration option to toggle this feature 
* Our version does not encode the filter value into base64 format
    * This is to preserve the interpretability of `?filter` search parameter value

The PR also includes the following changes:

* "Explorer More" button on home Overview component now uses URL to set explorer filter
* Replaces the use of `component` prop with `children` prop for `<ProtectedContent>` component
    * This was required to avoid re-rendering the whole page on URL update 
* Minor refactoring to improve code quality
