### PR TITLE
Add visual feedback to download data button PEDS-438

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -22,6 +22,7 @@ class ExplorerButtonGroup extends React.Component {
     this.state = {
       // for data
       isDownloadingData: false,
+      downloadDataCount: props.accessibleCount,
 
       // for manifest
       manifestEntryCount: 0,
@@ -98,6 +99,18 @@ class ExplorerButtonGroup extends React.Component {
 
   componentWillUnmount() {
     this.props.resetJobState();
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (
+      !state.isDownloadingData &&
+      props.accessibleCount !== state.downloadDataCount
+    ) {
+      return {
+        downloadDataCount: props.accessibleCount,
+      };
+    }
+    return null;
   }
 
   getOnClickFunction = (buttonConfig) => {
@@ -321,7 +334,12 @@ class ExplorerButtonGroup extends React.Component {
           throw Error('Error when downloading data');
         }
       })
-      .finally(() => this.setState({ isDownloadingData: false }));
+      .finally(() =>
+        this.setState({
+          isDownloadingData: false,
+          downloadDataCount: this.props.accessibleCount,
+        })
+      );
   };
 
   downloadManifest = (filename, indexType) => async () => {
@@ -621,7 +639,7 @@ class ExplorerButtonGroup extends React.Component {
     let buttonTitle = buttonConfig.title;
     if (buttonConfig.type === 'data') {
       const buttonCount =
-        this.props.accessibleCount >= 0 ? this.props.accessibleCount : 0;
+        this.state.downloadDataCount >= 0 ? this.state.downloadDataCount : 0;
       buttonTitle = `${buttonConfig.title} (${buttonCount})`;
     } else if (
       buttonConfig.type === 'manifest' &&

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -638,9 +638,7 @@ class ExplorerButtonGroup extends React.Component {
     const clickFunc = this.getOnClickFunction(buttonConfig);
     let buttonTitle = buttonConfig.title;
     if (buttonConfig.type === 'data') {
-      const buttonCount =
-        this.state.downloadDataCount >= 0 ? this.state.downloadDataCount : 0;
-      buttonTitle = `${buttonConfig.title} (${buttonCount})`;
+      buttonTitle = `${buttonConfig.title} (${this.state.downloadDataCount})`;
     } else if (
       buttonConfig.type === 'manifest' &&
       this.state.manifestEntryCount > 0

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -20,6 +20,9 @@ class ExplorerButtonGroup extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      // for data
+      isDownloadingData: false,
+
       // for manifest
       manifestEntryCount: 0,
 
@@ -305,16 +308,20 @@ class ExplorerButtonGroup extends React.Component {
   };
 
   downloadData = (filename) => () => {
-    this.props.downloadRawData({}).then((res) => {
-      if (res) {
-        const blob = new Blob([JSON.stringify(res, null, 2)], {
-          type: 'text/json',
-        });
-        FileSaver.saveAs(blob, filename);
-      } else {
-        throw Error('Error when downloading data');
-      }
-    });
+    this.setState({ isDownloadingData: true });
+    this.props
+      .downloadRawData({})
+      .then((res) => {
+        if (res) {
+          const blob = new Blob([JSON.stringify(res, null, 2)], {
+            type: 'text/json',
+          });
+          FileSaver.saveAs(blob, filename);
+        } else {
+          throw Error('Error when downloading data');
+        }
+      })
+      .finally(() => this.setState({ isDownloadingData: false }));
   };
 
   downloadManifest = (filename, indexType) => async () => {
@@ -574,6 +581,9 @@ class ExplorerButtonGroup extends React.Component {
   isButtonPending = (buttonConfig) => {
     if (this.props.isPending) {
       return true;
+    }
+    if (buttonConfig.type === 'data') {
+      return this.state.isDownloadingData;
     }
     if (
       buttonConfig.type === 'export-to-workspace' ||


### PR DESCRIPTION
Ticket: [PEDS-438](https://pcdc.atlassian.net/browse/PEDS-438)

This PR fixes the UX issue where download data does not provide any visual feedback to indicate that download is in progress. This can lead users to retry download only to find multiple files downloaded later. With the PR, the download button will show as pending while download is in progress and the button count will defer any update until download is complete.