### PR TITLE
Update UI for saved cohort feature PEDS-390

### DIFF
--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -21,8 +21,8 @@ export function CohortActionMenu({
   const options = [
     { label: 'New', value: 'new', isDisabled: isCohortEmpty },
     { label: 'Open', value: 'open', isDisabled: hasNoSavedCohorts },
-    { label: isCohortEmpty ? 'Save New' : 'Save As', value: 'save' },
-    { label: 'Update', value: 'update', isDisabled: isCohortEmpty },
+    { label: 'Save', value: 'save' },
+    { label: 'Save As', value: 'save as', isDisabled: isCohortEmpty },
     { label: 'Delete', value: 'delete', isDisabled: isCohortEmpty },
   ];
   return (
@@ -249,7 +249,7 @@ function CohortUpdateForm({
   }
   return (
     <div className='guppy-explorer-cohort__form'>
-      <h4>Update the current Cohort</h4>
+      <h4>Save changes to the current Cohort</h4>
       {isFiltersChanged && (
         <p>
           <FontAwesomeIcon
@@ -400,7 +400,7 @@ export function CohortActionForm({
         />
       );
     case 'save':
-      return (
+      return currentCohort.name === '' ? (
         <CohortSaveForm
           currentCohort={currentCohort}
           currentFilters={currentFilters}
@@ -409,15 +409,24 @@ export function CohortActionForm({
           onAction={handleSave}
           onClose={handleClose}
         />
-      );
-    case 'update':
-      return (
+      ) : (
         <CohortUpdateForm
           currentCohort={currentCohort}
           currentFilters={currentFilters}
           cohorts={cohorts}
           isFiltersChanged={isFiltersChanged}
           onAction={handleUpdate}
+          onClose={handleClose}
+        />
+      );
+    case 'save as':
+      return (
+        <CohortSaveForm
+          currentCohort={currentCohort}
+          currentFilters={currentFilters}
+          cohorts={cohorts}
+          isFiltersChanged={isFiltersChanged}
+          onAction={handleSave}
           onClose={handleClose}
         />
       );

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -1,32 +1,43 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import { stringifyFilters } from './utils';
 import './ExplorerCohort.css';
 import './typedef';
 
-function CohortButton(props) {
-  return <Button className='guppy-explorer-cohort__button' {...props} />;
-}
-
 /**
- * @param {{ labelIcon: IconProp; labelText: string; [x: string]: * }} prop
+ * @param {Object} prop
+ * @param {boolean} prop.isCohortEmpty
+ * @param {({ value: ExplorerCohortActionType }) => void} prop.onSelectAction
  */
-export function CohortActionButton({ labelIcon, labelText, ...attrs }) {
+export function CohortActionMenu({ isCohortEmpty, onSelectAction }) {
+  const options = [
+    { label: 'Open', value: 'open' },
+    { label: isCohortEmpty ? 'Save New' : 'Save As', value: 'save' },
+    { label: 'Update', value: 'update', isDisabled: isCohortEmpty },
+    { label: 'Delete', value: 'delete', isDisabled: isCohortEmpty },
+  ];
   return (
-    <CohortButton
-      buttonType='default'
-      label={
-        <div>
-          {labelText} {labelIcon && <FontAwesomeIcon icon={labelIcon} />}
-        </div>
-      }
-      {...attrs}
+    <Select
+      className='guppy-explorer-cohort__menu'
+      value={{ label: 'Manage Cohorts', value: '' }}
+      options={options}
+      theme={(theme) => ({
+        ...theme,
+        colors: {
+          ...theme.colors,
+          primary: 'var(--pcdc-color__primary)',
+        },
+      })}
+      onChange={onSelectAction}
     />
   );
+}
+
+function CohortButton(props) {
+  return <Button className='guppy-explorer-cohort__button' {...props} />;
 }
 
 /**

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -54,16 +54,12 @@ function CohortButton(props) {
  * @param {() => void} prop.onClose
  */
 function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
-  const emptyOption = {
-    label: 'Open New (no cohort)',
-    value: { name: '', description: '', filters: {} },
-  };
   const options = cohorts.map((cohort) => ({
     label: cohort.name,
     value: cohort,
   }));
   const [selected, setSelected] = useState({
-    label: currentCohort.name || 'Open New (no cohort)',
+    label: currentCohort.name,
     value: currentCohort,
   });
   return (
@@ -74,7 +70,7 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
           label='Name'
           input={
             <Select
-              options={[emptyOption, ...options]}
+              options={options}
               value={selected}
               autoFocus
               clearable={false}
@@ -118,6 +114,7 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
         />
         <CohortButton
           label='Open Cohort'
+          enabled={selected.value.name !== ''}
           onClick={() => onAction(selected.value)}
         />
       </div>

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -10,12 +10,17 @@ import './typedef';
 /**
  * @param {Object} prop
  * @param {boolean} prop.isCohortEmpty
+ * @param {boolean} prop.hasNoSavedCohorts
  * @param {({ value: ExplorerCohortActionType }) => void} prop.onSelectAction
  */
-export function CohortActionMenu({ isCohortEmpty, onSelectAction }) {
+export function CohortActionMenu({
+  isCohortEmpty,
+  hasNoSavedCohorts,
+  onSelectAction,
+}) {
   const options = [
     { label: 'New', value: 'new', isDisabled: isCohortEmpty },
-    { label: 'Open', value: 'open' },
+    { label: 'Open', value: 'open', isDisabled: hasNoSavedCohorts },
     { label: isCohortEmpty ? 'Save New' : 'Save As', value: 'save' },
     { label: 'Update', value: 'update', isDisabled: isCohortEmpty },
     { label: 'Delete', value: 'delete', isDisabled: isCohortEmpty },

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -14,6 +14,7 @@ import './typedef';
  */
 export function CohortActionMenu({ isCohortEmpty, onSelectAction }) {
   const options = [
+    { label: 'New', value: 'new', isDisabled: isCohortEmpty },
     { label: 'Open', value: 'open' },
     { label: isCohortEmpty ? 'Save New' : 'Save As', value: 'save' },
     { label: 'Update', value: 'update', isDisabled: isCohortEmpty },

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -128,10 +128,10 @@ function CohortOpenForm({ currentCohort, cohorts, onAction, onClose }) {
  * @param {ExplorerFilters} prop.currentFilters
  * @param {ExplorerCohort[]} prop.cohorts
  * @param {boolean} prop.isFiltersChanged
- * @param {(saved: ExplorerCohort) => void} prop.onAction
+ * @param {(created: ExplorerCohort) => void} prop.onAction
  * @param {() => void} prop.onClose
  */
-function CohortSaveForm({
+function CohortCreateForm({
   currentCohort,
   currentFilters,
   cohorts,
@@ -367,7 +367,7 @@ function CohortDeleteForm({ currentCohort, onAction, onClose }) {
  * @param {ExplorerCohort[]} prop.cohorts
  * @param {object} prop.handlers
  * @param {(opened: ExplorerCohort) => void} prop.handlers.handleOpen
- * @param {(saved: ExplorerCohort) => void} prop.handlers.handleSave
+ * @param {(created: ExplorerCohort) => void} prop.handlers.handleCreate
  * @param {(updated: ExplorerCohort) => void} prop.handlers.handleUpdate
  * @param {(deleted: ExplorerCohort) => void} prop.handlers.handleDelete
  * @param {() => void} prop.handlers.handleClose
@@ -383,7 +383,7 @@ export function CohortActionForm({
 }) {
   const {
     handleOpen,
-    handleSave,
+    handleCreate,
     handleUpdate,
     handleDelete,
     handleClose,
@@ -401,12 +401,12 @@ export function CohortActionForm({
       );
     case 'save':
       return currentCohort.name === '' ? (
-        <CohortSaveForm
+        <CohortCreateForm
           currentCohort={currentCohort}
           currentFilters={currentFilters}
           cohorts={cohorts}
           isFiltersChanged={isFiltersChanged}
-          onAction={handleSave}
+          onAction={handleCreate}
           onClose={handleClose}
         />
       ) : (
@@ -421,12 +421,12 @@ export function CohortActionForm({
       );
     case 'save as':
       return (
-        <CohortSaveForm
+        <CohortCreateForm
           currentCohort={currentCohort}
           currentFilters={currentFilters}
           cohorts={cohorts}
           isFiltersChanged={isFiltersChanged}
-          onAction={handleSave}
+          onAction={handleCreate}
           onClose={handleClose}
         />
       );

--- a/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/CohortActionComponents.jsx
@@ -320,7 +320,7 @@ function CohortUpdateForm({
           onClick={onClose}
         />
         <CohortButton
-          label='Update Cohort'
+          label='Save changes'
           enabled={
             (isFiltersChanged ||
               cohort.name !== currentCohort.name ||

--- a/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
+++ b/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
@@ -7,6 +7,7 @@
   min-width: 180px;
   margin-left: 2rem;
   text-align: center;
+  z-index: 20;
 }
 
 .guppy-explorer-cohort__button {

--- a/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
+++ b/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
@@ -1,4 +1,5 @@
 .guppy-explorer-cohort__name {
+  font-size: 1.5rem;
   line-height: 1.25;
 }
 

--- a/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
+++ b/src/GuppyDataExplorer/ExplorerCohort/ExplorerCohort.css
@@ -2,9 +2,10 @@
   line-height: 1.25;
 }
 
-.guppy-explorer-cohort__buttons {
-  display: flex;
-  justify-content: flex-end;
+.guppy-explorer-cohort__menu {
+  min-width: 180px;
+  margin-left: 2rem;
+  text-align: center;
 }
 
 .guppy-explorer-cohort__button {

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -54,7 +54,16 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
 
   /** @param {{ value: ExplorerCohortActionType}} e */
   function handleSelectAction({ value }) {
-    openActionForm(value);
+    if (value === 'new') {
+      handleNew();
+    } else {
+      openActionForm(value);
+    }
+  }
+  function handleNew() {
+    const emptyCohort = createEmptyCohort();
+    setCohort(emptyCohort);
+    onOpenCohort(emptyCohort);
   }
   function handleOpen(/** @type {ExplorerCohort} */ opened) {
     setCohort(cloneDeep(opened));

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -10,7 +10,7 @@ import {
   createEmptyCohort,
   truncateWithEllipsis,
   fetchCohorts,
-  saveCohort,
+  createCohort,
   updateCohort,
   deleteCohort,
 } from './utils';
@@ -70,9 +70,9 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     onOpenCohort(cloneDeep(opened));
     closeActionForm();
   }
-  async function handleSave(/** @type {ExplorerCohort} */ saved) {
+  async function handleCreate(/** @type {ExplorerCohort} */ created) {
     try {
-      setCohort(await saveCohort(saved));
+      setCohort(await createCohort(created));
       setCohorts(await fetchCohorts());
     } catch (e) {
       setIsError(true);
@@ -181,7 +181,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
             cohorts={cohorts}
             handlers={{
               handleOpen,
-              handleSave,
+              handleCreate,
               handleUpdate,
               handleDelete,
               handleClose: closeActionForm,

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -144,7 +144,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
             </h1>
             <p>
               {cohort.description ? (
-                truncateWithEllipsis(cohort.description, 80)
+                truncateWithEllipsis(cohort.description, 70)
               ) : (
                 <span className='guppy-explorer-cohort__placeholder'>
                   No description

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -5,7 +5,7 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimplePopup from '../../components/SimplePopup';
 import Button from '../../gen3-ui-component/components/Button';
-import { CohortActionButton, CohortActionForm } from './CohortActionComponents';
+import { CohortActionMenu, CohortActionForm } from './CohortActionComponents';
 import {
   createEmptyCohort,
   truncateWithEllipsis,
@@ -152,31 +152,10 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
               )}
             </p>
           </div>
-          <div className='guppy-explorer-cohort__buttons'>
-            <CohortActionButton
-              labelIcon='folder-open'
-              labelText='Open Cohort'
-              enabled={cohorts.length > 0}
-              onClick={() => openActionForm('open')}
-            />
-            <CohortActionButton
-              labelIcon='save'
-              labelText={`Save ${cohort.name === '' ? 'New' : 'As'}`}
-              onClick={() => openActionForm('save')}
-            />
-            <CohortActionButton
-              labelIcon='pen'
-              labelText='Update Cohort'
-              enabled={cohort.name !== ''}
-              onClick={() => openActionForm('update')}
-            />
-            <CohortActionButton
-              labelIcon='trash-alt'
-              labelText='Delete Cohort'
-              enabled={cohort.name !== ''}
-              onClick={() => openActionForm('delete')}
-            />
-          </div>
+          <CohortActionMenu
+            isCohortEmpty={cohort.name === ''}
+            onSelectAction={(e) => openActionForm(e.value)}
+          />
         </>
       )}
       {showActionForm && (

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -167,6 +167,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
           </div>
           <CohortActionMenu
             isCohortEmpty={cohort.name === ''}
+            hasNoSavedCohorts={cohorts.length === 0}
             onSelectAction={handleSelectAction}
           />
         </>

--- a/src/GuppyDataExplorer/ExplorerCohort/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerCohort/index.jsx
@@ -52,6 +52,10 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
     setShowActionForm(false);
   }
 
+  /** @param {{ value: ExplorerCohortActionType}} e */
+  function handleSelectAction({ value }) {
+    openActionForm(value);
+  }
   function handleOpen(/** @type {ExplorerCohort} */ opened) {
     setCohort(cloneDeep(opened));
     onOpenCohort(cloneDeep(opened));
@@ -154,7 +158,7 @@ function ExplorerCohort({ className, filter, onOpenCohort, onDeleteCohort }) {
           </div>
           <CohortActionMenu
             isCohortEmpty={cohort.name === ''}
-            onSelectAction={(e) => openActionForm(e.value)}
+            onSelectAction={handleSelectAction}
           />
         </>
       )}

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -29,5 +29,5 @@
  */
 
 /**
- * @typedef {'open' | 'save' | 'update' | 'delete'} ExplorerCohortActionType
+ * @typedef {'new' | 'open' | 'save' | 'update' | 'delete'} ExplorerCohortActionType
  */

--- a/src/GuppyDataExplorer/ExplorerCohort/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/typedef.js
@@ -29,5 +29,5 @@
  */
 
 /**
- * @typedef {'new' | 'open' | 'save' | 'update' | 'delete'} ExplorerCohortActionType
+ * @typedef {'new' | 'open' | 'save' | 'save as' | 'delete'} ExplorerCohortActionType
  */

--- a/src/GuppyDataExplorer/ExplorerCohort/utils.js
+++ b/src/GuppyDataExplorer/ExplorerCohort/utils.js
@@ -28,7 +28,7 @@ export function fetchCohorts() {
  * @param {ExplorerCohort} cohort
  * @returns {Promise<ExplorerCohort>}
  */
-export function saveCohort(cohort) {
+export function createCohort(cohort) {
   return fetchWithCreds({
     path: COHORT_URL,
     method: 'POST',

--- a/src/GuppyDataExplorer/GuppyDataExplorer.css
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.css
@@ -27,8 +27,7 @@
 .guppy-data-explorer__cohort {
   width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
 }
 
 /* Tablet width and less */


### PR DESCRIPTION
Ticket: [PEDS-390](https://pcdc.atlassian.net/browse/PEDS-390)

This PR updates the UI for working with saved cohort features. Most notable UI changes include:

* Consolidating a list of cohort action buttons into a single "dropdown button" implemented using `react-select`.
* Restructuring cohort actions
  * Replace "Open New" option from "Open" action with a dedicated "New" action
  * Make "Save" action serve double duty depending on the current cohort (empty vs not)
  * Create a "Save As" action that is available only if the current cohort is not empty
* Reduce the screen estate available for cohort name/description