### PR TITLE
Handle patient ids search param in URL PEDS-403

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -34,10 +34,9 @@ class ConnectedFilter extends React.Component {
 
     // get array types info from guppy
     queryGuppyForStatus(this.props.guppyConfig.path).then((res) => {
-      const keys = Object.keys(res.indices);
-      for (const key of keys)
-        if (res[key].arrayFields && res[key].arrayFields.length > 0)
-          this.arrayFields = this.arrayFields.concat(res[key].arrayFields);
+      for (const { arrayFields } of Object.values(res.indices))
+        if (arrayFields?.length > 0)
+          this.arrayFields = this.arrayFields.concat(arrayFields);
     });
   }
 

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -34,7 +34,7 @@ class ConnectedFilter extends React.Component {
 
     // get array types info from guppy
     queryGuppyForStatus(this.props.guppyConfig.path).then((res) => {
-      const keys = Object.keys(res.indicies);
+      const keys = Object.keys(res.indices);
       for (const key of keys)
         if (res[key].arrayFields && res[key].arrayFields.length > 0)
           this.arrayFields = this.arrayFields.concat(res[key].arrayFields);

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -1,7 +1,7 @@
 /* eslint react/forbid-prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { askGuppyAboutArrayTypes } from '../Utils/queries';
+import { queryGuppyForStatus } from '../Utils/queries';
 import {
   getFilterSections,
   mergeFilters,
@@ -32,8 +32,9 @@ class ConnectedFilter extends React.Component {
   componentDidMount() {
     this._isMounted = true;
 
-    askGuppyAboutArrayTypes(this.props.guppyConfig.path).then((res) => {
-      const keys = Object.keys(res);
+    // get array types info from guppy
+    queryGuppyForStatus(this.props.guppyConfig.path).then((res) => {
+      const keys = Object.keys(res.indicies);
       for (const key of keys)
         if (res[key].arrayFields && res[key].arrayFields.length > 0)
           this.arrayFields = this.arrayFields.concat(res[key].arrayFields);

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -131,13 +131,19 @@ class GuppyWrapper extends React.Component {
       // eslint-disable-next-line no-console
       console.error(`Invalid value ${format} found for arg format!`);
     }
+    const filterForGuppy =
+      this.props.patientIds.length > 0
+        ? mergeFilters(this.filter, {
+            subject_submitter_id: { selectedValues: this.props.patientIds },
+          })
+        : this.state.filter;
     return downloadDataFromGuppy({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       size: this.state.accessibleCount,
       fields: this.state.rawDataFields,
       sort,
-      filter: this.state.filter,
+      filter: filterForGuppy,
       format,
     });
   }
@@ -200,11 +206,18 @@ class GuppyWrapper extends React.Component {
   fetchAggsDataFromGuppy(filter) {
     if (this._isMounted) this.setState({ isLoadingAggsData: true });
 
+    const filterForGuppy =
+      this.props.patientIds.length > 0
+        ? mergeFilters(filter, {
+            subject_submitter_id: { selectedValues: this.props.patientIds },
+          })
+        : filter;
+
     askGuppyForAggregationData({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       fields: this.state.aggsDataFields,
-      filter,
+      filter: filterForGuppy,
       signal: this.controller.signal,
     }).then((res) => {
       if (!res.data)
@@ -249,6 +262,12 @@ class GuppyWrapper extends React.Component {
       return Promise.resolve({ data: [], totalCount: 0 });
     }
 
+    const filterForGuppy =
+      this.props.patientIds.length > 0
+        ? mergeFilters(this.filter, {
+            subject_submitter_id: { selectedValues: this.props.patientIds },
+          })
+        : this.filter;
     // sub aggregations -- for DAT
     if (this.props.guppyConfig.mainField) {
       const numericAggAsText = this.props.guppyConfig.mainFieldIsNumeric;
@@ -259,7 +278,7 @@ class GuppyWrapper extends React.Component {
         numericAggAsText,
         termsNestedFields: this.props.guppyConfig.aggFields,
         missedNestedFields: [],
-        filter: this.filter,
+        filter: filterForGuppy,
         signal: this.controller.signal,
       }).then((res) => {
         if (!res || !res.data) {
@@ -285,7 +304,7 @@ class GuppyWrapper extends React.Component {
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       fields,
-      filter: this.filter,
+      filter: filterForGuppy,
       sort,
       offset,
       size,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -3,9 +3,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  queryGuppyForAggs,
+  queryGuppyForAggregationData,
   queryGuppyForRawData,
-  queryGuppyForSubAgg,
+  queryGuppyForSubAggregationData,
   queryGuppyForTotalCounts,
   downloadDataFromGuppy,
   getAllFieldsFromFilterConfigs,
@@ -214,7 +214,7 @@ class GuppyWrapper extends React.Component {
           })
         : filter;
 
-    queryGuppyForAggs({
+    queryGuppyForAggregationData({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       fields: this.state.aggsDataFields,
@@ -272,7 +272,7 @@ class GuppyWrapper extends React.Component {
     // sub aggregations -- for DAT
     if (this.props.guppyConfig.mainField) {
       const numericAggAsText = this.props.guppyConfig.mainFieldIsNumeric;
-      return queryGuppyForSubAgg({
+      return queryGuppyForSubAggregationData({
         path: this.props.guppyConfig.path,
         type: this.props.guppyConfig.type,
         mainField: this.props.guppyConfig.mainField,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -369,6 +369,7 @@ GuppyWrapper.propTypes = {
   onFilterChange: PropTypes.func,
   adminAppliedPreFilters: PropTypes.object,
   initialAppliedFilters: PropTypes.object,
+  patientIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 GuppyWrapper.defaultProps = {
@@ -376,6 +377,7 @@ GuppyWrapper.defaultProps = {
   rawDataFields: [],
   adminAppliedPreFilters: {},
   initialAppliedFilters: {},
+  patientIds: [],
 };
 
 export default GuppyWrapper;

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -3,13 +3,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  askGuppyForAggregationData,
-  askGuppyForRawData,
-  askGuppyForSubAggregationData,
+  queryGuppyForAggs,
+  queryGuppyForRawData,
+  queryGuppyForSubAgg,
   queryGuppyForTotalCounts,
   downloadDataFromGuppy,
   getAllFieldsFromFilterConfigs,
   getAllFieldsFromGuppy,
+  getGQLFilter,
 } from '../Utils/queries';
 import { FILE_FORMATS } from '../Utils/const';
 import { excludeSelfFilterFromAggsData, mergeFilters } from '../Utils/filters';
@@ -213,11 +214,11 @@ class GuppyWrapper extends React.Component {
           })
         : filter;
 
-    askGuppyForAggregationData({
+    queryGuppyForAggs({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       fields: this.state.aggsDataFields,
-      filter: filterForGuppy,
+      gqlFilter: getGQLFilter(filterForGuppy),
       signal: this.controller.signal,
     }).then((res) => {
       if (!res.data)
@@ -271,14 +272,14 @@ class GuppyWrapper extends React.Component {
     // sub aggregations -- for DAT
     if (this.props.guppyConfig.mainField) {
       const numericAggAsText = this.props.guppyConfig.mainFieldIsNumeric;
-      return askGuppyForSubAggregationData({
+      return queryGuppyForSubAgg({
         path: this.props.guppyConfig.path,
         type: this.props.guppyConfig.type,
         mainField: this.props.guppyConfig.mainField,
         numericAggAsText,
-        termsNestedFields: this.props.guppyConfig.aggFields,
-        missedNestedFields: [],
-        filter: filterForGuppy,
+        termsFields: this.props.guppyConfig.aggFields,
+        missingFields: [],
+        gqlFilter: getGQLFilter(filterForGuppy),
         signal: this.controller.signal,
       }).then((res) => {
         if (!res || !res.data) {
@@ -300,11 +301,11 @@ class GuppyWrapper extends React.Component {
     }
 
     // non-nested aggregation
-    return askGuppyForRawData({
+    return queryGuppyForRawData({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.type,
       fields,
-      filter: filterForGuppy,
+      gqlFilter: getGQLFilter(filterForGuppy),
       sort,
       offset,
       size,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -6,7 +6,7 @@ import {
   askGuppyForAggregationData,
   askGuppyForRawData,
   askGuppyForSubAggregationData,
-  askGuppyForTotalCounts,
+  queryGuppyForTotalCounts,
   downloadDataFromGuppy,
   getAllFieldsFromFilterConfigs,
   getAllFieldsFromGuppy,
@@ -169,8 +169,8 @@ class GuppyWrapper extends React.Component {
    * @param {string} type
    * @param {object} filter
    */
-  handleAskGuppyForTotalCounts(type, filter) {
-    return askGuppyForTotalCounts({
+  handleGetTotalCountsByTypeAndFilter(type, filter) {
+    return queryGuppyForTotalCounts({
       path: this.props.guppyConfig.path,
       type,
       filter,
@@ -345,7 +345,7 @@ class GuppyWrapper extends React.Component {
         allFields: this.state.allFields,
 
         // a callback function which return total counts for any type, with any filter
-        getTotalCountsByTypeAndFilter: this.handleAskGuppyForTotalCounts.bind(
+        getTotalCountsByTypeAndFilter: this.handleGetTotalCountsByTypeAndFilter.bind(
           this
         ),
         downloadRawDataByTypeAndFilter: this.handleDownloadRawDataByTypeAndFilter.bind(

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -48,7 +48,7 @@ function histogramQueryStrForEachField(field) {
  * @param {object} [opt.gqlFilter]
  * @param {AbortSignal} [opt.signal]
  */
-function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
+export function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
   const query = (gqlFilter !== undefined
     ? `query ($filter: JSON) {
         _aggregation {
@@ -89,7 +89,7 @@ function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
 }
 
 /** @param {string} path */
-function queryGuppyForStatus(path) {
+export function queryGuppyForStatus(path) {
   return fetch(`${path}${statusEndpoint}`, {
     method: 'GET',
     headers: {
@@ -133,7 +133,7 @@ function nestedHistogramQueryStrForEachField(mainField, numericAggAsText) {
  * @param {object} [opt.gqlFilter]
  * @param {AbortSignal} [opt.signal]
  */
-function queryGuppyForSubAgg({
+export function queryGuppyForSubAgg({
   path,
   type,
   mainField,
@@ -337,68 +337,6 @@ export function getGQLFilter(filter) {
   return { AND: facetsList };
 }
 
-/** @param {string} path */
-export function askGuppyAboutArrayTypes(path) {
-  return queryGuppyForStatus(path).then((res) => res.indices);
-}
-
-/**
- * @param {object} opt
- * @param {string} opt.path
- * @param {string} opt.type
- * @param {string[]} opt.fields
- * @param {object} opt.filter
- * @param {AbortSignal} [opt.signal]
- */
-export function askGuppyForAggregationData({ filter, ...opt }) {
-  return queryGuppyForAggs({ ...opt, gqlFilter: getGQLFilter(filter) });
-}
-
-/**
- * @param {object} opt
- * @param {string} opt.path
- * @param {string} opt.type
- * @param {string} opt.mainField
- * @param {boolean} [opt.numericAggAsText]
- * @param {string[]} [opt.termsNestedFields]
- * @param {string[]} [opt.missedNestedFields]
- * @param {object} [opt.filter]
- * @param {AbortSignal} [opt.signal]
- */
-export function askGuppyForSubAggregationData({
-  termsNestedFields,
-  missedNestedFields,
-  filter,
-  ...opt
-}) {
-  return queryGuppyForSubAgg({
-    ...opt,
-    termsFields: termsNestedFields,
-    missingFields: missedNestedFields,
-    gqlFilter: getGQLFilter(filter),
-  });
-}
-
-/**
- * @param {object} opt
- * @param {string} opt.path
- * @param {string} opt.type
- * @param {string[]} opt.fields
- * @param {object} [opt.filter]
- * @param {*} [opt.sort]
- * @param {number} [opt.offset]
- * @param {number} [opt.size]
- * @param {AbortSignal} [opt.signal]
- * @param {string} [opt.format]
- * @param {boolean} [opt.withTotalCount]
- */
-export function askGuppyForRawData({ filter, ...opt }) {
-  return queryGuppyForRawData({
-    ...opt,
-    gqlFilter: getGQLFilter(filter),
-  });
-}
-
 /** @param {object} filterTabConfigs */
 export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
   return filterTabConfigs.flatMap(({ fields }) => fields);
@@ -444,11 +382,11 @@ export function downloadDataFromGuppy({
       }).then((res) =>
         JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)
       )
-    : askGuppyForRawData({
+    : queryGuppyForRawData({
         path,
         type,
         fields,
-        filter,
+        gqlFilter: getGQLFilter(filter),
         sort,
         size,
         format,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -468,7 +468,7 @@ export function downloadDataFromGuppy({
  * @param {string} opt.type
  * @param {object} [opt.filter]
  */
-export function askGuppyForTotalCounts({ path, type, filter }) {
+export function queryGuppyForTotalCounts({ path, type, filter }) {
   const query = (filter !== undefined || Object.keys(filter).length > 0
     ? `query ($filter: JSON) {
         _aggregation {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -48,7 +48,13 @@ function histogramQueryStrForEachField(field) {
  * @param {object} [opt.gqlFilter]
  * @param {AbortSignal} [opt.signal]
  */
-export function queryGuppyForAggs({ path, type, fields, gqlFilter, signal }) {
+export function queryGuppyForAggregationData({
+  path,
+  type,
+  fields,
+  gqlFilter,
+  signal,
+}) {
   const query = (gqlFilter !== undefined
     ? `query ($filter: JSON) {
         _aggregation {
@@ -133,7 +139,7 @@ function nestedHistogramQueryStrForEachField(mainField, numericAggAsText) {
  * @param {object} [opt.gqlFilter]
  * @param {AbortSignal} [opt.signal]
  */
-export function queryGuppyForSubAgg({
+export function queryGuppyForSubAggregationData({
   path,
   type,
   mainField,
@@ -179,7 +185,7 @@ export function queryGuppyForSubAgg({
   })
     .then((response) => response.json())
     .catch((err) => {
-      throw new Error(`Error during queryGuppyForSubAgg ${err}`);
+      throw new Error(`Error during queryGuppyForSubAggregationData ${err}`);
     });
 }
 

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -22,8 +22,9 @@ class GuppyDataExplorer extends React.Component {
   constructor(props) {
     super(props);
 
-    let initialAppliedFilters = {};
     const searchParams = new URLSearchParams(props.history.location.search);
+
+    let initialAppliedFilters = {};
     if (searchParams.has('filter')) {
       try {
         const filterInUrl = JSON.parse(decodeURI(searchParams.get('filter')));
@@ -36,8 +37,13 @@ class GuppyDataExplorer extends React.Component {
       }
     }
 
+    const patientIds = searchParams.has('patientIds')
+      ? searchParams.get('patientIds').split(',')
+      : [];
+
     this.state = {
       initialAppliedFilters,
+      patientIds,
     };
     this._isMounted = false;
   }

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -107,6 +107,7 @@ class GuppyDataExplorer extends React.Component {
             accessibleFieldCheckList={
               this.props.guppyConfig.accessibleFieldCheckList
             }
+            patientIds={this.state.patientIds}
           >
             <ExplorerTopMessageBanner
               className='guppy-data-explorer__top-banner'

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -61,14 +61,18 @@ class GuppyDataExplorer extends React.Component {
   };
 
   handleFilterChange = (filter) => {
-    let search = '';
+    const searchParams = new URLSearchParams(
+      this.props.history.location.search
+    );
+    searchParams.delete('filter');
+
     if (filter && Object.keys(filter).length > 0) {
       const allSearchFields = [];
       for (const { searchFields } of this.props.filterConfig.tabs)
         if (searchFields?.length > 0) allSearchFields.push(...searchFields);
 
       if (allSearchFields.length === 0) {
-        search = `filter=${JSON.stringify(filter)}`;
+        searchParams.set('filter', JSON.stringify(filter));
       } else {
         const allSearchFieldSet = new Set(allSearchFields);
         const filterWithoutSearchFields = {};
@@ -77,11 +81,13 @@ class GuppyDataExplorer extends React.Component {
             filterWithoutSearchFields[field] = filter[field];
 
         if (Object.keys(filterWithoutSearchFields).length > 0)
-          search = `filter=${JSON.stringify(filterWithoutSearchFields)}`;
+          searchParams.set('filter', JSON.stringify(filterWithoutSearchFields));
       }
     }
 
-    this.props.history.push({ search });
+    this.props.history.push({
+      search: Array.from(searchParams.entries(), (e) => e.join('=')).join('&'),
+    });
   };
 
   render() {


### PR DESCRIPTION
Ticket: [PEDS-403](https://pcdc.atlassian.net/browse/PEDS-403)

This PR allows the exploration page to handle a new URL search parameter `?patientIds`. Its value should be a comma-separated list of `subject_submitter_id` values and will be combined with the applied filters to fetch data from `guppy`.

This PR also includes some refactoring commits to
- remove a layer of indirection in data fetching helper functions; and
- rename some of the helper functions to clarify their jobs.