### PR TITLE
Consolidate custom popups into a single component

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
+++ b/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
@@ -15,29 +15,7 @@
   font-style: italic;
 }
 
-.guppy-explorer-cohort__overlay {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(245, 245, 245, 0.9);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 999;
-}
-
 .guppy-explorer-cohort__form {
-  background-color: var(--g3-color__white);
-  border: 1px solid var(--g3-color__silver);
-  border-top: 4px solid var(--pcdc-color__primary);
-  border-radius: 4px;
-  min-height: 200px;
-  width: 100%;
-  max-width: 480px;
-  padding: 2rem 1rem;
-  margin: 0 0.5rem;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import ReactDOM from 'react-dom';
 import cloneDeep from 'lodash.clonedeep';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import SimplePopup from '../../components/SimplePopup';
 import Button from '../../gen3-ui-component/components/Button';
 import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
 import {
@@ -179,26 +179,24 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
           </div>
         </>
       )}
-      {showActionForm &&
-        ReactDOM.createPortal(
-          <div className='guppy-explorer-cohort__overlay'>
-            <CohortActionForm
-              actionType={actionType}
-              currentCohort={cohort}
-              currentFilters={filter}
-              cohorts={cohorts}
-              handlers={{
-                handleOpen,
-                handleSave,
-                handleUpdate,
-                handleDelete,
-                handleClose: closeActionForm,
-              }}
-              isFiltersChanged={isFiltersChanged}
-            />
-          </div>,
-          document.getElementById('root')
-        )}
+      {showActionForm && (
+        <SimplePopup>
+          <CohortActionForm
+            actionType={actionType}
+            currentCohort={cohort}
+            currentFilters={filter}
+            cohorts={cohorts}
+            handlers={{
+              handleOpen,
+              handleSave,
+              handleUpdate,
+              handleDelete,
+              handleClose: closeActionForm,
+            }}
+            isFiltersChanged={isFiltersChanged}
+          />
+        </SimplePopup>
+      )}
     </div>
   );
 }

--- a/src/UserRegistration/UserRegistration.css
+++ b/src/UserRegistration/UserRegistration.css
@@ -1,26 +1,4 @@
-.user-registration__overlay {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(245, 245, 245, 0.9);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 999;
-}
-
 .user-registration__form {
-  background-color: var(--g3-color__white);
-  border: 1px solid var(--g3-color__silver);
-  border-top: 4px solid var(--pcdc-color__primary);
-  border-radius: 4px;
-  min-height: 360px;
-  width: 100%;
-  max-width: 480px;
-  padding: 2rem 1rem;
-  margin: 0 0.5rem;
   text-align: center;
   display: flex;
   flex-direction: column;

--- a/src/UserRegistration/UserRegistration.jsx
+++ b/src/UserRegistration/UserRegistration.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import SimplePopup from '../components/SimplePopup';
 import { headers, userapiPath } from '../localconf';
 import RegistrationForm from './RegistrationForm';
 import './UserRegistration.css';
@@ -37,18 +37,15 @@ function UserRegistration({ shouldRegister, updateAccess }) {
     window.open('http://sam.am/PCDCnews', '_blank');
   }
 
-  return show
-    ? ReactDOM.createPortal(
-        <div className='user-registration__overlay'>
-          <RegistrationForm
-            onClose={handleClose}
-            onRegister={handleRegister}
-            onSubscribe={handleSubscribe}
-          />
-        </div>,
-        document.getElementById('root')
-      )
-    : null;
+  return show ? (
+    <SimplePopup>
+      <RegistrationForm
+        onClose={handleClose}
+        onRegister={handleRegister}
+        onSubscribe={handleSubscribe}
+      />
+    </SimplePopup>
+  ) : null;
 }
 
 UserRegistration.propTypes = {

--- a/src/UserRegistration/UserRegistration.jsx
+++ b/src/UserRegistration/UserRegistration.jsx
@@ -37,15 +37,17 @@ function UserRegistration({ shouldRegister, updateAccess }) {
     window.open('http://sam.am/PCDCnews', '_blank');
   }
 
-  return show ? (
-    <SimplePopup>
-      <RegistrationForm
-        onClose={handleClose}
-        onRegister={handleRegister}
-        onSubscribe={handleSubscribe}
-      />
-    </SimplePopup>
-  ) : null;
+  return (
+    show && (
+      <SimplePopup>
+        <RegistrationForm
+          onClose={handleClose}
+          onRegister={handleRegister}
+          onSubscribe={handleSubscribe}
+        />
+      </SimplePopup>
+    )
+  );
 }
 
 UserRegistration.propTypes = {

--- a/src/components/SimplePopup.css
+++ b/src/components/SimplePopup.css
@@ -1,0 +1,24 @@
+.simple-popup__overlay {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(245, 245, 245, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.simple-popup__main {
+  background-color: var(--g3-color__white);
+  border: 1px solid var(--g3-color__silver);
+  border-top: 4px solid var(--pcdc-color__primary);
+  border-radius: 4px;
+  min-height: 200px;
+  width: 100%;
+  max-width: 480px;
+  padding: 2rem 1rem;
+  margin: 0 0.5rem;
+}

--- a/src/components/SimplePopup.jsx
+++ b/src/components/SimplePopup.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import './SimplePopup.css';
+
+/**
+ * @param {Object} props
+ * @param {React.ReactNode} props.children
+ */
+function SimplePopup({ children }) {
+  return ReactDOM.createPortal(
+    <div className='simple-popup__overlay'>
+      <div className='simple-popup__main'>{children}</div>
+    </div>,
+    document.getElementById('root')
+  );
+}
+
+SimplePopup.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+};
+
+export default SimplePopup;


### PR DESCRIPTION
This PR consolidates the simple overlay dialogue/modal element (see image below) used in multiple places into a single component to improve re-usability and maintainability. 

<img width="537" alt="image" src="https://user-images.githubusercontent.com/22449454/118333364-324cf180-b4d1-11eb-912f-50dcf12d3a15.png">

The component name `<SimplePopup>` is chosen to note its similarity in use with the existing overlay dialogue/modal component, i.e. `<Popup>`