### PR TITLE
Create "filter" component for patient ids PEDS-405

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -146,6 +146,7 @@ class ConnectedFilter extends React.Component {
           ),
         }}
         onFilterChange={(e) => this.handleFilterChange(e)}
+        onPatientIdsChange={this.props.onPatientIdsChange}
         hideZero={this.props.hideZero}
         initialAppliedFilters={this.props.initialAppliedFilters}
       />
@@ -168,6 +169,7 @@ ConnectedFilter.propTypes = {
     type: PropTypes.string.isRequired,
   }).isRequired,
   onFilterChange: PropTypes.func,
+  onPatientIdsChange: PropTypes.func,
   className: PropTypes.string,
   fieldMapping: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -147,6 +147,7 @@ class ConnectedFilter extends React.Component {
         }}
         onFilterChange={(e) => this.handleFilterChange(e)}
         onPatientIdsChange={this.props.onPatientIdsChange}
+        patientIds={this.props.patientIds}
         hideZero={this.props.hideZero}
         initialAppliedFilters={this.props.initialAppliedFilters}
       />
@@ -180,6 +181,7 @@ ConnectedFilter.propTypes = {
   tierAccessLimit: PropTypes.number,
   onProcessFilterAggsData: PropTypes.func,
   adminAppliedPreFilters: PropTypes.object,
+  patientIds: PropTypes.arrayOf(PropTypes.string),
   initialAppliedFilters: PropTypes.object,
   receivedAggsData: PropTypes.object,
   lockedTooltipMessage: PropTypes.string,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -96,6 +96,13 @@ class GuppyWrapper extends React.Component {
     this._isMounted = false;
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.patientIds.join(',') !== this.props.patientIds.join(',')) {
+      this.fetchAggsDataFromGuppy(this.state.filter);
+      this.fetchRawDataFromGuppy(this.state.rawDataFields, undefined, true);
+    }
+  }
+
   handleFilterChange(filter) {
     if (this.props.onFilterChange) this.props.onFilterChange(filter);
 

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -365,6 +365,7 @@ class GuppyWrapper extends React.Component {
         guppyConfig: this.props.guppyConfig,
         adminAppliedPreFilters: this.props.adminAppliedPreFilters,
         initialAppliedFilters: this.props.initialAppliedFilters,
+        patientIds: this.props.patientIds,
         receivedAggsData: this.state.receivedAggsData,
       })
     );

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -10,6 +10,7 @@ function ExplorerFilter({
   filterConfig = {},
   guppyConfig = {},
   onFilterChange = () => {},
+  onPatientIdsChange = () => {},
   tierAccessLimit,
   adminAppliedPreFilters = {},
   initialAppliedFilters = {},
@@ -23,6 +24,7 @@ function ExplorerFilter({
     },
     fieldMapping: guppyConfig.fieldMapping,
     onFilterChange,
+    onPatientIdsChange,
     tierAccessLimit,
     adminAppliedPreFilters,
     initialAppliedFilters,
@@ -53,6 +55,7 @@ ExplorerFilter.propTypes = {
   tierAccessLimit: PropTypes.number, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
   initialAppliedFilters: PropTypes.object,
+  onPatientIdsChange: PropTypes.func,
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,6 +14,7 @@ function ExplorerFilter({
   tierAccessLimit,
   adminAppliedPreFilters = {},
   initialAppliedFilters = {},
+  patientIds = [],
   receivedAggsData = {},
 }) {
   const filterProps = {
@@ -27,6 +28,7 @@ function ExplorerFilter({
     onPatientIdsChange,
     tierAccessLimit,
     adminAppliedPreFilters,
+    patientIds,
     initialAppliedFilters,
     receivedAggsData,
     lockedTooltipMessage: `You may only view summary information for this project. You do not have ${guppyConfig.dataType}-level access.`,
@@ -54,6 +56,7 @@ ExplorerFilter.propTypes = {
   onReceiveNewAggsData: PropTypes.func, // inherit from GuppyWrapper
   tierAccessLimit: PropTypes.number, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
+  patientIds: PropTypes.arrayOf(PropTypes.string), // inherit from GuppyWrapper
   initialAppliedFilters: PropTypes.object,
   onPatientIdsChange: PropTypes.func,
 };

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -90,6 +90,21 @@ class GuppyDataExplorer extends React.Component {
     });
   };
 
+  handlePatientIdsChange = (patientIds) => {
+    const searchParams = new URLSearchParams(
+      this.props.history.location.search
+    );
+    searchParams.delete('patientIds');
+
+    if (patientIds.length > 1)
+      searchParams.set('patientIds', patientIds.join(','));
+
+    this.setState({ patientIds });
+    this.props.history.push({
+      search: Array.from(searchParams.entries(), (e) => e.join('=')).join('&'),
+    });
+  };
+
   render() {
     return (
       <ExplorerErrorBoundary>
@@ -126,6 +141,7 @@ class GuppyDataExplorer extends React.Component {
               hideGetAccessButton={this.props.hideGetAccessButton}
               tierAccessLimit={this.props.tierAccessLimit}
               initialAppliedFilters={this.props.initialAppliedFilters}
+              onPatientIdsChange={this.handlePatientIdsChange}
             />
             <ExplorerVisualization
               className='guppy-data-explorer__visualization'

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -96,7 +96,7 @@ class GuppyDataExplorer extends React.Component {
     );
     searchParams.delete('patientIds');
 
-    if (patientIds.length > 1)
+    if (patientIds.length > 0)
       searchParams.set('patientIds', patientIds.join(','));
 
     this.setState({ patientIds });

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -28,6 +28,7 @@ const Popup = ({
                 verticalAlign: 'middle',
                 marginRight: '17px',
                 display: 'inline-flex',
+                fill: 'white',
               }}
             />
           )}

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -13,7 +13,7 @@
 }
 
 .simple-input-field__input {
-  width: 60%;
+  flex-grow: 1;
 }
 
 .simple-input-field__input > input,

--- a/src/components/SimpleInputField.css
+++ b/src/components/SimpleInputField.css
@@ -31,6 +31,10 @@
   width: 100%;
 }
 
+.simple-input-field__input > input[type='file'] {
+  border: none;
+}
+
 .simple-input-field__input > textarea {
   resize: none;
 }

--- a/src/components/SimpleInputField.jsx
+++ b/src/components/SimpleInputField.jsx
@@ -11,7 +11,7 @@ import './SimpleInputField.css';
 function SimpleInputField({ label, input, error }) {
   return (
     <div className='simple-input-field__container'>
-      <label className='simple-input-field__label'>{label}</label>
+      {label && <label className='simple-input-field__label'>{label}</label>}
       <div
         className={
           'simple-input-field__input' +

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import PatientIdFilter from '../PatientIdFilter';
 import './FilterGroup.css';
 
 const removeEmptyFilter = (filterResults) => {
@@ -383,6 +384,10 @@ class FilterGroup extends React.Component {
             </div>
           ))}
         </div>
+        <PatientIdFilter
+          onPatientIdsChange={this.props.onPatientIdsChange}
+          patientIds={this.props.patientIds}
+        />
         <div className='g3-filter-group__collapse'>
           <span
             className='g3-link g3-filter-group__collapse-link'

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -434,6 +434,7 @@ FilterGroup.propTypes = {
     ),
   }).isRequired,
   onFilterChange: PropTypes.func,
+  onPatientIdsChange: PropTypes.func,
   hideZero: PropTypes.bool,
   className: PropTypes.string,
   initialAppliedFilters: PropTypes.object,

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -438,6 +438,7 @@ FilterGroup.propTypes = {
   hideZero: PropTypes.bool,
   className: PropTypes.string,
   initialAppliedFilters: PropTypes.object,
+  patientIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 FilterGroup.defaultProps = {

--- a/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
+++ b/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
@@ -55,6 +55,12 @@ function PatientIdFilter({ onPatientIdsChange, patientIds }) {
           style={{ marginBottom: '.5rem' }}
         >
           <div className='g3-filter-section__title-container'>
+            <div className='g3-filter-section__toggle-icon-container'>
+              <i
+                role='button'
+                className='g3-filter-section__toggle-icon g3-icon g3-icon-color__coal g3-icon--sm g3-icon--star'
+              />
+            </div>
             <div
               className={`g3-filter-section__title${
                 isUsingPatientIds ? ' g3-filter-section__title--active' : ''

--- a/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
+++ b/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
@@ -1,0 +1,143 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import Popup from '../../../components/Popup';
+import SimpleInputField from '../../../components/SimpleInputField';
+import Button from '../Button';
+
+/**
+ * @param {Object} props
+ * @param {Function} props.onPatientIdsChange
+ * @param {string[]} props.patientIds
+ */
+function PatientIdFilter({ onPatientIdsChange, patientIds }) {
+  const isUsingPatientIds = patientIds.length > 0;
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  function openModal() {
+    setIsModalOpen(true);
+  }
+  function closeModal() {
+    setIsModalOpen(false);
+  }
+
+  const [fileContent, setFileContent] = useState(null);
+  const isFileUploaded = fileContent !== null;
+  function handleFileUpload(e) {
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = (e) => setFileContent(e.target.result);
+    reader.readAsText(file);
+  }
+
+  const textareaRef = useRef(null);
+  function handleChange() {
+    let input;
+    if (isFileUploaded) {
+      input = fileContent.replace(/\s/g, '');
+      setFileContent(null);
+    } else {
+      input = textareaRef.current.value.replace(/\s/g, '');
+      textareaRef.current.value = '';
+    }
+
+    onPatientIdsChange(input ? input.split(',') : []);
+    closeModal();
+  }
+  function handleReset() {
+    onPatientIdsChange([]);
+  }
+
+  return (
+    <>
+      <div className='g3-filter-section'>
+        <div
+          className='g3-filter-section__header'
+          style={{ marginBottom: '.5rem' }}
+        >
+          <div className='g3-filter-section__title-container'>
+            <div
+              className={`g3-filter-section__title${
+                isUsingPatientIds ? ' g3-filter-section__title--active' : ''
+              }`}
+            >
+              Patient IDs
+            </div>
+            {isUsingPatientIds && (
+              <div className='g3-filter-section__selected-count-chip'>
+                <div
+                  role='button'
+                  className='g3-filter-section__range-filter-clear-btn'
+                  onClick={handleReset}
+                >
+                  <div className='g3-filter-section__range-filter-clear-btn-text'>
+                    reset
+                  </div>
+                  <div className='g3-filter-section__range-filter-clear-btn-icon'>
+                    <i className='g3-icon g3-icon--sm g3-icon-color__lightgray g3-icon--sm g3-icon--undo'></i>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <Button label='Upload IDs' rightIcon='upload' onClick={openModal} />
+      </div>
+      {isModalOpen && (
+        <Popup
+          iconName='upload'
+          title='Upload Patient IDs to explore'
+          onClose={closeModal}
+          leftButtons={[
+            {
+              caption: 'Back to page',
+              fn: closeModal,
+            },
+          ]}
+          rightButtons={[
+            {
+              caption: 'Explore',
+              fn: handleChange,
+            },
+          ]}
+        >
+          <div>
+            Upload a CSV file containing patient IDs to explore:
+            <br />
+            <SimpleInputField
+              input={
+                <input type='file' accept='.csv' onChange={handleFileUpload} />
+              }
+            />
+          </div>
+          <div>
+            {isFileUploaded
+              ? 'Review the patient IDs in the uploaded file:'
+              : 'Or type a list of patient IDs separated by commas:'}
+          </div>
+
+          <SimpleInputField
+            input={
+              <textarea
+                ref={textareaRef}
+                disabled={isFileUploaded}
+                placeholder={
+                  isFileUploaded
+                    ? fileContent
+                    : 'e.g. patient-id-1, patient-id-2, patient-id-3, ...'
+                }
+              />
+            }
+          />
+        </Popup>
+      )}
+    </>
+  );
+}
+
+PatientIdFilter.propTypes = {
+  onPatientIdsChange: PropTypes.func,
+  patientIds: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default PatientIdFilter;

--- a/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
+++ b/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
@@ -66,7 +66,7 @@ function PatientIdFilter({ onPatientIdsChange, patientIds }) {
                 isUsingPatientIds ? ' g3-filter-section__title--active' : ''
               }`}
             >
-              Patient IDs
+              Patient ID
             </div>
             {isUsingPatientIds && (
               <div className='g3-filter-section__selected-count-chip'>

--- a/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
+++ b/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
 import Popup from '../../../components/Popup';
 import SimpleInputField from '../../../components/SimpleInputField';
 import Button from '../Button';
@@ -50,42 +51,48 @@ function PatientIdFilter({ onPatientIdsChange, patientIds }) {
   return (
     <>
       <div className='g3-filter-section'>
-        <div
-          className='g3-filter-section__header'
-          style={{ marginBottom: '.5rem' }}
+        <Tooltip
+          placement='topLeft'
+          overlay='Patient ID is a special filter and cannot be used in cohorts like other normal filters.'
+          arrowContent={<div className='rc-tooltip-arrow-inner' />}
         >
-          <div className='g3-filter-section__title-container'>
-            <div className='g3-filter-section__toggle-icon-container'>
-              <i
-                role='button'
-                className='g3-filter-section__toggle-icon g3-icon g3-icon-color__coal g3-icon--sm g3-icon--star'
-              />
-            </div>
-            <div
-              className={`g3-filter-section__title${
-                isUsingPatientIds ? ' g3-filter-section__title--active' : ''
-              }`}
-            >
-              Patient ID
-            </div>
-            {isUsingPatientIds && (
-              <div className='g3-filter-section__selected-count-chip'>
-                <div
+          <div
+            className='g3-filter-section__header'
+            style={{ marginBottom: '.5rem' }}
+          >
+            <div className='g3-filter-section__title-container'>
+              <div className='g3-filter-section__toggle-icon-container'>
+                <i
                   role='button'
-                  className='g3-filter-section__range-filter-clear-btn'
-                  onClick={handleReset}
-                >
-                  <div className='g3-filter-section__range-filter-clear-btn-text'>
-                    reset
-                  </div>
-                  <div className='g3-filter-section__range-filter-clear-btn-icon'>
-                    <i className='g3-icon g3-icon--sm g3-icon-color__lightgray g3-icon--sm g3-icon--undo'></i>
+                  className='g3-filter-section__toggle-icon g3-icon g3-icon-color__coal g3-icon--sm g3-icon--star'
+                />
+              </div>
+              <div
+                className={`g3-filter-section__title${
+                  isUsingPatientIds ? ' g3-filter-section__title--active' : ''
+                }`}
+              >
+                Patient ID
+              </div>
+              {isUsingPatientIds && (
+                <div className='g3-filter-section__selected-count-chip'>
+                  <div
+                    role='button'
+                    className='g3-filter-section__range-filter-clear-btn'
+                    onClick={handleReset}
+                  >
+                    <div className='g3-filter-section__range-filter-clear-btn-text'>
+                      reset
+                    </div>
+                    <div className='g3-filter-section__range-filter-clear-btn-icon'>
+                      <i className='g3-icon g3-icon--sm g3-icon-color__lightgray g3-icon--sm g3-icon--undo'></i>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
-        </div>
+        </Tooltip>
 
         <Button label='Upload IDs' rightIcon='upload' onClick={openModal} />
       </div>


### PR DESCRIPTION
Ticket: [PEDS-405](https://pcdc.atlassian.net/browse/PEDS-405)

This PR creates a special "filter" UI component to use patient IDs. This "filter" is visible for all filter tabs and lives outside of the normal filter handling process and relies on what is implemented by #141. To enable this UI, the PR also adds a handler for changes to `patientIds`.

The special filter looks like the following:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/22449454/118151670-7bba1580-b3d9-11eb-9d9d-dfb724cd2d75.png">

Clicking "Upload IDs" button opens the following modal:
<img width="922" alt="image" src="https://user-images.githubusercontent.com/22449454/118052041-aeb3c900-b347-11eb-9f48-93cfe9bb9764.png">

The patient ID values can be then provided by uploading a CSV file or filling out an input element.