### PR TITLE
Fix broken sync between filter state and URL on browser navigation PEDS-410

### DIFF
--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -23,36 +23,40 @@ class GuppyDataExplorer extends React.Component {
   constructor(props) {
     super(props);
 
-    const searchParams = new URLSearchParams(props.history.location.search);
-
-    let initialAppliedFilters = {};
-    if (searchParams.has('filter')) {
-      try {
-        const filterInUrl = JSON.parse(decodeURI(searchParams.get('filter')));
-        if (validateFilter(filterInUrl, props.filterConfig))
-          initialAppliedFilters = filterInUrl;
-        else throw undefined;
-      } catch (e) {
-        console.error('Invalid filter value in URL.', e);
-        props.history.push({ search: '' });
-      }
-    }
-
-    const patientIds = props.patientIdsConfig?.enabled
-      ? searchParams.has('patientIds')
-        ? searchParams.get('patientIds').split(',')
-        : []
-      : undefined;
-
     this.state = {
-      initialAppliedFilters,
-      patientIds,
+      initialAppliedFilters: {},
+      patientIds: undefined,
     };
     this._isMounted = false;
   }
 
   componentDidMount() {
     this._isMounted = true;
+    const syncFilterStateWithURL = () => {
+      const searchParams = new URLSearchParams(
+        this.props.history.location.search
+      );
+      let initialAppliedFilters = {};
+      if (searchParams.has('filter'))
+        try {
+          const filterInUrl = JSON.parse(decodeURI(searchParams.get('filter')));
+          if (validateFilter(filterInUrl, this.props.filterConfig))
+            initialAppliedFilters = filterInUrl;
+          else throw undefined;
+        } catch (e) {
+          console.error('Invalid filter value in URL.', e);
+        }
+
+      const patientIds = this.props.patientIdsConfig?.enabled
+        ? searchParams.has('patientIds')
+          ? searchParams.get('patientIds').split(',')
+          : []
+        : undefined;
+
+      this._isMounted && this.setState({ initialAppliedFilters, patientIds });
+    };
+    window.onpopstate = syncFilterStateWithURL;
+    syncFilterStateWithURL();
   }
 
   componentWillUnmount() {

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -28,6 +28,7 @@ class GuppyDataExplorer extends React.Component {
       patientIds: undefined,
     };
     this._isMounted = false;
+    this._isBrowserNavigation = false;
   }
 
   componentDidMount() {
@@ -55,7 +56,11 @@ class GuppyDataExplorer extends React.Component {
 
       this._isMounted && this.setState({ initialAppliedFilters, patientIds });
     };
-    window.onpopstate = syncFilterStateWithURL;
+    window.onpopstate = () => {
+      this._isBrowserNavigation = true;
+      syncFilterStateWithURL();
+      this._isBrowserNavigation = false;
+    };
     syncFilterStateWithURL();
   }
 
@@ -92,9 +97,12 @@ class GuppyDataExplorer extends React.Component {
       }
     }
 
-    this.props.history.push({
-      search: Array.from(searchParams.entries(), (e) => e.join('=')).join('&'),
-    });
+    this._isBrowserNavigation ||
+      this.props.history.push({
+        search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
+          '&'
+        ),
+      });
   };
 
   handlePatientIdsChange = this.props.patientIdsConfig?.enabled
@@ -108,11 +116,12 @@ class GuppyDataExplorer extends React.Component {
           searchParams.set('patientIds', patientIds.join(','));
 
         this.setState({ patientIds });
-        this.props.history.push({
-          search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
-            '&'
-          ),
-        });
+        this._isBrowserNavigation ||
+          this.props.history.push({
+            search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
+              '&'
+            ),
+          });
       }
     : () => {};
 


### PR DESCRIPTION
Ticket: [PEDS-410](https://pcdc.atlassian.net/browse/PEDS-410)

This PR fixes the broken sync between filter (and patient IDs) state and URL search params when user navigates back/forward on browser. This is caused by unhandled `window.onpopstate` event, which updates the URL without parsing its search params to update filter state.