### PR TITLE
Use option parameter object in guppy query helpers + other refactors

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -125,23 +125,21 @@ class GuppyWrapper extends React.Component {
    * Download all data from Guppy server and return raw data
    * This function uses current filter argument
    */
-  handleDownloadRawData({ sort, format }) {
+  handleDownloadRawData({ sort = [], format }) {
     // error handling for misconfigured format types
     if (format && !(format in FILE_FORMATS)) {
       // eslint-disable-next-line no-console
       console.error(`Invalid value ${format} found for arg format!`);
     }
-    return downloadDataFromGuppy(
-      this.props.guppyConfig.path,
-      this.props.guppyConfig.type,
-      this.state.accessibleCount,
-      {
-        fields: this.state.rawDataFields,
-        sort: sort || [],
-        filter: this.state.filter,
-        format,
-      }
-    );
+    return downloadDataFromGuppy({
+      path: this.props.guppyConfig.path,
+      type: this.props.guppyConfig.type,
+      size: this.state.accessibleCount,
+      fields: this.state.rawDataFields,
+      sort,
+      filter: this.state.filter,
+      format,
+    });
   }
 
   /**
@@ -150,16 +148,14 @@ class GuppyWrapper extends React.Component {
    * This function uses current filter argument
    */
   handleDownloadRawDataByFields({ fields, sort = [] }) {
-    return downloadDataFromGuppy(
-      this.props.guppyConfig.path,
-      this.props.guppyConfig.type,
-      this.state.accessibleCount,
-      {
-        fields: fields || this.state.rawDataFields,
-        sort,
-        filter: this.state.filter,
-      }
-    );
+    return downloadDataFromGuppy({
+      path: this.props.guppyConfig.path,
+      type: this.props.guppyConfig.type,
+      size: this.state.accessibleCount,
+      fields: fields || this.state.rawDataFields,
+      sort,
+      filter: this.state.filter,
+    });
   }
 
   /**
@@ -178,15 +174,13 @@ class GuppyWrapper extends React.Component {
    * @param {string[]} fields
    */
   handleDownloadRawDataByTypeAndFilter(type, filter, fields) {
-    return downloadDataFromGuppy(
-      this.props.guppyConfig.path,
+    return downloadDataFromGuppy({
+      path: this.props.guppyConfig.path,
       type,
-      this.state.accessibleCount,
-      {
-        fields,
-        filter,
-      }
-    );
+      size: this.state.accessibleCount,
+      fields,
+      filter,
+    });
   }
 
   /**

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -74,10 +74,10 @@ class GuppyWrapper extends React.Component {
   componentDidMount() {
     this._isMounted = true;
 
-    getAllFieldsFromGuppy(
-      this.props.guppyConfig.path,
-      this.props.guppyConfig.type
-    ).then((fields) => {
+    getAllFieldsFromGuppy({
+      path: this.props.guppyConfig.path,
+      type: this.props.guppyConfig.type,
+    }).then((fields) => {
       const rawDataFields =
         this.props.rawDataFields && this.props.rawDataFields.length > 0
           ? this.props.rawDataFields

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -283,16 +283,16 @@ class GuppyWrapper extends React.Component {
     }
 
     // non-nested aggregation
-    return askGuppyForRawData(
-      this.props.guppyConfig.path,
-      this.props.guppyConfig.type,
+    return askGuppyForRawData({
+      path: this.props.guppyConfig.path,
+      type: this.props.guppyConfig.type,
       fields,
-      this.filter,
+      filter: this.filter,
       sort,
       offset,
       size,
-      this.controller.signal
-    ).then((res) => {
+      signal: this.controller.signal,
+    }).then((res) => {
       if (!res || !res.data) {
         throw new Error(
           `Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -202,13 +202,13 @@ class GuppyWrapper extends React.Component {
   fetchAggsDataFromGuppy(filter) {
     if (this._isMounted) this.setState({ isLoadingAggsData: true });
 
-    askGuppyForAggregationData(
-      this.props.guppyConfig.path,
-      this.props.guppyConfig.type,
-      this.state.aggsDataFields,
+    askGuppyForAggregationData({
+      path: this.props.guppyConfig.path,
+      type: this.props.guppyConfig.type,
+      fields: this.state.aggsDataFields,
       filter,
-      this.controller.signal
-    ).then((res) => {
+      signal: this.controller.signal,
+    }).then((res) => {
       if (!res.data)
         console.error(
           `error querying guppy${

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -164,7 +164,11 @@ class GuppyWrapper extends React.Component {
    * @param {object} filter
    */
   handleAskGuppyForTotalCounts(type, filter) {
-    return askGuppyForTotalCounts(this.props.guppyConfig.path, type, filter);
+    return askGuppyForTotalCounts({
+      path: this.props.guppyConfig.path,
+      type,
+      filter,
+    });
   }
 
   /**

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -253,24 +253,24 @@ class GuppyWrapper extends React.Component {
 
     // sub aggregations -- for DAT
     if (this.props.guppyConfig.mainField) {
-      const numericAggregation = this.props.guppyConfig.mainFieldIsNumeric;
-      return askGuppyForSubAggregationData(
-        this.props.guppyConfig.path,
-        this.props.guppyConfig.type,
-        this.props.guppyConfig.mainField,
-        numericAggregation,
-        this.props.guppyConfig.aggFields,
-        [],
-        this.filter,
-        this.controller.signal
-      ).then((res) => {
+      const numericAggAsText = this.props.guppyConfig.mainFieldIsNumeric;
+      return askGuppyForSubAggregationData({
+        path: this.props.guppyConfig.path,
+        type: this.props.guppyConfig.type,
+        mainField: this.props.guppyConfig.mainField,
+        numericAggAsText,
+        termsNestedFields: this.props.guppyConfig.aggFields,
+        missedNestedFields: [],
+        filter: this.filter,
+        signal: this.controller.signal,
+      }).then((res) => {
         if (!res || !res.data) {
           throw new Error(
             `Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`
           );
         }
         const data = res.data._aggregation[this.props.guppyConfig.type];
-        const field = numericAggregation ? 'asTextHistogram' : 'histogram';
+        const field = numericAggAsText ? 'asTextHistogram' : 'histogram';
         const parsedData = data[this.props.guppyConfig.mainField][field];
         if (this._isMounted) {
           if (updateDataWhenReceive) this.setState({ rawData: parsedData });

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -257,27 +257,20 @@ const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (
   searchString,
   offset
 ) => {
-  const NUM_SEARCH_OPTIONS = 20;
   return new Promise((resolve, reject) => {
     // If searchString is empty return just the first NUM_SEARCH_OPTIONS options.
     // This allows the client to show default options in the search filter before
     // the user has started searching.
-    let filter = {};
-    if (searchString) {
-      filter = {
-        search: {
-          keyword: searchString,
-          fields: [field],
-        },
-      };
-    }
+    const gqlFilter = searchString
+      ? { search: { keyword: searchString, fields: [field] } }
+      : undefined;
+
     queryGuppyForRawData({
       path: guppyConfig.path,
       type: guppyConfig.type,
       fields: [field],
-      gqlFilter: filter,
+      gqlFilter,
       offset,
-      size: NUM_SEARCH_OPTIONS,
       withTotalCount: true,
     })
       .then((res) => {

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -271,16 +271,15 @@ const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (
         },
       };
     }
-    queryGuppyForRawData(
-      guppyConfig.path,
-      guppyConfig.type,
-      [field],
-      filter,
-      undefined,
+    queryGuppyForRawData({
+      path: guppyConfig.path,
+      type: guppyConfig.type,
+      fields: [field],
+      gqlFilter: filter,
       offset,
-      NUM_SEARCH_OPTIONS,
-      true
-    )
+      size: NUM_SEARCH_OPTIONS,
+      withTotalCount: true,
+    })
       .then((res) => {
         if (!res.data || !res.data[guppyConfig.type]) {
           resolve({

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -371,28 +371,30 @@ export function askGuppyForAggregationData({ filter, ...opt }) {
   return queryGuppyForAggs({ ...opt, gqlFilter: getGQLFilter(filter) });
 }
 
-export const askGuppyForSubAggregationData = ({
-  path,
-  type,
-  mainField,
-  numericAggAsText,
+/**
+ * @param {object} opt
+ * @param {string} opt.path
+ * @param {string} opt.type
+ * @param {string} opt.mainField
+ * @param {boolean} [opt.numericAggAsText]
+ * @param {string[]} [opt.termsNestedFields]
+ * @param {string[]} [opt.missedNestedFields]
+ * @param {object} [opt.filter]
+ * @param {AbortSignal} [opt.signal]
+ */
+export function askGuppyForSubAggregationData({
   termsNestedFields,
   missedNestedFields,
   filter,
-  signal,
-}) => {
-  const gqlFilter = getGQLFilter(filter);
+  ...opt
+}) {
   return queryGuppyForSubAgg({
-    path,
-    type,
-    mainField,
-    numericAggAsText,
+    ...opt,
     termsFields: termsNestedFields,
     missingFields: missedNestedFields,
-    gqlFilter,
-    signal,
+    gqlFilter: getGQLFilter(filter),
   });
-};
+}
 
 export const askGuppyForRawData = (
   path,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -183,19 +183,18 @@ function queryGuppyForSubAgg({
     });
 }
 
