### PR TITLE
Add find cohort feature PEDS-355

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFindCohortButton/ExplorerFindCohortButton.css
+++ b/src/GuppyDataExplorer/ExplorerFindCohortButton/ExplorerFindCohortButton.css
@@ -1,0 +1,10 @@
+.explorer-find-cohort__button {
+  margin-right: 10px;
+}
+
+.explorer-find-cohort__form {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}

--- a/src/GuppyDataExplorer/ExplorerFindCohortButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFindCohortButton/index.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+import SimplePopup from '../../components/SimplePopup';
+import SimpleInputField from '../../components/SimpleInputField';
+import Button from '../../gen3-ui-component/components/Button';
+import { fetchWithCreds } from '../../actions';
+import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
+import { stringifyFilters } from '../ExplorerCohort/utils';
+import '../ExplorerCohort/typedef';
+import './ExplorerFindCohortButton.css';
+
+/**
+ * @param {Object} props
+ * @param {ExplorerFilters} props.filter
+ */
+function ExplorerFindCohortButton({ filter }) {
+  const [show, setShow] = useState(false);
+  function openPopup() {
+    setShow(true);
+  }
+  function closePopup() {
+    setShow(false);
+  }
+  async function handleFind() {
+    try {
+      const { data, response, status } = await fetchWithCreds({
+        path: `/analysis/tools/${selected.value}`,
+        method: 'POST',
+        body: JSON.stringify({ filter: getGQLFilter(filter) }),
+      });
+      if (status !== 200) throw response.statusText;
+
+      window.open(data.link, '_blank');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      closePopup();
+    }
+  }
+
+  const emptyOption = {
+    label: 'Select data commons',
+    value: '',
+  };
+  const externalCommonsOptions = [
+    {
+      label: 'Genomic Data Commons',
+      value: 'gdc',
+    },
+  ];
+  const [selected, setSelected] = useState(emptyOption);
+  return (
+    <>
+      <Button
+        className='explorer-find-cohort__button'
+        label={<div>Find Cohort in...</div>}
+        rightIcon='external-link'
+        buttonType='secondary'
+        onClick={openPopup}
+      />
+      {show && (
+        <SimplePopup>
+          <div className='explorer-find-cohort__form'>
+            <h4>Find Cohort in An External Data Commons</h4>
+            <form onKeyDown={(e) => e.key === 'Enter' && e.preventDefault()}>
+              <SimpleInputField
+                label='Data Commons'
+                input={
+                  <Select
+                    options={[emptyOption, ...externalCommonsOptions]}
+                    value={selected}
+                    autoFocus
+                    clearable={false}
+                    theme={(theme) => ({
+                      ...theme,
+                      colors: {
+                        ...theme.colors,
+                        primary: 'var(--pcdc-color__primary)',
+                      },
+                    })}
+                    onChange={setSelected}
+                  />
+                }
+              />
+              <SimpleInputField
+                label='Filters'
+                input={
+                  <textarea
+                    disabled
+                    placeholder='No filters'
+                    value={stringifyFilters(filter)}
+                  />
+                }
+              />
+            </form>
+            <div>
+              <Button
+                className='explorer-find-cohort__button'
+                buttonType='default'
+                label='Back to page'
+                onClick={closePopup}
+              />
+              <Button
+                label='Open in new tab'
+                enabled={selected.value !== ''}
+                onClick={handleFind}
+              />
+            </div>
+          </div>
+        </SimplePopup>
+      )}
+    </>
+  );
+}
+
+ExplorerFindCohortButton.propTypes = {
+  filter: PropTypes.object.isRequired,
+};
+
+export default ExplorerFindCohortButton;

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -6,6 +6,7 @@ import PercentageStackedBarChart from '../../gen3-ui-component/components/charts
 import Spinner from '../../gen3-ui-component/components/Spinner/Spinner';
 import { components } from '../../params';
 import DataSummaryCardGroup from '../../components/cards/DataSummaryCardGroup';
+import ExplorerFindCohortButton from '../ExplorerFindCohortButton';
 import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
 import ReduxExplorerButtonGroup from '../ExplorerButtonGroup/ReduxExplorerButtonGroup';
@@ -15,6 +16,7 @@ import {
   GuppyConfigType,
   SurvivalAnalysisConfigType,
   TableConfigType,
+  PatientIdsConfigType,
 } from '../configTypeDef';
 import './ExplorerVisualization.css';
 
@@ -124,6 +126,7 @@ function ExplorerVisualization({
   guppyConfig = {},
   survivalAnalysisConfig = {},
   tableConfig = {},
+  patientIdsConfig = {},
   nodeCountTitle,
   tierAccessLimit,
 }) {
@@ -198,6 +201,9 @@ function ExplorerVisualization({
           ))}
         </div>
         <div className='guppy-explorer-visualization__button-group'>
+          {patientIdsConfig?.enabled && (
+            <ExplorerFindCohortButton filter={filter} />
+          )}
           <ReduxExplorerButtonGroup {...buttonGroupProps} />
         </div>
       </div>
@@ -281,6 +287,7 @@ ExplorerVisualization.propTypes = {
   guppyConfig: GuppyConfigType,
   survivalAnalysisConfig: SurvivalAnalysisConfigType,
   tableConfig: TableConfigType,
+  patientIdsConfig: PatientIdsConfigType,
   nodeCountTitle: PropTypes.string.isRequired,
   tierAccessLimit: PropTypes.number.isRequired,
 };

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -154,6 +154,7 @@ class GuppyDataExplorer extends React.Component {
               survivalAnalysisConfig={this.props.survivalAnalysisConfig}
               buttonConfig={this.props.buttonConfig}
               guppyConfig={this.props.guppyConfig}
+              patientIdsConfig={this.props.patientIdsConfig}
               history={this.props.history}
               nodeCountTitle={
                 this.props.guppyConfig.nodeCountTitle ||


### PR DESCRIPTION
Ticket: [PEDS-355](https://pcdc.atlassian.net/browse/PEDS-355)

This PR implements "find cohort in" feature originally included in a demo (#114), with the following changes:

* The component is no longer implemented as another "cohort action" type
* The component is rendered conditionally (if `dataExplorerConfig.patientIds.enabled` is `true`)
* The button element is now located next to "download" button (see image below)
<img width="461" alt="image" src="https://user-images.githubusercontent.com/22449454/118538130-6ca5d100-b713-11eb-9552-07d51b8523bf.png">
