### PR TITLE
Update check for registration status PEDS-461

### DIFF
--- a/src/UserRegistration/ReduxUserRegistration.js
+++ b/src/UserRegistration/ReduxUserRegistration.js
@@ -4,8 +4,7 @@ import UserRegistration from './UserRegistration';
 import { fetchUserAccess } from '../actions';
 
 const mapStateToProps = (state) => ({
-  shouldRegister:
-    !state.user.authz || Object.keys(state.user.authz).length === 0,
+  shouldRegister: !(state.user.authz?.['/portal']?.length > 0),
   docsToBeReviewed: state.user?.docs_to_be_reviewed || [],
 });
 


### PR DESCRIPTION
Ticket: [PEDS-461](https://pcdc.atlassian.net/browse/PEDS-461)

This PR updates how `shouldRegister` value is set to more accurately represent the criteria.

Previously, it only checked if the `/user/user` response meets the following:
1. the response object has `authz` property
2. `authz` is not an empty object
 
The updated check tests if
1. the response object has `authz` property
2. `authz` object has `/portal` property
3. `authz['/portal']` is an array with more than 0 element.