### PR TITLE
Stop updating survival results on filter change PEDS-459

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -63,18 +63,6 @@ const ControlForm = ({
   }, [isInputChanged, isError]);
 
   const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
-  useEffect(() => {
-    if (isFilterChanged)
-      onSubmit({
-        factorVariable: factorVariable.value,
-        stratificationVariable: stratificationVariable.value,
-        timeInterval: localTimeInterval,
-        startTime,
-        endTime,
-        efsFlag: survivalType.value === 'efs',
-        shouldUpdateResults: true,
-      });
-  }, [isFilterChanged]);
 
   const validateNumberInput = (
     /** @type {{ target: { value: string, min: string, max: string }}} */ e


### PR DESCRIPTION
Ticket: [PEDS-459](https://pcdc.atlassian.net/browse/PEDS-459)

This PR removes the auto-updating of survival plot on filter change, and therefore reverts part of https://github.com/chicagopcdc/data-portal/pull/103. This change is made to help the survival analysis service to better track the intentional use of the tool.