### PR TITLE
Remove obsolete config options PEDS-369

### DIFF
--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -53,9 +53,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
           "resourceIdField": "object_id",
           "referenceIdFieldInResourceIndex": "case_id",
           "referenceIdFieldInDataIndex": "case_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id"
+        }
       },
       "buttons": [
          ...
@@ -90,9 +88,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
           "resourceIdField": "case_id",
           "referenceIdFieldInResourceIndex": "object_id",
           "referenceIdFieldInDataIndex": "object_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
+        }
         "downloadAccessor": "object_id"
       },
       "buttons": [
@@ -135,9 +131,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
         ],
         "nodeCountTitle": "Subjects",
         "manifestMapping": {
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id"
+        }
       },
       "buttons": [
       ],

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -134,7 +134,6 @@ Below is an example, with inline comments describing what each JSON block config
       "text": "This is a generic Gen3 data commons.", // optional; text on the login page
       "contact": "If you have any questions about access or the registration process, please contact ", // optional; text for the contact section of the login page
       "email": "support@datacommons.io", // optional; email for contact
-      "image": "gene" // optional; images displayed on the login page
     },
     "footerLogos": [ // optional; logos to be displayed in the footer, usually sponsors
       {

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -271,9 +271,7 @@ Below is an example, with inline comments describing what each JSON block config
         "resourceIdField": "object_id", // required; what is the identifier in the manifest index that you want to grab?
         "referenceIdFieldInResourceIndex": "case_id", // required; what is the field in the manifest index you want to make sure matches a field in the cohort?
         "referenceIdFieldInDataIndex": "case_id" // required; what is the field in the case/subject/participant index you are using to match with a field in the manifest index?
-      },
-      "accessibleFieldCheckList": ["project_id"], // optional; only useful when tiered access is enabled (tier_access_level=regular). When tiered access is on, portal needs to perform some filtering to display data explorer UI components according to user’s accessibility. Guppy will make queries for each of the fields listed in this array and figure out for each fields, what values are accessible to the current user and what values are not.
-      "accessibleValidationField": "project_id" // optional; only useful when tiered access is enabled (tier_access_level=regular). This value should be selected from the “accessibleFieldCheckList” variable. Portal will use this field to check against the result returned from Guppy with “accessibleFieldCheckList” to determine if user has selected any unaccessible values on the UI, and changes UI appearance accordingly.
+      }
     },
     "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/", // optional; for tiered access, if a user wants to get access to the data sets what site should they visit?
     "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data" // optional; if exporting to Terra which URL should we use?
@@ -322,8 +320,6 @@ Below is an example, with inline comments describing what each JSON block config
         "referenceIdFieldInResourceIndex": "object_id", // required; which field should we join on in the other index?
         "referenceIdFieldInDataIndex": "object_id" // required; which field should we join on in the current index?
       },
-      "accessibleFieldCheckList": ["project_id"],
-      "accessibleValidationField": "project_id",
       "downloadAccessor": "object_id" // required; for downloading a file, what is the GUID? This should probably not change
     },
     "buttons": [ // required; buttons for File Explorer

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -152,10 +152,7 @@ Below is an example, with inline comments describing what each JSON block config
     "categorical2Colors": ["#6d6e70", "#c02f42"] // optional; colors for the graphs when there are only 2 colors (bar and pie graphs usually)
   },
   "requiredCerts": [], // optional; do users need to take a quiz or agree to something before they can access the site?
-  "featureFlags": { // optional; will hide certain parts of the site if needed
-    "explorer": true, // required; indicates the flag and whether to hide it or not
-    "explorerPublic": true // optional; If set to true, the data explorer page would be treated as a public component and can be accessed without login. Data explorer page would be public accessible if 1. tiered access level is set to libre OR 2. this explorerPublic flag is set to true.
-  },
+  "featureFlags": {}, // optional; will hide certain parts of the site if needed
   "dataExplorerConfig": { // required; configuration for the Data Explorer (/explorer)
     "charts": { // optional; indicates which charts to display in the Data Explorer
       "project_id": { // required; GraphQL field to query for a chart (ex: this one will display the number of projects, based on the project_id)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -304,20 +304,18 @@ function App({ store }) {
                 );
               }}
             />
