### PR TITLE
Improve accessibility for color contrast PEDS-424

### DIFF
--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -39,19 +39,24 @@
 }
 
 .guppy-explorer-visualization__view-group > button {
-  background-color: transparent;
+  background-color: var(--g3-color__silver);
   border: none;
-  color: var(--pcdc-color__primary);
-  font-weight: bold;
-  padding-left: 20px;
-  padding-right: 20px;
+  color: var(--g3-color__gray);
+  font-weight: var(--g3-font__semi-bold-weight);
+  padding: 0 10px;
+  margin-right: 10px;
   text-transform: capitalize;
   width: auto;
 }
 
+.guppy-explorer-visualization__view-group > button:last-child {
+  margin-right: 0;
+}
+
 .guppy-explorer-visualization__view-group > button.active,
 .guppy-explorer-visualization__view-group > button:hover {
-  color: var(--pcdc-color__secondary);
+  border: 1px solid var(--g3-color__silver);
+  background-color: var(--g3-color__white);
 }
 
 /* Tablet width and less */

--- a/src/gen3-ui-component/css/base.css
+++ b/src/gen3-ui-component/css/base.css
@@ -24,7 +24,7 @@
   --g3-color__black: #000000;
   --g3-color__white: #ffffff;
 
-  --g3-primary-btn__color: var(--g3-color__white);
+  --g3-primary-btn__color: var(--g3-color__black);
   --g3-primary-btn__bg-color: var(--pcdc-color__secondary);
   --g3-primary-btn__bg-color--hover: var(--pcdc-color__secondary-light);
   --g3-primary-btn__border-color: var(--g3-color__lightgray);


### PR DESCRIPTION
Ticket: [PEDS-424](https://pcdc.atlassian.net/browse/PEDS-424)

This PR changes UI style to address insufficient color contrast for the following elements:

* Primary (orange) button
* Exploration visualization tab

See below for before/after comparison:

Before:
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/22449454/121087842-8a160a00-c7aa-11eb-865d-25b0aef3c01b.png">

After:
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/22449454/121087877-94380880-c7aa-11eb-8883-e58e2fd35e88.png">
