### PR TITLE
Fix explorer failing to extract initial state from url PEDS-439

### DIFF
--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -141,7 +141,7 @@ class GuppyDataExplorer extends React.Component {
     : () => {};
 
   updateInitialAppliedFilters = ({ filters }) => {
-    this._hasAppliedFilters = Object.kes(filters).length > 0;
+    this._hasAppliedFilters = Object.keys(filters).length > 0;
     if (this._isMounted) this.setState({ initialAppliedFilters: filters });
   };
 

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -67,19 +67,15 @@ class GuppyDataExplorer extends React.Component {
 
   componentDidMount() {
     this._isMounted = true;
-    const syncFilterStateWithURL = () => {
+    window.onpopstate = () => {
+      this._isBrowserNavigation = true;
       const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
         new URLSearchParams(this.props.history.location.search),
         this.props.filterConfig,
         this.props.patientIdsConfig
       );
-
       this._hasAppliedFilters = Object.keys(initialAppliedFilters).length > 0;
       if (this._isMounted) this.setState({ initialAppliedFilters, patientIds });
-    };
-    window.onpopstate = () => {
-      this._isBrowserNavigation = true;
-      syncFilterStateWithURL();
       this._isBrowserNavigation = false;
     };
   }

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -50,13 +50,19 @@ class GuppyDataExplorer extends React.Component {
   constructor(props) {
     super(props);
 
+    const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
+      new URLSearchParams(props.history.location.search),
+      props.filterConfig,
+      props.patientIdsConfig
+    );
+
     this.state = {
-      initialAppliedFilters: {},
-      patientIds: undefined,
+      initialAppliedFilters,
+      patientIds,
     };
     this._isMounted = false;
     this._isBrowserNavigation = false;
-    this._hasAppliedFilters = false;
+    this._hasAppliedFilters = Object.keys(initialAppliedFilters).length > 0;
   }
 
   componentDidMount() {
@@ -76,7 +82,6 @@ class GuppyDataExplorer extends React.Component {
       syncFilterStateWithURL();
       this._isBrowserNavigation = false;
     };
-    syncFilterStateWithURL();
   }
 
   componentWillUnmount() {

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -19,6 +19,11 @@ import {
 } from './configTypeDef';
 import './GuppyDataExplorer.css';
 
+/**
+ * @param {URLSearchParams} searchParams
+ * @param {{ tabs: { fields: string[] }[] }} filterConfig
+ * @param {{ enabled?: boolean }} patientIdsConfig
+ */
 function extractExplorerStateFromURL(
   searchParams,
   filterConfig,


### PR DESCRIPTION
Ticket: [PEDS-439](https://pcdc.atlassian.net/browse/PEDS-439)

This PR fixes an issue where `<GuppyDataExplorer>` fails to extract initial state from URL used to make the first set of data queries to guppy, resulting in the initial queries always using empty filter.

This bug is caused by the order in which React invokes lifecycle methods for its component tree (see [this StackOverflow page](https://stackoverflow.com/questions/44654982/in-which-order-are-parent-child-components-rendered)) and was introduced in #149 that moved the initial state extraction from `constructor()` to `componentDidMount()`. In essence, the fix involves moving the logic back to `constructor()`.