-            {isEnabled('explorer') && (
-              <Route
-                path='/explorer'
-                component={(props) => (
-                  <ProtectedContent {...props}>
-                    <GuppyDataExplorer
-                      history={props.history}
-                      location={props.location}
-                      params={props.match.params}
-                    />
-                  </ProtectedContent>
-                )}
-              />
-            )}
+            <Route
+              path='/explorer'
+              component={(props) => (
+                <ProtectedContent {...props}>
+                  <GuppyDataExplorer
+                    history={props.history}
+                    location={props.location}
+                    params={props.match.params}
+                  />
+                </ProtectedContent>
+              )}
+            />
             {components.privacyPolicy &&
               (!!components.privacyPolicy.file ||
                 !!components.privacyPolicy.routeHref) && (

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -23,7 +23,6 @@ function buildConfig(opts) {
     workspaceURL: process.env.WORKSPACE_URL,
     manifestServiceURL: process.env.MANIFEST_SERVICE_URL,
     gaDebug: !!(process.env.GA_DEBUG && process.env.GA_DEBUG === 'true'),
-    tierAccessLevel: process.env.TIER_ACCESS_LEVEL || 'private',
     tierAccessLimit: Number.parseInt(process.env.TIER_ACCESS_LIMIT, 10) || 1000,
   };
 
@@ -51,7 +50,6 @@ function buildConfig(opts) {
     workspaceURL,
     manifestServiceURL,
     gaDebug,
-    tierAccessLevel,
     tierAccessLimit,
   } = Object.assign({}, defaults, opts);
 
@@ -148,9 +146,6 @@ function buildConfig(opts) {
 
   // for "libre" data commons, explorer page is public
   let explorerPublic = false;
-  if (tierAccessLevel === 'libre') {
-    explorerPublic = true;
-  }
   if (config.featureFlags && config.featureFlags.explorerPublic) {
     explorerPublic = true;
   }
@@ -254,7 +249,6 @@ function buildConfig(opts) {
     externalLoginOptionsUrl,
     showFenceAuthzOnProfile,
     terraExportWarning,
-    tierAccessLevel,
     tierAccessLimit,
     useIndexdAuthz,
     explorerPublic,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -60,7 +60,7 @@ function buildConfig(opts) {
   const submissionApiOauthPath = `${hostname}api/v0/oauth2/`;
   const graphqlPath = `${hostname}api/v0/submission/graphql/`;
   const dataDictionaryTemplatePath = `${hostname}api/v0/submission/template/`;
-  let userapiPath =
+  const userapiPath =
     typeof fenceURL === 'undefined'
       ? `${hostname}user/`
       : ensureTrailingSlash(fenceURL);
@@ -76,7 +76,7 @@ function buildConfig(opts) {
       ? `${hostname}wts/oauth2/`
       : ensureTrailingSlash(wtsURL);
   const externalLoginOptionsUrl = `${hostname}wts/external_oidc/`;
-  let login = {
+  const login = {
     url: `${userapiPath}login/google?redirect=`,
     title: 'Login from Google',
   };
@@ -144,14 +144,6 @@ function buildConfig(opts) {
     categorical2Colors: components.categorical2Colors ?? ['#3283c8', '#e7e7e7'],
   };
 
-  if (app === 'gdc' && typeof fenceURL === 'undefined') {
-    userapiPath = dev === true ? `${hostname}user/` : `${hostname}api/`;
-    login = {
-      url:
-        'https://itrusteauth.nih.gov/affwebservices/public/saml2sso?SPID=https://bionimbus-pdc.opensciencedatacloud.org/shibboleth&RelayState=',
-      title: 'Login from NIH',
-    };
-  }
   const fenceDownloadPath = `${userapiPath}data/download`;
 
   const defaultLineLimit = 30;

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -144,12 +144,6 @@ function buildConfig(opts) {
     terraExportWarning = config.terraExportWarning;
   }
 
-  // for "libre" data commons, explorer page is public
-  let explorerPublic = false;
-  if (config.featureFlags && config.featureFlags.explorerPublic) {
-    explorerPublic = true;
-  }
-
   const enableResourceBrowser = !!config.resourceBrowser;
   let resourceBrowserPublic = false;
   if (config.resourceBrowser && config.resourceBrowser.public) {
@@ -251,7 +245,6 @@ function buildConfig(opts) {
     terraExportWarning,
     tierAccessLimit,
     useIndexdAuthz,
-    explorerPublic,
     authzPath,
     enableResourceBrowser,
     resourceBrowserPublic,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -4,14 +4,14 @@ const { components, requiredCerts, config } = require('./params');
  * Setup configuration variables based on the "app" the data-portal is
  * being deployed into (Brain Health Commons, Blood Pack, ...)
  *
- * @param {app, dev, basename, mockStore, hostname} opts overrides for defaults
+ * @param {Object} opts overrides for defaults
  */
 function buildConfig(opts) {
   const defaults = {
-    dev: !!(process.env.NODE_ENV && process.env.NODE_ENV === 'dev'),
-    mockStore: !!(process.env.MOCK_STORE && process.env.MOCK_STORE === 'true'),
-    app: process.env.APP || 'generic',
-    basename: process.env.BASENAME || '/',
+    dev: process.env.NODE_ENV === 'dev',
+    mockStore: process.env.MOCK_STORE === 'true',
+    app: process.env.APP ?? 'generic',
+    basename: process.env.BASENAME ?? '/',
     hostname:
       typeof window !== 'undefined'
         ? `${window.location.protocol}//${window.location.hostname}/`
@@ -22,20 +22,14 @@ function buildConfig(opts) {
     wtsURL: process.env.WTS_URL,
     workspaceURL: process.env.WORKSPACE_URL,
     manifestServiceURL: process.env.MANIFEST_SERVICE_URL,
-    gaDebug: !!(process.env.GA_DEBUG && process.env.GA_DEBUG === 'true'),
+    gaDebug: process.env.GA_DEBUG === 'true',
     tierAccessLimit: Number.parseInt(process.env.TIER_ACCESS_LIMIT, 10) || 1000,
   };
 
-  //
   // Override default basename if loading via /dev.html
   // dev.html loads bundle.js via https://localhost...
-  //
-  if (
-    typeof location !== 'undefined' &&
-    location.pathname.indexOf(`${defaults.basename}dev.html`) === 0
-  ) {
+  if (location?.pathname.startsWith(`${defaults.basename}dev.html`))
     defaults.basename += 'dev.html';
-  }
 
   const {
     dev,
@@ -91,8 +85,8 @@ function buildConfig(opts) {
       ? `${hostname}authz`
       : `${arboristURL}authz`;
   const loginPath = `${userapiPath}login/`;
-  const logoutInactiveUsers = !(process.env.LOGOUT_INACTIVE_USERS === 'false');
-  const useIndexdAuthz = !(process.env.USE_INDEXD_AUTHZ === 'false');
+  const logoutInactiveUsers = process.env.LOGOUT_INACTIVE_USERS !== 'false';
+  const useIndexdAuthz = process.env.USE_INDEXD_AUTHZ !== 'false';
   const workspaceTimeoutInMinutes =
     process.env.WORKSPACE_TIMEOUT_IN_MINUTES || 480;
   const graphqlSchemaUrl = `${hostname}data/schema.json`;
@@ -114,59 +108,40 @@ function buildConfig(opts) {
       ? `${hostname}manifests/`
       : ensureTrailingSlash(manifestServiceURL);
 
-  let explorerConfig = [];
+  const explorerConfig = config.explorerConfig ?? [];
   // for backward compatibilities
-  if (config.dataExplorerConfig) {
-    explorerConfig.push({
-      tabTitle: 'Data',
-      ...config.dataExplorerConfig,
-    });
-  }
-  if (config.fileExplorerConfig) {
-    explorerConfig.push({
-      tabTitle: 'File',
-      ...config.fileExplorerConfig,
-    });
+  if (explorerConfig.length === 0) {
+    if (config.dataExplorerConfig)
+      explorerConfig.push({
+        tabTitle: 'Data',
+        ...config.dataExplorerConfig,
+      });
+
+    if (config.fileExplorerConfig)
+      explorerConfig.push({
+        tabTitle: 'File',
+        ...config.fileExplorerConfig,
+      });
   }
 
-  // new explorer config format
-  if (config.explorerConfig) {
-    explorerConfig = config.explorerConfig;
-  }
-
-  let showFenceAuthzOnProfile = true;
-  if (config.showFenceAuthzOnProfile === false) {
-    showFenceAuthzOnProfile = config.showFenceAuthzOnProfile;
-  }
-
-  let terraExportWarning;
-  if (config.terraExportWarning) {
-    terraExportWarning = config.terraExportWarning;
-  }
-
-  const enableResourceBrowser = !!config.resourceBrowser;
-  let resourceBrowserPublic = false;
-  if (config.resourceBrowser && config.resourceBrowser.public) {
-    resourceBrowserPublic = true;
-  }
+  const showFenceAuthzOnProfile = config.showFenceAuthzOnProfile ?? true;
+  const terraExportWarning = config.terraExportWarning;
+  const enableResourceBrowser = config.resourceBrowser ?? true;
+  const resourceBrowserPublic = config.resourceBrowser?.public ?? false;
 
   const colorsForCharts = {
-    categorical9Colors: components.categorical9Colors
-      ? components.categorical9Colors
-      : [
-          '#3283c8',
-          '#7ec500',
-          '#ad91ff',
-          '#f4b940',
-          '#e74c3c',
-          '#05b8ee',
-          '#ff7abc',
-          '#ef8523',
-          '#26d9b1',
-        ],
-    categorical2Colors: components.categorical2Colors
-      ? components.categorical2Colors
-      : ['#3283c8', '#e7e7e7'],
+    categorical9Colors: components.categorical9Colors ?? [
+      '#3283c8',
+      '#7ec500',
+      '#ad91ff',
+      '#f4b940',
+      '#e74c3c',
+      '#05b8ee',
+      '#ff7abc',
+      '#ef8523',
+      '#26d9b1',
+    ],
+    categorical2Colors: components.categorical2Colors ?? ['#3283c8', '#e7e7e7'],
   };
 
   if (app === 'gdc' && typeof fenceURL === 'undefined') {
@@ -180,8 +155,7 @@ function buildConfig(opts) {
   const fenceDownloadPath = `${userapiPath}data/download`;
 
   const defaultLineLimit = 30;
-  const lineLimit =
-    config.lineLimit == null ? defaultLineLimit : config.lineLimit;
+  const lineLimit = config.lineLimit ?? defaultLineLimit;
 
   const breakpoints = {
     laptop: 1024,


### PR DESCRIPTION
Ticket: [PEDS-369](https://pcdc.atlassian.net/browse/PEDS-369)

This PR removes now obsolete config options from the code base:
* `tierAccessLevel`(provided as environment variable)
  * Made obsolete by #116 #118 #119  
* `dataExplorerConfig.guppyConfig.accessibleFieldCheckList` & `dataExplorerConfig.guppyConfig.accessibleValidationField`
  *   Made obsolete by #116 #118 #119   
* `featureFlags.explorer` & `featureFlags.explorerPublic`
  * It is clear that the PCDC use case always uses Explorer 
* `components.login.image`
  * Made obsolete by #74

The PR also refactors `src/localconf.js` to improve maintainability & focus on PCDC use case.

Note that this refactoring uses option chaining & null coalescing operator, which requires Node v14 or later for testing. However, I do not consider this a breaking change since `localconf.js` values are intended for in-browser use and the docker image already uses Node 14.