### PR TITLE
Add watermark to survival plot PEDS-113

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -60,6 +60,15 @@
   min-height: 300px;
 }
 
+.explorer-survival-analysis .recharts-wrapper {
+  background-blend-mode: lighten;
+  background-color: rgba(255, 255, 255, 0.9);
+  background-image: url(../../img/logo.png);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100%;
+}
+
 .explorer-survival-analysis__risk-table {
   margin: 12px;
   min-height: 150px;


### PR DESCRIPTION
Ticket: [PEDS-113](https://pcdc.atlassian.net/browse/PEDS-113)

This PR uses the PCDC logo to watermark survival plots. See image below for an exmple:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/22449454/118727231-1199da00-b7f8-11eb-99e6-b106c5a3dd7e.png">
