### PR TITLE
Fix survival error on empty filter PEDS-411

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -106,7 +106,7 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
 
     if (shouldUpdateResults)
       fetchResult({
-        filter: transformedFilter,
+        filter: transformedFilter ?? {},
         parameter: requestParameter,
         result: config.result,
       })
@@ -135,7 +135,7 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
       setIsError(false);
       setIsUpdating(true);
       fetchResult({
-        filter: transformedFilter,
+        filter: transformedFilter ?? {},
         parameter: {
           factorVariable: '',
           stratificationVariable: '',


### PR DESCRIPTION
Ticket: [PEDS-411](https://pcdc.atlassian.net/browse/PEDS-411)

This PR fixes sending invalid request to survival analysis backend when the explorer filter is empty. The bug is caused by a recent refactoring effort (#136), which modified the return value for `getGQLFilter()` from `{}` to `undefined` if explorer filter is empty (e92488183cad23a057b0f78971790dbb26e603c6).