### PR TITLE
Update patient ids config PEDS-457

### DIFF
--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -208,7 +208,7 @@ function ExplorerVisualization({
           ))}
         </div>
         <div className='guppy-explorer-visualization__button-group'>
-          {patientIdsConfig?.enabled && (
+          {patientIdsConfig?.enabled && patientIdsConfig?.export && (
             <ExplorerFindCohortButton filter={filter} />
           )}
           <ReduxExplorerButtonGroup {...buttonGroupProps} />

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -208,7 +208,7 @@ function ExplorerVisualization({
           ))}
         </div>
         <div className='guppy-explorer-visualization__button-group'>
-          {patientIdsConfig?.enabled && patientIdsConfig?.export && (
+          {patientIdsConfig?.export && (
             <ExplorerFindCohortButton filter={filter} />
           )}
           <ReduxExplorerButtonGroup {...buttonGroupProps} />

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -22,7 +22,7 @@ import './GuppyDataExplorer.css';
 /**
  * @param {URLSearchParams} searchParams
  * @param {{ tabs: { fields: string[] }[] }} filterConfig
- * @param {{ enabled?: boolean; export?: boolean }} patientIdsConfig
+ * @param {{ filter?: boolean; export?: boolean }} patientIdsConfig
  */
 function extractExplorerStateFromURL(
   searchParams,
@@ -42,7 +42,7 @@ function extractExplorerStateFromURL(
     }
 
   // eslint-disable-next-line no-nested-ternary
-  const patientIds = patientIdsConfig?.enabled
+  const patientIds = patientIdsConfig?.filter
     ? searchParams.has('patientIds')
       ? searchParams.get('patientIds').split(',')
       : []
@@ -125,7 +125,7 @@ class GuppyDataExplorer extends React.Component {
       });
   };
 
-  handlePatientIdsChange = this.props.patientIdsConfig?.enabled
+  handlePatientIdsChange = this.props.patientIdsConfig?.filter
     ? (patientIds) => {
         const searchParams = new URLSearchParams(
           this.props.history.location.search

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -22,7 +22,7 @@ import './GuppyDataExplorer.css';
 /**
  * @param {URLSearchParams} searchParams
  * @param {{ tabs: { fields: string[] }[] }} filterConfig
- * @param {{ enabled?: boolean }} patientIdsConfig
+ * @param {{ enabled?: boolean; export?: boolean }} patientIdsConfig
  */
 function extractExplorerStateFromURL(
   searchParams,

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -61,6 +61,6 @@ export const SurvivalAnalysisConfigType = PropTypes.shape({
 });
 
 export const PatientIdsConfigType = PropTypes.shape({
-  enabled: PropTypes.bool,
+  filter: PropTypes.bool,
   export: PropTypes.bool,
 });

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -62,4 +62,5 @@ export const SurvivalAnalysisConfigType = PropTypes.shape({
 
 export const PatientIdsConfigType = PropTypes.shape({
   enabled: PropTypes.bool,
+  export: PropTypes.bool,
 });


### PR DESCRIPTION
Ticket: [PEDS-457](https://pcdc.atlassian.net/browse/PEDS-457)

This PR modifies the config for patient IDs to enable more granular control, breaking a single `"enable"` option into `"filter"` and `"export"` that can be toggled independently.