### PR TITLE
Replace query string pkgs with browser api PEDS-395

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15833,11 +15833,6 @@
         }
       }
     },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -24737,21 +24732,11 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
-    "query-string": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-      "integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -28391,11 +28376,6 @@
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -28544,11 +28524,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-convert": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "postcss-loader": "^5.2.0",
     "postcss-svgo": "^4.0.3",
     "prop-types": "^15.6.0",
-    "query-string": "^7.0.0",
-    "querystring": "^0.2.1",
     "rc-slider": "^9.7.2",
     "rc-tooltip": "^5.1.0",
     "react": "^16.14.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { Suspense } from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import querystring from 'querystring';
 import { Helmet } from 'react-helmet';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
@@ -279,21 +278,20 @@ function App({ store }) {
               path='/:project/search'
               component={(props) => {
                 const queryFilter = () => {
-                  const location = props.location;
-                  const queryParams = querystring.parse(
-                    location.search ? location.search.replace(/^\?+/, '') : ''
+                  const searchParams = new URLSearchParams(
+                    props.location.search
                   );
-                  if (Object.keys(queryParams).length > 0) {
-                    // Linking directly to a search result,
-                    // so kick-off search here (rather than on button click)
-                    return store.dispatch(
-                      submitSearchForm({
-                        project: props.match.params.project,
-                        ...queryParams,
-                      })
-                    );
-                  }
-                  return Promise.resolve('ok');
+
+                  return Array.from(searchParams).length > 0
+                    ? // Linking directly to a search result,
+                      // so kick-off search here (rather than on button click)
+                      store.dispatch(
+                        submitSearchForm({
+                          project: props.match.params.project,
+                          ...Object.fromEntries(searchParams),
+                        })
+                      )
+                    : Promise.resolve('ok');
                 };
                 return (
                   <ProtectedContent filter={queryFilter} {...props}>

--- a/src/GraphQLEditor/ReduxGqlEditor.js
+++ b/src/GraphQLEditor/ReduxGqlEditor.js
@@ -1,14 +1,14 @@
 import { connect } from 'react-redux';
-import queryString from 'query-string';
 import GqlEditor from './GqlEditor';
 
 const mapStateToProps = (state, ownProps) => {
-  const params = queryString.parse(ownProps.location.search);
+  const searchParams = new URLSearchParams(ownProps.location.search);
 
   return {
     schema: state.graphiql.schema,
-    endpointIndex:
-      params && params.endpoint ? parseInt(params.endpoint, 10) : null,
+    endpointIndex: searchParams.has('endpoint')
+      ? parseInt(searchParams.get('endpoint'), 10)
+      : null,
   };
 };
 

--- a/src/Login/Login.jsx
+++ b/src/Login/Login.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import querystring from 'querystring';
 import PropTypes from 'prop-types'; // see https://github.com/facebook/prop-types#prop-types
 import Select, { createFilter } from 'react-select';
 import Button from '../gen3-ui-component/components/Button';
@@ -51,16 +50,14 @@ class Login extends React.Component {
 
   render() {
     const location = this.props.location; // this is the react-router "location"
-    // compose next according to location.from
-    let next = location.from ? `${basename}${location.from}` : basename;
-    // clean up url: no double slashes
-    next = next.replace(/\/+/g, '/');
-    const queryParams = querystring.parse(
-      location.search ? location.search.replace(/^\?+/, '') : ''
-    );
-    if (queryParams.next) {
-      next = basename === '/' ? queryParams.next : basename + queryParams.next;
-    }
+
+    const searchParams = new URLSearchParams(location.search);
+    const next = (searchParams.has('next')
+      ? basename + searchParams.get('next')
+      : location.from
+      ? `${basename}${location.from}`
+      : basename
+    ).replace(/\/+/g, '/'); // clean up url: no double slashes
 
     const loginOptions = {}; // one for each login provider
     this.props.providers.forEach((provider, i) => {

--- a/src/QueryNode/QueryForm.jsx
+++ b/src/QueryNode/QueryForm.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import querystring from 'querystring';
 import Select from 'react-select';
 import Dropdown from '../gen3-ui-component/components/Dropdown';
 import { getSubmitPath } from '../utils';
@@ -12,15 +11,16 @@ class QueryForm extends React.Component {
   };
 
   constructor(props) {
-    const queryParams = querystring.parse(
-      location.search ? location.search.replace(/^\?+/, '') : ''
-    );
+    const searchParams = new URLSearchParams(location.search);
+
     super(props);
     this.state = {
-      selectValue:
-        Object.keys(queryParams).length > 0 && queryParams.node_type
-          ? { value: queryParams.node_type, label: queryParams.node_type }
-          : null,
+      selectValue: searchParams.has('node_type')
+        ? {
+            value: searchParams.get('node_type'),
+            label: searchParams.get('node_type'),
+          }
+        : null,
     };
     this.updateValue = this.updateValue.bind(this);
     this.handleDownloadAll = this.handleDownloadAll.bind(this);

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import queryString from 'query-string';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { AutoSizer, Column, Table } from 'react-virtualized';
@@ -23,8 +22,7 @@ dayjs.extend(customParseFormat);
 
 class MapFiles extends React.Component {
   constructor(props) {
-    const params = queryString.parse(window.location.search);
-    const message = params && params.message ? params.message : null;
+    const searchParams = new URLSearchParams(window.location.search);
     super(props);
     this.state = {
       selectedFilesByGroup: {},
@@ -32,7 +30,7 @@ class MapFiles extends React.Component {
       filesByDate: {},
       isScrolling: false,
       sortedDates: [],
-      message,
+      message: searchParams.get('message'),
       loading: true,
     };
   }


### PR DESCRIPTION
Ticket: [PEDS-395](https://pcdc.atlassian.net/browse/PEDS-395)

This PR replaces the dependencies for parsing search params (i.e. query strings) with built-in `URLSearchParams` browser API. This is made possible because the prior use cases for these packages are all on the browser.