-const rawDataQueryStrForEachField = (field) => {
-  const splittedFieldArray = field.split('.');
-  const splittedField = splittedFieldArray.shift();
-  if (splittedFieldArray.length === 0) {
-    return `
-    ${splittedField}
-    `;
-  }
-  return `
-  ${splittedField} {
-    ${rawDataQueryStrForEachField(splittedFieldArray.join('.'))}
-  }`;
-};
+/**
+ * @param {string} field
+ * @returns {string}
+ */
+function rawDataQueryStrForEachField(field) {
+  const [fieldName, ...nestedFieldNames] = field.split('.');
+  return nestedFieldNames.length === 0
+    ? `${fieldName}`
+    : `${fieldName} {
+      ${rawDataQueryStrForEachField(nestedFieldNames.join('.'))}
+    }`;
+}
 
 /**
  * @param {object} opt
@@ -257,12 +256,9 @@ export function queryGuppyForRawData({
     }`
     : '';
 
-  const processedFields = fields.map((field) =>
-    rawDataQueryStrForEachField(field)
-  );
   const query = `${queryLine} {
     ${dataTypeLine} {
-      ${processedFields.join('\n')}
+      ${fields.map(rawDataQueryStrForEachField).join('\n')}
     }
     ${aggregationFragment}
   }`.replace(/\s+/g, ' ');

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -503,23 +503,28 @@ export function askGuppyForTotalCounts({ path, type, filter }) {
     });
 }
 
-export const getAllFieldsFromGuppy = (path, type) => {
-  const query = `{
-    _mapping {
-      ${type}
-    }
-  }`;
-  const queryBody = { query };
+/**
+ * @param {object} opt
+ * @param {string} opt.path
+ * @param {string} opt.type
+ */
+export function getAllFieldsFromGuppy({ path, type }) {
   return fetch(`${path}${graphqlEndpoint}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(queryBody),
+    body: JSON.stringify({
+      query: `{
+        _mapping {
+          ${type}
+        }
+      }`,
+    }),
   })
     .then((response) => response.json())
     .then((response) => response.data._mapping[type])
     .catch((err) => {
       throw new Error(`Error when getting fields from guppy: ${err}`);
     });
-};
+}

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -359,16 +359,17 @@ export const getGQLFilter = (filterObj) => {
 export const askGuppyAboutArrayTypes = (path) =>
   queryGuppyForStatus(path).then((res) => res.indices);
 
-export const askGuppyForAggregationData = (
-  path,
-  type,
-  fields,
-  filter,
-  signal
-) => {
-  const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs({ path, type, fields, gqlFilter, signal });
-};
+/**
+ * @param {object} opt
+ * @param {string} opt.path
+ * @param {string} opt.type
+ * @param {string[]} opt.fields
+ * @param {object} opt.filter
+ * @param {AbortSignal} [opt.signal]
+ */
+export function askGuppyForAggregationData({ filter, ...opt }) {
+  return queryGuppyForAggs({ ...opt, gqlFilter: getGQLFilter(filter) });
+}
 
 export const askGuppyForSubAggregationData = ({
   path,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -14,15 +14,12 @@ const statusEndpoint = '/_status';
  * @param {string} format
  */
 function jsonToFormat(json, format) {
-  if (format in FILE_DELIMITERS) {
-    const flatJson = Object.keys(json).map((key) =>
-      flat(json[key], { delimiter: '_' })
-    );
-    return papaparse.unparse(flatJson, {
-      delimiter: FILE_DELIMITERS[format],
-    });
-  }
-  return json;
+  return format in FILE_DELIMITERS
+    ? papaparse.unparse(
+        Object.values(json).map((value) => flat(value, { delimiter: '_' })),
+        { delimiter: FILE_DELIMITERS[format] }
+      )
+    : json;
 }
 
 const histogramQueryStrForEachField = (field) => {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -49,34 +49,34 @@ function histogramQueryStrForEachField(field) {
  * @param {AbortSignal} [opt.signal]
  */
 function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
-  const query =
-    gqlFilter !== undefined
-      ? `query ($filter: JSON) {
-          _aggregation {
-            ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-              ${fields.map((field) => histogramQueryStrForEachField(field))}
-            }
-            accessible: ${type} (filter: $filter, accessibility: accessible) {
-              _totalCount
-            }
-            all: ${type} (filter: $filter, accessibility: all) {
-              _totalCount
-            }
+  const query = (gqlFilter !== undefined
+    ? `query ($filter: JSON) {
+        _aggregation {
+          ${type} (filter: $filter, filterSelf: false, accessibility: all) {
+            ${fields.map((field) => histogramQueryStrForEachField(field))}
           }
-        }`
-      : `query {
-          _aggregation {
-            ${type} (accessibility: all) {
-              ${fields.map((field) => histogramQueryStrForEachField(field))}
-            }
-            accessible: ${type} (accessibility: accessible) {
-              _totalCount
-            }
-            all: ${type} (accessibility: all) {
-              _totalCount
-            }
+          accessible: ${type} (filter: $filter, accessibility: accessible) {
+            _totalCount
           }
-        }`;
+          all: ${type} (filter: $filter, accessibility: all) {
+            _totalCount
+          }
+        }
+      }`
+    : `query {
+        _aggregation {
+          ${type} (accessibility: all) {
+            ${fields.map((field) => histogramQueryStrForEachField(field))}
+          }
+          accessible: ${type} (accessibility: accessible) {
+            _totalCount
+          }
+          all: ${type} (accessibility: all) {
+            _totalCount
+          }
+        }
+      }`
+  ).replace(/\s+/g, ' ');
 
   return fetch(`${path}${graphqlEndpoint}`, {
     method: 'POST',
@@ -143,28 +143,25 @@ function queryGuppyForSubAgg({
   gqlFilter,
   signal,
 }) {
-  const query =
-    gqlFilter !== undefined
-      ? `query ($filter: JSON, $nestedAggFields: JSON) {
-          _aggregation {
-              ${type} (filter: $filter, filterSelf: false, nestedAggFields: $nestedAggFields, accessibility: all) {
-                ${nestedHistogramQueryStrForEachField(
-                  mainField,
-                  numericAggAsText
-                )}
-              }
-            }
-          }`
-      : `query ($nestedAggFields: JSON) {
-          _aggregation {
-            ${type} (nestedAggFields: $nestedAggFields, accessibility: all) {
+  const query = (gqlFilter !== undefined
+    ? `query ($filter: JSON, $nestedAggFields: JSON) {
+        _aggregation {
+            ${type} (filter: $filter, filterSelf: false, nestedAggFields: $nestedAggFields, accessibility: all) {
               ${nestedHistogramQueryStrForEachField(
                 mainField,
                 numericAggAsText
               )}
             }
           }
-        }`;
+        }`
+    : `query ($nestedAggFields: JSON) {
+        _aggregation {
+          ${type} (nestedAggFields: $nestedAggFields, accessibility: all) {
+            ${nestedHistogramQueryStrForEachField(mainField, numericAggAsText)}
+          }
+        }
+      }`
+  ).replace(/\s+/g, ' ');
 
   return fetch(`${path}${graphqlEndpoint}`, {
     method: 'POST',
@@ -268,7 +265,7 @@ export function queryGuppyForRawData({
       ${processedFields.join('\n')}
     }
     ${aggregationFragment}
-  }`;
+  }`.replace(/\s+/g, ' ');
 
   return fetch(`${path}${graphqlEndpoint}`, {
     method: 'POST',
@@ -475,22 +472,22 @@ export function downloadDataFromGuppy({
  * @param {object} [opt.filter]
  */
 export function askGuppyForTotalCounts({ path, type, filter }) {
-  const query =
-    filter !== undefined || Object.keys(filter).length > 0
-      ? `query ($filter: JSON) {
-          _aggregation {
-            ${type} (filter: $filter, accessibility: all) {
-              _totalCount
-            }
+  const query = (filter !== undefined || Object.keys(filter).length > 0
+    ? `query ($filter: JSON) {
+        _aggregation {
+          ${type} (filter: $filter, accessibility: all) {
+            _totalCount
           }
-        }`
-      : `query {
-          _aggregation {
-            ${type} (accessibility: all) {
-              _totalCount
-            }
+        }
+      }`
+    : `query {
+        _aggregation {
+          ${type} (accessibility: all) {
+            _totalCount
           }
-        }`;
+        }
+      }`
+  ).replace(/\s+/g, ' ');
 
   return fetch(`${path}${graphqlEndpoint}`, {
     method: 'POST',
@@ -525,7 +522,7 @@ export function getAllFieldsFromGuppy({ path, type }) {
         _mapping {
           ${type}
         }
-      }`,
+      }`.replace(/\s+/g, ' '),
     }),
   })
     .then((response) => response.json())

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -22,23 +22,23 @@ function jsonToFormat(json, format) {
     : json;
 }
 
-const histogramQueryStrForEachField = (field) => {
-  const splittedFieldArray = field.split('.');
-  const splittedField = splittedFieldArray.shift();
-  if (splittedFieldArray.length === 0) {
-    return `
-    ${splittedField} {
-      histogram {
-        key
-        count
-      }
-    }`;
-  }
-  return `
-  ${splittedField} {
-    ${histogramQueryStrForEachField(splittedFieldArray.join('.'))}
-  }`;
-};
+/**
+ * @param {string} field
+ * @returns {string}
+ */
+function histogramQueryStrForEachField(field) {
+  const [fieldName, ...nestedFieldNames] = field.split('.');
+  return nestedFieldNames.length === 0
+    ? `${fieldName} {
+        histogram {
+          key
+          count
+        }
+      }`
+    : `${fieldName} {
+        ${histogramQueryStrForEachField(nestedFieldNames.join('.'))}
+      }`;
+}
 
 /**
  * @param {object} opt

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -396,32 +396,25 @@ export function askGuppyForSubAggregationData({
   });
 }
 
-export const askGuppyForRawData = (
-  path,
-  type,
-  fields,
-  filter,
-  sort,
-  offset = 0,
-  size = 20,
-  signal,
-  format,
-  withTotalCount
-) => {
-  const gqlFilter = getGQLFilter(filter);
+/**
+ * @param {object} opt
+ * @param {string} opt.path
+ * @param {string} opt.type
+ * @param {string[]} opt.fields
+ * @param {object} [opt.filter]
+ * @param {*} [opt.sort]
+ * @param {number} [opt.offset]
+ * @param {number} [opt.size]
+ * @param {AbortSignal} [opt.signal]
+ * @param {string} [opt.format]
+ * @param {boolean} [opt.withTotalCount]
+ */
+export function askGuppyForRawData({ filter, ...opt }) {
   return queryGuppyForRawData({
-    path,
-    type,
-    fields,
-    gqlFilter,
-    sort,
-    offset,
-    size,
-    signal,
-    format,
-    withTotalCount,
+    ...opt,
+    gqlFilter: getGQLFilter(filter),
   });
-};
+}
 
 export const getAllFieldsFromFilterConfigs = (filterTabConfigs) =>
   filterTabConfigs.reduce((acc, cur) => acc.concat(cur.fields), []);
@@ -454,16 +447,15 @@ export const downloadDataFromGuppy = (
       JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)
     );
   }
-  return askGuppyForRawData(
+  return askGuppyForRawData({
     path,
     type,
     fields,
     filter,
     sort,
-    0,
     size,
-    format
-  ).then((res) => {
+    format,
+  }).then((res) => {
     if (res && res.data && res.data[type]) {
       return JSON_FORMAT
         ? res.data[type]

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -407,6 +407,7 @@ export function askGuppyForRawData({ filter, ...opt }) {
 export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
   return filterTabConfigs.flatMap(({ fields }) => fields);
 }
+
 /**
  * Download all data from guppy using fields, filter, and sort args.
  * If total count is less than 10000 this will use normal graphql endpoint

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -204,7 +204,20 @@ const rawDataQueryStrForEachField = (field) => {
   }`;
 };
 
-export const queryGuppyForRawData = (
+/**
+ * @param {object} opt
+ * @param {string} opt.path
+ * @param {string} opt.type
+ * @param {string[]} opt.fields
+ * @param {object} [opt.gqlFilter]
+ * @param {*} [opt.sort]
+ * @param {number} [opt.offset]
+ * @param {number} [opt.size]
+ * @param {AbortSignal} [opt.signal]
+ * @param {string} [opt.format]
+ * @param {boolean} [opt.withTotalCount]
+ */
+export function queryGuppyForRawData({
   path,
   type,
   fields,
@@ -214,8 +227,8 @@ export const queryGuppyForRawData = (
   size = 20,
   signal,
   format,
-  withTotalCount = false
-) => {
+  withTotalCount = false,
+}) {
   const queryArgument = [
     sort ? '$sort: JSON' : '',
     gqlFilter ? '$filter: JSON' : '',
@@ -280,7 +293,7 @@ export const queryGuppyForRawData = (
     .catch((err) => {
       throw new Error(`Error during queryGuppyForRawData ${err}`);
     });
-};
+}
 
 export const getGQLFilter = (filterObj) => {
   const facetsList = [];
@@ -401,7 +414,7 @@ export const askGuppyForRawData = (
   withTotalCount
 ) => {
   const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForRawData(
+  return queryGuppyForRawData({
     path,
     type,
     fields,
@@ -411,8 +424,8 @@ export const askGuppyForRawData = (
     size,
     signal,
     format,
-    withTotalCount
-  );
+    withTotalCount,
+  });
 };
 
 export const getAllFieldsFromFilterConfigs = (filterTabConfigs) =>

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -88,16 +88,22 @@ function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
   }).then((response) => response.json());
 }
 
-const queryGuppyForStatus = (path) =>
-  fetch(`${path}${statusEndpoint}`, {
+/** @param {string} path */
+function queryGuppyForStatus(path) {
+  return fetch(`${path}${statusEndpoint}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
   }).then((response) => response.json());
+}
 
-const nestedHistogramQueryStrForEachField = (mainField, numericAggAsText) => `
-  ${mainField} {
+/**
+ * @param {string} mainField
+ * @param {boolean} numericAggAsText
+ */
+function nestedHistogramQueryStrForEachField(mainField, numericAggAsText) {
+  return `${mainField} {
     ${numericAggAsText ? 'asTextHistogram' : 'histogram'} {
       key
       count
@@ -114,6 +120,7 @@ const nestedHistogramQueryStrForEachField = (mainField, numericAggAsText) => `
       }
     }
   }`;
+}
 
 /**
  * @param {object} opt
@@ -337,9 +344,10 @@ export function getGQLFilter(filter) {
   return { AND: facetsList };
 }
 
-// eslint-disable-next-line max-len
-export const askGuppyAboutArrayTypes = (path) =>
-  queryGuppyForStatus(path).then((res) => res.indices);
+/** @param {string} path */
+export function askGuppyAboutArrayTypes(path) {
+  return queryGuppyForStatus(path).then((res) => res.indices);
+}
 
 /**
  * @param {object} opt
@@ -398,9 +406,10 @@ export function askGuppyForRawData({ filter, ...opt }) {
   });
 }
 
-export const getAllFieldsFromFilterConfigs = (filterTabConfigs) =>
-  filterTabConfigs.reduce((acc, cur) => acc.concat(cur.fields), []);
-
+/** @param {object} filterTabConfigs */
+export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
+  return filterTabConfigs.flatMap(({ fields }) => fields);
+}
 /**
  * Download all data from guppy using fields, filter, and sort args.
  * If total count is less than 10000 this will use normal graphql endpoint


### PR DESCRIPTION
This PR refactors query helpers for guppy to

- use a single object parameter object
    - this improves readability/maintainability for functions with many parameters
- add JSDoc to query helpers
- simplify to improve readability