### PR TITLE
Update filter state representation PEDS-466

### DIFF
--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -360,8 +360,7 @@ function parseAnchoredFilter(anchorName, { filter }) {
       continue;
 
     if (path in nestedFacetIndices) {
-      const nestedFilter = facetsList[nestedFacetIndices[path]];
-      if ('nested' in nestedFilter) nestedFilter.nested.AND.push(facetsPiece);
+      facetsList[nestedFacetIndices[path]].nested.AND.push(facetsPiece);
     } else {
       nestedFacetIndices[path] = facetIndex;
       facetsList.push({

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -360,18 +360,16 @@ function parseAnchoredFilter(anchorName, { filter }) {
       continue;
 
     if (path in nestedFacetIndices) {
-      const nestedFacetIndex = nestedFacetIndices[path];
-      const nestedFilter = facetsList[nestedFacetIndex];
+      const nestedFilter = facetsList[nestedFacetIndices[path]];
       if ('nested' in nestedFilter) nestedFilter.nested.AND.push(facetsPiece);
     } else {
       nestedFacetIndices[path] = facetIndex;
-      const nestedFilter = {
+      facetsList.push({
         nested: {
           path,
           AND: [anchorPiece, facetsPiece],
         },
-      };
-      facetsList.push(nestedFilter);
+      });
       facetIndex += 1;
     }
   }
@@ -403,19 +401,17 @@ export function getGQLFilter(filter) {
         const { path, AND } = nested;
         const facetsPiece = { AND };
         if (path in nestedFacetIndices) {
-          const nestedFacetIndex = nestedFacetIndices[path];
-          const nestedFilter = facetsList[nestedFacetIndex];
+          const nestedFilter = facetsList[nestedFacetIndices[path]];
           if ('nested' in nestedFilter)
             nestedFilter.nested.AND.push(facetsPiece);
         } else {
           nestedFacetIndices[path] = facetIndex;
-          const nestedFilter = {
+          facetsList.push({
             nested: {
               path,
               AND: [facetsPiece],
             },
-          };
-          facetsList.push(nestedFilter);
+          });
           facetIndex += 1;
         }
       }
@@ -431,18 +427,16 @@ export function getGQLFilter(filter) {
     if (isNestedField) {
       const path = fieldStr; // parent path
       if (path in nestedFacetIndices) {
-        const nestedFacetIndex = nestedFacetIndices[path];
-        const nestedFilter = facetsList[nestedFacetIndex];
+        const nestedFilter = facetsList[nestedFacetIndices[path]];
         if ('nested' in nestedFilter) nestedFilter.nested.AND.push(facetsPiece);
       } else {
         nestedFacetIndices[path] = facetIndex;
-        const nestedFilter = {
+        facetsList.push({
           nested: {
             path,
             AND: [facetsPiece],
           },
-        };
-        facetsList.push(nestedFilter);
+        });
         facetIndex += 1;
       }
     } else {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -315,9 +315,9 @@ function parseSimpleFilter(fieldName, filterValues) {
   }
 
   // an option-type filter
-  if ('selectedValues' in filterValues) {
+  if ('selectedValues' in filterValues || '__combineMode' in filterValues) {
     const { selectedValues, __combineMode } = filterValues;
-    if (selectedValues.length > 0)
+    if (selectedValues?.length > 0)
       return __combineMode === 'AND'
         ? {
             AND: selectedValues.map((selectedValue) => ({

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -297,7 +297,9 @@ export function queryGuppyForRawData({
  * @returns {GqlInFilter | GqlSimpleAndFilter | undefined}
  */
 function parseSimpleFilter(fieldName, filterValues) {
-  const invalidFilterError = new Error(`Invalid filter object ${filterValues}`);
+  const invalidFilterError = new Error(
+    `Invalid filter object for "${fieldName}": ${JSON.stringify(filterValues)}`
+  );
   if (filterValues === undefined) throw invalidFilterError;
 
   // a range-type filter

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -355,21 +355,19 @@ function parseAnchoredFilter(anchorName, { filter }) {
     const [path, fieldName] = field.split('.');
     const facetsPiece = parseSimpleFilter(fieldName, filterValues);
 
-    if (facetsPiece === undefined)
-      // eslint-disable-next-line no-continue
-      continue;
-
-    if (path in nestedFacetIndices) {
-      facetsList[nestedFacetIndices[path]].nested.AND.push(facetsPiece);
-    } else {
-      nestedFacetIndices[path] = facetIndex;
-      facetsList.push({
-        nested: {
-          path,
-          AND: [anchorPiece, facetsPiece],
-        },
-      });
-      facetIndex += 1;
+    if (facetsPiece !== undefined) {
+      if (path in nestedFacetIndices) {
+        facetsList[nestedFacetIndices[path]].nested.AND.push(facetsPiece);
+      } else {
+        nestedFacetIndices[path] = facetIndex;
+        facetsList.push({
+          nested: {
+            path,
+            AND: [anchorPiece, facetsPiece],
+          },
+        });
+        facetIndex += 1;
+      }
     }
   }
 
@@ -414,33 +412,31 @@ export function getGQLFilter(filter) {
           facetIndex += 1;
         }
       }
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-    const facetsPiece = parseSimpleFilter(fieldName, filterValues);
-
-    if (facetsPiece === undefined)
-      // eslint-disable-next-line no-continue
-      continue;
-
-    if (isNestedField) {
-      const path = fieldStr; // parent path
-      if (path in nestedFacetIndices) {
-        const nestedFilter = facetsList[nestedFacetIndices[path]];
-        if ('nested' in nestedFilter) nestedFilter.nested.AND.push(facetsPiece);
-      } else {
-        nestedFacetIndices[path] = facetIndex;
-        facetsList.push({
-          nested: {
-            path,
-            AND: [facetsPiece],
-          },
-        });
-        facetIndex += 1;
-      }
     } else {
-      facetsList.push(facetsPiece);
-      facetIndex += 1;
+      const facetsPiece = parseSimpleFilter(fieldName, filterValues);
+
+      if (facetsPiece !== undefined) {
+        if (isNestedField) {
+          const path = fieldStr; // parent path
+          if (path in nestedFacetIndices) {
+            const nestedFilter = facetsList[nestedFacetIndices[path]];
+            if ('nested' in nestedFilter)
+              nestedFilter.nested.AND.push(facetsPiece);
+          } else {
+            nestedFacetIndices[path] = facetIndex;
+            facetsList.push({
+              nested: {
+                path,
+                AND: [facetsPiece],
+              },
+            });
+            facetIndex += 1;
+          }
+        } else {
+          facetsList.push(facetsPiece);
+          facetIndex += 1;
+        }
+      }
     }
   }
 

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -2,39 +2,39 @@ import { getGQLFilter } from '../Utils/queries';
 
 describe('Get GQL filter from filter object from', () => {
   test('a simple option filter', async () => {
-    const filter = { a: { selectedValues: ['foo', 'bar'] } };
+    const filterState = { a: { selectedValues: ['foo', 'bar'] } };
     const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('a simple option filter with combine mode OR', () => {
-    const filter = {
+    const filterState = {
       a: { __combineMode: 'OR', selectedValues: ['foo', 'bar'] },
     };
     const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('a simple option filter with combine mode AND', () => {
-    const filter = {
+    const filterState = {
       a: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
     };
     const gqlFilter = {
       AND: [{ AND: [{ IN: { a: ['foo'] } }, { IN: { a: ['bar'] } }] }],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('a simple range filter', () => {
-    const filter = { a: { lowerBound: 0, upperBound: 1 } };
+    const filterState = { a: { lowerBound: 0, upperBound: 1 } };
     const gqlFilter = {
       AND: [{ AND: [{ GTE: { a: 0 } }, { LTE: { a: 1 } }] }],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('simple filters', () => {
-    const filter = {
+    const filterState = {
       a: { selectedValues: ['foo', 'bar'] },
       b: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
       c: { lowerBound: 0, upperBound: 1 },
@@ -46,34 +46,34 @@ describe('Get GQL filter from filter object from', () => {
         { AND: [{ GTE: { c: 0 } }, { LTE: { c: 1 } }] },
       ],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('a combine mode only filter', () => {
-    const filter = { a: { __combineMode: 'OR' } };
+    const filterState = { a: { __combineMode: 'OR' } };
     const gqlFilter = { AND: [] };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('an invalid filter', () => {
     const fieldName = 'a';
     const filterValue = {};
-    const filter = { [fieldName]: filterValue };
-    expect(() => getGQLFilter(filter)).toThrow(
+    const filterState = { [fieldName]: filterValue };
+    expect(() => getGQLFilter(filterState)).toThrow(
       `Invalid filter object for "${fieldName}": ${JSON.stringify(filterValue)}`
     );
   });
 
   test('a nested filter', () => {
-    const filter = { 'a.b': { selectedValues: ['foo', 'bar'] } };
+    const filterState = { 'a.b': { selectedValues: ['foo', 'bar'] } };
     const gqlFilter = {
       AND: [{ nested: { path: 'a', AND: [{ IN: { b: ['foo', 'bar'] } }] } }],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('nested filters with same parent path', () => {
-    const filter = {
+    const filterState = {
       'a.b': { selectedValues: ['foo', 'bar'] },
       'a.c': { lowerBound: 0, upperBound: 1 },
     };
@@ -90,11 +90,11 @@ describe('Get GQL filter from filter object from', () => {
         },
       ],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('nested filters with different parent paths', () => {
-    const filter = {
+    const filterState = {
       'a.b': { selectedValues: ['foo', 'bar'] },
       'c.d': { lowerBound: 0, upperBound: 1 },
     };
@@ -114,11 +114,11 @@ describe('Get GQL filter from filter object from', () => {
         },
       ],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('an anchored filter state', () => {
-    const filter = {
+    const filterState = {
       'x:y': {
         filter: {
           'a.b': { selectedValues: ['foo', 'bar'] },
@@ -153,11 +153,11 @@ describe('Get GQL filter from filter object from', () => {
         },
       ],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('various filters', () => {
-    const filter = {
+    const filterState = {
       a: { selectedValues: ['foo', 'bar'] },
       'b.c': { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
       'b.d': { lowerBound: 0, upperBound: 1 },
@@ -184,6 +184,6 @@ describe('Get GQL filter from filter object from', () => {
         },
       ],
     };
-    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 });

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -56,9 +56,11 @@ describe('Get GQL filter from filter object from', () => {
   });
 
   test('an invalid filter', () => {
-    const filter = { a: {} };
+    const fieldName = 'a';
+    const filterValue = {};
+    const filter = { [fieldName]: filterValue };
     expect(() => getGQLFilter(filter)).toThrow(
-      `Invalid filter object ${filter.a}`
+      `Invalid filter object for "${fieldName}": ${JSON.stringify(filterValue)}`
     );
   });
 

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -117,6 +117,45 @@ describe('Get GQL filter from filter object from', () => {
     expect(getGQLFilter(filter)).toEqual(gqlFilter);
   });
 
+  test('an anchored filter state', () => {
+    const filter = {
+      'x:y': {
+        filter: {
+          'a.b': { selectedValues: ['foo', 'bar'] },
+          'c.d': { lowerBound: 0, upperBound: 1 },
+        },
+      },
+    };
+    const gqlFilter = {
+      AND: [
+        {
+          nested: {
+            path: 'a',
+            AND: [
+              {
+                AND: [{ IN: { x: ['y'] } }, { IN: { b: ['foo', 'bar'] } }],
+              },
+            ],
+          },
+        },
+        {
+          nested: {
+            path: 'c',
+            AND: [
+              {
+                AND: [
+                  { IN: { x: ['y'] } },
+                  { AND: [{ GTE: { d: 0 } }, { LTE: { d: 1 } }] },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    expect(getGQLFilter(filter)).toEqual(gqlFilter);
+  });
+
   test('various filters', () => {
     const filter = {
       a: { selectedValues: ['foo', 'bar'] },

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -1,0 +1,47 @@
+/**
+ * @typedef {Object} OptionFilter
+ * @property {string[]} selectedValues
+ * @property {'AND' | 'OR'} [__combineMode]
+ */
+
+/**
+ * @typedef {Object} RangeFilter
+ * @property {number} lowerBound
+ * @property {number} upperBound
+ */
+
+/**
+ * @typedef {{ [x: string]: OptionFilter | RangeFilter }} FilterState
+ */
+
+/**
+ * @typedef {Object} GqlInFilter
+ * @property {{ [x: string]: string[] }} IN
+ */
+
+/**
+ * @typedef {Object} GqlRangeFilter
+ * @property {{ [x: string]: number }} [GTE]
+ * @property {{ [x: string]: number }} [LTE]
+ */
+
+/**
+ * @typedef {Object} GqlSimpleAndFilter
+ * @property {(GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter)[]} AND
+ */
+
+/**
+ * @typedef {Object} GqlNestedFilter
+ * @property {Object} nested
+ * @property {string} nested.path
+ * @property {(GqlInFilter | GqlSimpleAndFilter)[]} nested.AND
+ */
+
+/**
+ * @typedef {Object} GqlAndFilter
+ * @property {(GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter | GqlNestedFilter)[]} AND
+ */
+
+/**
+ * @typedef {GqlAndFilter | GqlInFilter | GqlRangeFilter | GqlNestedFilter} GqlFilter
+ */

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -15,7 +15,11 @@
  */
 
 /**
- * @typedef {{ [x: string]: OptionFilter | RangeFilter }} FilterState
+ * @typedef {{ filter: SimpleFilterState }} AnchoredFilterState
+ */
+
+/**
+ * @typedef {{ [x: string]: OptionFilter | RangeFilter | AnchoredFilterState }} FilterState
  */
 
 /**
@@ -42,7 +46,7 @@
  * @typedef {Object} GqlNestedFilter
  * @property {Object} nested
  * @property {string} nested.path
- * @property {(GqlInFilter | GqlSimpleAndFilter)[]} nested.AND
+ * @property {GqlFilter[]} nested.AND
  */
 
 /**

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -11,6 +11,10 @@
  */
 
 /**
+ * @typedef {{ [x: string]: OptionFilter | RangeFilter }} SimpleFilterState
+ */
+
+/**
  * @typedef {{ [x: string]: OptionFilter | RangeFilter }} FilterState
  */
 
@@ -27,7 +31,11 @@
 
 /**
  * @typedef {Object} GqlSimpleAndFilter
- * @property {(GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter)[]} AND
+ * @property {GqlSimpleFilter[]} AND
+ */
+
+/**
+ * @typedef {GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter} GqlSimpleFilter
  */
 
 /**
@@ -39,9 +47,9 @@
 
 /**
  * @typedef {Object} GqlAndFilter
- * @property {(GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter | GqlNestedFilter)[]} AND
+ * @property {GqlFilter[]} AND
  */
 
 /**
- * @typedef {GqlAndFilter | GqlInFilter | GqlRangeFilter | GqlNestedFilter} GqlFilter
+ * @typedef {GqlSimpleFilter | GqlNestedFilter | GqlAndFilter} GqlFilter
  */


### PR DESCRIPTION
Ticket: [PEDS-466](https://pcdc.atlassian.net/browse/PEDS-466)

This PR modifies `getGQLFilter()` to handle the updated explorer filter state representation. The updated representation includes "anchored" set of filters, which allows a group of nested filters to be "anchored" to a specific field and its value. The "anchor field" here must be a shared field for a group of nested filter objects. Only "option-type" filters with a single `selectedValues` element can be used as anchors.

Refer to the related Jira ticket description for more details.

The PR also:
* adds JSDoc types for explorer filter state and GraphQL filters to improve static type checking for `getGQLFilter()` and related code. This PR does not add these types for all relevant places in the codebase--this is left for a future work.
* update tests for `getGQLFilter()` to try "anchored" filters
* refactors `getGQLFilter()` body to improve type checking and readability--renaming variables to better communicate their meanings, restructuring control flow, etc.

