### PR TITLE
Make patient ids a config option PEDS-406

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -97,7 +97,7 @@ class GuppyWrapper extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.patientIds.join(',') !== this.props.patientIds.join(',')) {
+    if (prevProps.patientIds?.join(',') !== this.props.patientIds?.join(',')) {
       this.fetchAggsDataFromGuppy(this.state.filter);
       this.fetchRawDataFromGuppy(this.state.rawDataFields, undefined, true);
     }
@@ -140,7 +140,7 @@ class GuppyWrapper extends React.Component {
       console.error(`Invalid value ${format} found for arg format!`);
     }
     const filterForGuppy =
-      this.props.patientIds.length > 0
+      this.props.patientIds?.length > 0
         ? mergeFilters(this.filter, {
             subject_submitter_id: { selectedValues: this.props.patientIds },
           })
@@ -215,7 +215,7 @@ class GuppyWrapper extends React.Component {
     if (this._isMounted) this.setState({ isLoadingAggsData: true });
 
     const filterForGuppy =
-      this.props.patientIds.length > 0
+      this.props.patientIds?.length > 0
         ? mergeFilters(filter, {
             subject_submitter_id: { selectedValues: this.props.patientIds },
           })
@@ -271,7 +271,7 @@ class GuppyWrapper extends React.Component {
     }
 
     const filterForGuppy =
-      this.props.patientIds.length > 0
+      this.props.patientIds?.length > 0
         ? mergeFilters(this.filter, {
             subject_submitter_id: { selectedValues: this.props.patientIds },
           })
@@ -405,7 +405,6 @@ GuppyWrapper.defaultProps = {
   rawDataFields: [],
   adminAppliedPreFilters: {},
   initialAppliedFilters: {},
-  patientIds: [],
 };
 
 export default GuppyWrapper;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,7 +14,7 @@ function ExplorerFilter({
   tierAccessLimit,
   adminAppliedPreFilters = {},
   initialAppliedFilters = {},
-  patientIds = [],
+  patientIds,
   receivedAggsData = {},
 }) {
   const filterProps = {

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -15,6 +15,7 @@ import {
   ButtonConfigType,
   ChartConfigType,
   SurvivalAnalysisConfigType,
+  PatientIdsConfigType,
 } from './configTypeDef';
 import './GuppyDataExplorer.css';
 
@@ -37,9 +38,11 @@ class GuppyDataExplorer extends React.Component {
       }
     }
 
-    const patientIds = searchParams.has('patientIds')
-      ? searchParams.get('patientIds').split(',')
-      : [];
+    const patientIds = props.patientIdsConfig?.enabled
+      ? searchParams.has('patientIds')
+        ? searchParams.get('patientIds').split(',')
+        : []
+      : undefined;
 
     this.state = {
       initialAppliedFilters,
@@ -90,20 +93,24 @@ class GuppyDataExplorer extends React.Component {
     });
   };
 
-  handlePatientIdsChange = (patientIds) => {
-    const searchParams = new URLSearchParams(
-      this.props.history.location.search
-    );
-    searchParams.delete('patientIds');
+  handlePatientIdsChange = this.props.patientIdsConfig?.enabled
+    ? (patientIds) => {
+        const searchParams = new URLSearchParams(
+          this.props.history.location.search
+        );
+        searchParams.delete('patientIds');
 
-    if (patientIds.length > 0)
-      searchParams.set('patientIds', patientIds.join(','));
+        if (patientIds.length > 0)
+          searchParams.set('patientIds', patientIds.join(','));
 
-    this.setState({ patientIds });
-    this.props.history.push({
-      search: Array.from(searchParams.entries(), (e) => e.join('=')).join('&'),
-    });
-  };
+        this.setState({ patientIds });
+        this.props.history.push({
+          search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
+            '&'
+          ),
+        });
+      }
+    : () => {};
 
   render() {
     return (
@@ -169,6 +176,7 @@ GuppyDataExplorer.propTypes = {
   filterConfig: FilterConfigType.isRequired,
   tableConfig: TableConfigType.isRequired,
   survivalAnalysisConfig: SurvivalAnalysisConfigType.isRequired,
+  patientIdsConfig: PatientIdsConfigType,
   chartConfig: ChartConfigType.isRequired,
   buttonConfig: ButtonConfigType.isRequired,
   nodeCountTitle: PropTypes.string,

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -61,3 +61,7 @@ export const SurvivalAnalysisConfigType = PropTypes.shape({
     survival: PropTypes.bool,
   }),
 });
+
+export const PatientIdsConfigType = PropTypes.shape({
+  enabled: PropTypes.bool,
+});

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -82,6 +82,7 @@ class Explorer extends React.Component {
             survivalAnalysisConfig={
               explorerConfig[this.state.tab].survivalAnalysis
             }
+            patientIdsConfig={explorerConfig[this.state.tab].patientIds}
             guppyConfig={{
               path: guppyUrl,
               ...explorerConfig[this.state.tab].guppyConfig,

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -384,10 +384,12 @@ class FilterGroup extends React.Component {
             </div>
           ))}
         </div>
-        <PatientIdFilter
-          onPatientIdsChange={this.props.onPatientIdsChange}
-          patientIds={this.props.patientIds}
-        />
+        {this.props.patientIds && (
+          <PatientIdFilter
+            onPatientIdsChange={this.props.onPatientIdsChange}
+            patientIds={this.props.patientIds}
+          />
+        )}
         <div className='g3-filter-group__collapse'>
           <span
             className='g3-link g3-filter-group__collapse-link'


### PR DESCRIPTION
Ticket: [PEDS-406](https://pcdc.atlassian.net/browse/PEDS-406)

This PR creates a new portal config option to toggle `patientIds`-related features (#141 & #142) on the Exploration page.

The new configuration option is placed under `dataExplorerConfig` and looks like the following:

```json
{
  "dataExplorerConfig": {
    "patientIds": {
      "enable": true
    }
  }
}
```