### PR TITLE
Use single download endpoint PEDS-358

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -146,7 +146,6 @@ class GuppyWrapper extends React.Component {
     return downloadDataFromGuppy({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.dataType,
-      size: this.state.accessibleCount,
       fields: this.state.rawDataFields,
       sort,
       filter: filterForGuppy,
@@ -163,7 +162,6 @@ class GuppyWrapper extends React.Component {
     return downloadDataFromGuppy({
       path: this.props.guppyConfig.path,
       type: this.props.guppyConfig.dataType,
-      size: this.state.accessibleCount,
       fields: fields || this.state.rawDataFields,
       sort,
       filter: this.state.filter,
@@ -193,7 +191,6 @@ class GuppyWrapper extends React.Component {
     return downloadDataFromGuppy({
       path: this.props.guppyConfig.path,
       type,
-      size: this.state.accessibleCount,
       fields,
       filter,
     });

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -351,12 +351,9 @@ export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
 
 /**
  * Download all data from guppy using fields, filter, and sort args.
- * If total count is less than 10000 this will use normal graphql endpoint
- * If greater than 10000, use /download endpoint
  * @param {object} opt
  * @param {string} opt.path
  * @param {string} opt.type
- * @param {number} opt.size
  * @param {string[]} [opt.fields]
  * @param {object} [opt.filter]
  * @param {*} [opt.sort]

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -365,46 +365,27 @@ export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
 export function downloadDataFromGuppy({
   path,
   type,
-  size,
   fields,
   filter,
   sort,
   format,
 }) {
-  const SCROLL_SIZE = 10000;
   const JSON_FORMAT = format === 'json' || format === undefined;
-  return size > SCROLL_SIZE
-    ? fetch(`${path}${downloadEndpoint}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          accessibility: 'accessible',
-          filter: getGQLFilter(filter),
-          type,
-          fields,
-          sort,
-        }),
-      }).then((res) =>
-        JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)
-      )
-    : queryGuppyForRawData({
-        path,
-        type,
-        fields,
-        gqlFilter: getGQLFilter(filter),
-        sort,
-        size,
-        format,
-      }).then((res) => {
-        if (res?.data?.[type])
-          return JSON_FORMAT
-            ? res.data[type]
-            : jsonToFormat(res.data[type], format);
-
-        throw Error('Error downloading data from Guppy');
-      });
+  return fetch(`${path}${downloadEndpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      accessibility: 'accessible',
+      filter: getGQLFilter(filter),
+      type,
+      fields,
+      sort,
+    }),
+  }).then((res) =>
+    JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)
+  );
 }
 
 /**


### PR DESCRIPTION
Ticket: [PEDS-358](https://pcdc.atlassian.net/browse/PEDS-358)

This PR modifies `downloadDataFromGuppy` utility function to always use `/download` endpoint for downloading data. This fixes potential perf issues (see ticket description).