### PR TITLE
Stop fetching survival results on initial page load PEDS-460

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -57,7 +57,7 @@ const ControlForm = ({
   const [endTime, setEndTime] = useState(20);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
-  const [isInputChanged, setIsInputChanged] = useState(false);
+  const [isInputChanged, setIsInputChanged] = useState(true);
   useEffect(() => {
     if (!isInputChanged && isError) setIsInputChanged(true);
   }, [isInputChanged, isError]);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -124,7 +124,7 @@ const RiskTable = ({ data, isStratified, timeInterval }) => (
   <div className='explorer-survival-analysis__risk-table'>
     {data.length === 0 ? (
       <div className='explorer-survival-analysis__figure-placeholder'>
-        Rist table here
+        Click "Apply" to get the risk table here.
       </div>
     ) : (
       <>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -121,7 +121,7 @@ const SurvivalPlot = ({ colorScheme, data, isStratified, timeInterval }) => (
     {/* eslint-disable-next-line no-nested-ternary */}
     {data.length === 0 ? (
       <div className='explorer-survival-analysis__figure-placeholder'>
-        Survival plot here
+        Click "Apply" to get the survival plot here.
       </div>
     ) : isStratified ? (
       Object.entries(

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -129,37 +129,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
         });
     else setIsUpdating(false);
   };
-  useEffect(() => {
-    let isMounted = true;
-
-    if (isMounted) {
-      setIsError(false);
-      setIsUpdating(true);
-      fetchResult({
-        filter: transformedFilter ?? {},
-        parameter: {
-          factorVariable: '',
-          stratificationVariable: '',
-          efsFlag: false,
-        },
-        result: config.result,
-      })
-        .then((result) => {
-          if (isMounted) {
-            if (config.result?.pval)
-              setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
-            if (config.result?.risktable) setRisktable(result.risktable);
-            if (config.result?.survival) setSurvival(result.survival);
-          }
-        })
-        .catch(() => isMounted && setIsError(true))
-        .finally(() => isMounted && setIsUpdating(false));
-    }
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
 
   return (
     <div className='explorer-survival-analysis'>


### PR DESCRIPTION
Ticket: [PEDS-460](https://pcdc.atlassian.net/browse/PEDS-460)

This PR removes fetching survival results on initial page load. The PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/182, and meant to further improve tracking users' intentional use of the survival analysis tool.