### PR TITLE
Implement clear filter button for explorer PEDS-422

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
+++ b/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
@@ -1,0 +1,30 @@
+.guppy-explorer-filter__title-container {
+  display: flex;
+  align-items: baseline;
+}
+
+.guppy-explorer-filter__title {
+  display: inline;
+}
+
+.guppy-explorer-filter__clear-button {
+  height: auto;
+  width: auto;
+  background: none;
+  border: none;
+  padding: none;
+  color: var(--g3-color__gray);
+  font-weight: var(--g3-font__semi-bold-weight);
+  margin-left: 10px;
+}
+
+.guppy-explorer-filter__clear-button:hover {
+  color: var(--g3-color__bg-coal);
+}
+
+.guppy-explorer-filter__clear-button::before {
+  border-left: 1px solid var(--g3-color__lightgray);
+  content: '';
+  height: 1.5rem;
+  margin-right: 10px;
+}

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -2,11 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ConnectedFilter from '../../GuppyComponents/ConnectedFilter';
 import { FilterConfigType, GuppyConfigType } from '../configTypeDef';
+import './ExplorerFilter.css';
 
-function ExplorerFilter({ className = '', ...filterProps }) {
+function ExplorerFilter({
+  className = '',
+  hasAppliedFilters,
+  onFilterClear,
+  ...filterProps
+}) {
   return (
     <div className={className}>
-      <h4>Filters</h4>
+      <div className='guppy-explorer-filter__title-container'>
+        <h4 className='guppy-explorer-filter__title'>Filters</h4>
+        {hasAppliedFilters && (
+          <button
+            type='button'
+            className='guppy-explorer-filter__clear-button'
+            onClick={onFilterClear}
+          >
+            Clear all
+          </button>
+        )}
+      </div>
       <ConnectedFilter {...filterProps} />
     </div>
   );
@@ -21,6 +38,8 @@ ExplorerFilter.propTypes = {
   initialAppliedFilters: PropTypes.object,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   onPatientIdsChange: PropTypes.func,
+  hasAppliedFilters: PropTypes.bool,
+  onFilterClear: PropTypes.func,
   onFilterChange: PropTypes.func, // inherit from GuppyWrapper
   onReceiveNewAggsData: PropTypes.func, // inherit from GuppyWrapper
 };

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -29,6 +29,7 @@ class GuppyDataExplorer extends React.Component {
     };
     this._isMounted = false;
     this._isBrowserNavigation = false;
+    this._hasAppliedFilters = false;
   }
 
   componentDidMount() {
@@ -56,6 +57,7 @@ class GuppyDataExplorer extends React.Component {
           : []
         : undefined;
 
+      this._hasAppliedFilters = Object.keys(initialAppliedFilters).length > 0;
       if (this._isMounted) this.setState({ initialAppliedFilters, patientIds });
     };
     window.onpopstate = () => {
@@ -77,6 +79,7 @@ class GuppyDataExplorer extends React.Component {
     searchParams.delete('filter');
 
     if (filter && Object.keys(filter).length > 0) {
+      this._hasAppliedFilters = true;
       const allSearchFields = [];
       for (const { searchFields } of this.props.filterConfig.tabs)
         if (searchFields?.length > 0) allSearchFields.push(...searchFields);
@@ -93,6 +96,8 @@ class GuppyDataExplorer extends React.Component {
         if (Object.keys(filterWithoutSearchFields).length > 0)
           searchParams.set('filter', JSON.stringify(filterWithoutSearchFields));
       }
+    } else {
+      this._hasAppliedFilters = false;
     }
 
     if (!this._isBrowserNavigation)
@@ -124,6 +129,7 @@ class GuppyDataExplorer extends React.Component {
     : () => {};
 
   updateInitialAppliedFilters = ({ filters }) => {
+    this._hasAppliedFilters = Object.kes(filters).length > 0;
     if (this._isMounted) this.setState({ initialAppliedFilters: filters });
   };
 

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -171,6 +171,8 @@ class GuppyDataExplorer extends React.Component {
               adminAppliedPreFilters={this.props.adminAppliedPreFilters}
               initialAppliedFilters={this.state.initialAppliedFilters}
               patientIds={this.state.patientIds}
+              hasAppliedFilters={this._hasAppliedFilters}
+              onFilterClear={this.clearFilters}
               onPatientIdsChange={this.handlePatientIdsChange}
             />
             <ExplorerVisualization

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -133,6 +133,11 @@ class GuppyDataExplorer extends React.Component {
     if (this._isMounted) this.setState({ initialAppliedFilters: filters });
   };
 
+  clearFilters = () => {
+    this._hasAppliedFilters = false;
+    if (this._isMounted) this.setState({ initialAppliedFilters: {} });
+  };
+
   render() {
     return (
       <ExplorerErrorBoundary>


### PR DESCRIPTION
Ticket: [PEDS-422](https://pcdc.atlassian.net/browse/PEDS-422)

This PR implements a simple "clear all" button for explorer filters (see image below), which stays hidden if no filter is applied. Once clicked, it clears the filters via updating `initialAppliedFilters`.

<img width="360" alt="image" src="https://user-images.githubusercontent.com/22449454/121228023-e122ea00-c851-11eb-99e7-e108d5d2d709.png">
