### PR TITLE
Consolidate nested field filters PEDS-453

### DIFF
--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -334,10 +334,7 @@ export function getGQLFilter(filter) {
       // combine mode defaults to OR when not set.
       else facetsPiece.IN = { [fieldName]: filterValues.selectedValues };
 
-    if (!isNestedField) {
-      facetsList.push(facetsPiece);
-    } else {
-      // nested field
+    if (isNestedField) {
       const path = fieldStr; // parent path
       if (nestedFacetIndices[path] === undefined)
         nestedFacetIndices[path] = facetIndex;
@@ -348,6 +345,8 @@ export function getGQLFilter(filter) {
           ...facetsPiece,
         },
       });
+    } else {
+      facetsList.push(facetsPiece);
     }
   }
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -303,8 +303,11 @@ export function getGQLFilter(filter) {
   const nestedFacetIndices = {};
   for (const [field, filterValues] of Object.entries(filter)) {
     facetIndex += 1;
-    const fieldSplitted = field.split('.');
-    const fieldName = fieldSplitted[fieldSplitted.length - 1];
+
+    const [fieldStr, nestedFieldStr] = field.split('.');
+    const isNestedField = nestedFieldStr !== undefined;
+    const fieldName = isNestedField ? nestedFieldStr : fieldStr;
+
     const isRangeFilter =
       typeof filterValues.lowerBound !== 'undefined' &&
       typeof filterValues.upperBound !== 'undefined';
@@ -331,11 +334,11 @@ export function getGQLFilter(filter) {
       // combine mode defaults to OR when not set.
       else facetsPiece.IN = { [fieldName]: filterValues.selectedValues };
 
-    if (fieldSplitted.length === 1) {
+    if (!isNestedField) {
       facetsList.push(facetsPiece);
     } else {
       // nested field
-      const path = fieldSplitted.slice(0, -1).join('.'); // parent path
+      const path = fieldStr; // parent path
       if (nestedFacetIndices[path] === undefined)
         nestedFacetIndices[path] = facetIndex;
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -302,8 +302,6 @@ export function getGQLFilter(filter) {
   const facetsList = [];
   const nestedFacetIndices = {};
   for (const [field, filterValues] of Object.entries(filter)) {
-    facetIndex += 1;
-
     const [fieldStr, nestedFieldStr] = field.split('.');
     const isNestedField = nestedFieldStr !== undefined;
     const fieldName = isNestedField ? nestedFieldStr : fieldStr;
@@ -348,6 +346,8 @@ export function getGQLFilter(filter) {
     } else {
       facetsList.push(facetsPiece);
     }
+
+    facetIndex += 1;
   }
 
   return { AND: facetsList };

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -328,17 +328,17 @@ export function getGQLFilter(filter) {
       // combine mode defaults to OR when not set.
       else facetsPiece.IN = { [fieldName]: filterValues.selectedValues };
 
-    facetsList.push(
-      fieldSplitted.length === 1
-        ? facetsPiece
-        : // nested field
-          {
-            nested: {
-              path: fieldSplitted.slice(0, -1).join('.'), // parent path
-              ...facetsPiece,
-            },
-          }
-    );
+    if (fieldSplitted.length === 1) {
+      facetsList.push(facetsPiece);
+    } else {
+      // nested field
+      facetsList.push({
+        nested: {
+          path: fieldSplitted.slice(0, -1).join('.'), // parent path
+          ...facetsPiece,
+        },
+      });
+    }
   }
 
   return { AND: facetsList };

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -334,8 +334,7 @@ export function getGQLFilter(filter) {
 
     if (isNestedField) {
       const path = fieldStr; // parent path
-      if (nestedFacetIndices[path] === undefined)
-        nestedFacetIndices[path] = facetIndex;
+      if (path in nestedFacetIndices) nestedFacetIndices[path] = facetIndex;
 
       facetsList.push({
         nested: {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -298,8 +298,11 @@ export function getGQLFilter(filter) {
   if (filter === undefined || Object.keys(filter).length === 0)
     return undefined;
 
+  let facetIndex = 0;
   const facetsList = [];
+  const nestedFacetIndices = {};
   for (const [field, filterValues] of Object.entries(filter)) {
+    facetIndex += 1;
     const fieldSplitted = field.split('.');
     const fieldName = fieldSplitted[fieldSplitted.length - 1];
     const isRangeFilter =
@@ -333,6 +336,9 @@ export function getGQLFilter(filter) {
     } else {
       // nested field
       const path = fieldSplitted.slice(0, -1).join('.'); // parent path
+      if (nestedFacetIndices[path] === undefined)
+        nestedFacetIndices[path] = facetIndex;
+
       facetsList.push({
         nested: {
           path,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -334,19 +334,23 @@ export function getGQLFilter(filter) {
 
     if (isNestedField) {
       const path = fieldStr; // parent path
-      if (path in nestedFacetIndices) nestedFacetIndices[path] = facetIndex;
-
-      facetsList.push({
-        nested: {
-          path,
-          ...facetsPiece,
-        },
-      });
+      if (path in nestedFacetIndices) {
+        // @ts-ignore
+        facetsList[nestedFacetIndices[path]].nested.AND.push(facetsPiece);
+      } else {
+        nestedFacetIndices[path] = facetIndex;
+        facetsList.push({
+          nested: {
+            path,
+            AND: [facetsPiece],
+          },
+        });
+        facetIndex += 1;
+      }
     } else {
       facetsList.push(facetsPiece);
+      facetIndex += 1;
     }
-
-    facetIndex += 1;
   }
 
   return { AND: facetsList };

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -332,9 +332,10 @@ export function getGQLFilter(filter) {
       facetsList.push(facetsPiece);
     } else {
       // nested field
+      const path = fieldSplitted.slice(0, -1).join('.'); // parent path
       facetsList.push({
         nested: {
-          path: fieldSplitted.slice(0, -1).join('.'), // parent path
+          path,
           ...facetsPiece,
         },
       });

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -1,0 +1,148 @@
+import { getGQLFilter } from '../Utils/queries';
+
+describe('Get GQL filter from filter object from', () => {
+  test('a simple option filter', async () => {
+    const filter = { a: { selectedValues: ['foo', 'bar'] } };
+    const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('a simple option filter with combine mode OR', () => {
+    const filter = {
+      a: { __combineMode: 'OR', selectedValues: ['foo', 'bar'] },
+    };
+    const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('a simple option filter with combine mode AND', () => {
+    const filter = {
+      a: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
+    };
+    const gqlFilter = {
+      AND: [{ AND: [{ IN: { a: ['foo'] } }, { IN: { a: ['bar'] } }] }],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('a simple range filter', () => {
+    const filter = { a: { lowerBound: 0, upperBound: 1 } };
+    const gqlFilter = {
+      AND: [{ AND: [{ '>=': { a: 0 } }, { '<=': { a: 1 } }] }],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('simple filters', () => {
+    const filter = {
+      a: { selectedValues: ['foo', 'bar'] },
+      b: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
+      c: { lowerBound: 0, upperBound: 1 },
+    };
+    const gqlFilter = {
+      AND: [
+        { IN: { a: ['foo', 'bar'] } },
+        { AND: [{ IN: { b: ['foo'] } }, { IN: { b: ['bar'] } }] },
+        { AND: [{ '>=': { c: 0 } }, { '<=': { c: 1 } }] },
+      ],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('a combine mode only filter', () => {
+    const filter = { a: { __combineMode: 'OR' } };
+    const gqlFilter = { AND: [] };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('an invalid filter', () => {
+    const filter = { a: {} };
+    expect(() => getGQLFilter(filter)).toThrow(
+      `Invalid filter object ${filter.a}`
+    );
+  });
+
+  test('a nested filter', () => {
+    const filter = { 'a.b': { selectedValues: ['foo', 'bar'] } };
+    const gqlFilter = {
+      AND: [{ nested: { path: 'a', AND: [{ IN: { b: ['foo', 'bar'] } }] } }],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('nested filters with same parent path', () => {
+    const filter = {
+      'a.b': { selectedValues: ['foo', 'bar'] },
+      'a.c': { lowerBound: 0, upperBound: 1 },
+    };
+    const gqlFilter = {
+      AND: [
+        {
+          nested: {
+            path: 'a',
+            AND: [
+              { IN: { b: ['foo', 'bar'] } },
+              { AND: [{ '>=': { c: 0 } }, { '<=': { c: 1 } }] },
+            ],
+          },
+        },
+      ],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('nested filters with different parent paths', () => {
+    const filter = {
+      'a.b': { selectedValues: ['foo', 'bar'] },
+      'c.d': { lowerBound: 0, upperBound: 1 },
+    };
+    const gqlFilter = {
+      AND: [
+        {
+          nested: {
+            path: 'a',
+            AND: [{ IN: { b: ['foo', 'bar'] } }],
+          },
+        },
+        {
+          nested: {
+            path: 'c',
+            AND: [{ AND: [{ '>=': { d: 0 } }, { '<=': { d: 1 } }] }],
+          },
+        },
+      ],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
+  test('various filters', () => {
+    const filter = {
+      a: { selectedValues: ['foo', 'bar'] },
+      'b.c': { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
+      'b.d': { lowerBound: 0, upperBound: 1 },
+      e: { __combineMode: 'OR' },
+      'f.g': { lowerBound: 0, upperBound: 1 },
+    };
+    const gqlFilter = {
+      AND: [
+        { IN: { a: ['foo', 'bar'] } },
+        {
+          nested: {
+            path: 'b',
+            AND: [
+              { AND: [{ IN: { c: ['foo'] } }, { IN: { c: ['bar'] } }] },
+              { AND: [{ '>=': { d: 0 } }, { '<=': { d: 1 } }] },
+            ],
+          },
+        },
+        {
+          nested: {
+            path: 'f',
+            AND: [{ AND: [{ '>=': { g: 0 } }, { '<=': { g: 1 } }] }],
+          },
+        },
+      ],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+});


### PR DESCRIPTION
Ticket: [PEDS-453](https://pcdc.atlassian.net/browse/PEDS-453)

This PR modifies `getGQLFilter()` body to combine filters for nested fields with the same parent field, consolidating them into a single nested filter object. The PR also adds tests to exercise `getGQLFilter()` based on updated behavior.

This PR contains some refactoring commits, including one that's on the following assumptions (561a4e5):

* Nesting fields goes only up to one level (e.g. `foo` or `foo.bar` is allowed; `foo.bar.baz` is not)
* Field name never includes `.` (period), which is reserved to indicate nesting.