### PR TITLE
Fix and refactor filter section methods PEDS-477

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -123,149 +123,6 @@ class FilterSection extends React.Component {
     );
   };
 
-  getSearchInput() {
-    return (
-      <div
-        className={
-          this.state.isExpanded && this.state.showingSearch
-            ? 'g3-filter-section__search-input'
-            : 'g3-filter-section__hidden'
-        }
-      >
-        <input
-          className='g3-filter-section__search-input-box body'
-          onChange={() => {
-            this.handleSearchInputChange();
-          }}
-          ref={this.inputElem}
-        />
-        <span
-          className=''
-          onClick={
-            this.state.searchInputEmpty ? undefined : this.clearSearchInput
-          }
-          onKeyPress={(e) => {
-            if (this.state.searchInputEmpty) return;
-
-            if (e.charCode === 13 || e.charCode === 32) {
-              e.preventDefault();
-              this.clearSearchInput();
-            }
-          }}
-          role='button'
-          tabIndex={0}
-          aria-label={this.state.searchInputEmpty ? 'Search' : 'Clear'}
-        >
-          <i
-            className={`g3-icon g3-icon--${
-              this.state.searchInputEmpty ? 'search' : 'cross'
-            } g3-filter-section__search-input-close`}
-          />
-        </span>
-      </div>
-    );
-  }
-
-  getAndOrToggle() {
-    const tooltipText =
-      'This toggle selects the logical operator used to combine checked filter options. ' +
-      'If AND is set, records must match all checked filter options. ' +
-      'If OR is set, records must match at least one checked option.';
-    return (
-      <div
-        className={
-          this.state.isExpanded && this.state.showingAndOrToggle
-            ? 'g3-filter-section__and-or-toggle'
-            : 'g3-filter-section__hidden'
-        }
-      >
-        <span style={{ marginRight: '5px' }}>Combine with </span>
-        <Radio.Group defaultValue={this.state.combineMode} buttonStyle='solid'>
-          <Radio.Button
-            value='AND'
-            onChange={() => this.handleSetCombineModeOption('AND')}
-          >
-            AND
-          </Radio.Button>
-          <Radio.Button
-            value='OR'
-            onChange={() => this.handleSetCombineModeOption('OR')}
-          >
-            OR
-          </Radio.Button>
-        </Radio.Group>
-
-        <Tooltip
-          placement='right'
-          overlay={tooltipText}
-          overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
-          arrowContent={<div className='rc-tooltip-arrow-inner' />}
-          width='300px'
-          trigger={['hover', 'focus']}
-        >
-          <span className='g3-helper-tooltip'>
-            <i className='g3-icon g3-icon--sm g3-icon--question-mark-bootstrap help-tooltip-icon' />
-          </span>
-        </Tooltip>
-      </div>
-    );
-  }
-
-  getSearchFilter() {
-    const selectedOptions = Object.entries(this.state.filterStatus)
-      .filter((kv) => kv[1] === true)
-      .map((kv) => ({ value: kv[0], label: kv[0] }));
-    return (
-      <AsyncPaginate
-        className={
-          this.state.isExpanded
-            ? ''
-            : 'g3-filter-section__search-filter--hidden'
-        }
-        cacheOptions
-        controlShouldRenderValue={false}
-        defaultOptions
-        debounceTimeout={250}
-        value={selectedOptions}
-        loadOptions={(input, loadedOptions) =>
-          this.props.onSearchFilterLoadOptions(input, loadedOptions.length)
-        }
-        onChange={(option) => this.handleSelectSingleSelectFilter(option.value)}
-      />
-    );
-  }
-
-  getShowMoreButton() {
-    let totalCount = 0;
-    for (const o of this.props.options) {
-      if (o.count > 0 || !this.props.hideZero || o.count === -1)
-        totalCount += 1;
-    }
-    return (
-      totalCount > this.props.initVisibleItemNumber && (
-        <div
-          className='g3-filter-section__show-more'
-          onClick={() => this.toggleShowMore()}
-          onKeyPress={(e) => {
-            if (e.charCode === 13 || e.charCode === 32) {
-              e.preventDefault();
-              this.toggleShowMore();
-            }
-          }}
-          role='button'
-          tabIndex={0}
-          aria-label={this.state.showingMore ? 'Show less' : 'Show more'}
-        >
-          {this.state.showingMore
-            ? 'less'
-            : `${(
-                totalCount - this.props.initVisibleItemNumber
-              ).toLocaleString()} more`}
-        </div>
-      )
-    );
-  }
-
   clearSearchInput = () => {
     this.inputElem.current.value = '';
     this.setState({
@@ -322,6 +179,149 @@ class FilterSection extends React.Component {
       ),
     }));
   };
+
+  renderAndOrToggle() {
+    const tooltipText =
+      'This toggle selects the logical operator used to combine checked filter options. ' +
+      'If AND is set, records must match all checked filter options. ' +
+      'If OR is set, records must match at least one checked option.';
+    return (
+      <div
+        className={
+          this.state.isExpanded && this.state.showingAndOrToggle
+            ? 'g3-filter-section__and-or-toggle'
+            : 'g3-filter-section__hidden'
+        }
+      >
+        <span style={{ marginRight: '5px' }}>Combine with </span>
+        <Radio.Group defaultValue={this.state.combineMode} buttonStyle='solid'>
+          <Radio.Button
+            value='AND'
+            onChange={() => this.handleSetCombineModeOption('AND')}
+          >
+            AND
+          </Radio.Button>
+          <Radio.Button
+            value='OR'
+            onChange={() => this.handleSetCombineModeOption('OR')}
+          >
+            OR
+          </Radio.Button>
+        </Radio.Group>
+
+        <Tooltip
+          placement='right'
+          overlay={tooltipText}
+          overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
+          arrowContent={<div className='rc-tooltip-arrow-inner' />}
+          width='300px'
+          trigger={['hover', 'focus']}
+        >
+          <span className='g3-helper-tooltip'>
+            <i className='g3-icon g3-icon--sm g3-icon--question-mark-bootstrap help-tooltip-icon' />
+          </span>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  renderSearchFilter() {
+    const selectedOptions = Object.entries(this.state.filterStatus)
+      .filter((kv) => kv[1] === true)
+      .map((kv) => ({ value: kv[0], label: kv[0] }));
+    return (
+      <AsyncPaginate
+        className={
+          this.state.isExpanded
+            ? ''
+            : 'g3-filter-section__search-filter--hidden'
+        }
+        cacheOptions
+        controlShouldRenderValue={false}
+        defaultOptions
+        debounceTimeout={250}
+        value={selectedOptions}
+        loadOptions={(input, loadedOptions) =>
+          this.props.onSearchFilterLoadOptions(input, loadedOptions.length)
+        }
+        onChange={(option) => this.handleSelectSingleSelectFilter(option.value)}
+      />
+    );
+  }
+
+  renderSearchInput() {
+    return (
+      <div
+        className={
+          this.state.isExpanded && this.state.showingSearch
+            ? 'g3-filter-section__search-input'
+            : 'g3-filter-section__hidden'
+        }
+      >
+        <input
+          className='g3-filter-section__search-input-box body'
+          onChange={() => {
+            this.handleSearchInputChange();
+          }}
+          ref={this.inputElem}
+        />
+        <span
+          className=''
+          onClick={
+            this.state.searchInputEmpty ? undefined : this.clearSearchInput
+          }
+          onKeyPress={(e) => {
+            if (this.state.searchInputEmpty) return;
+
+            if (e.charCode === 13 || e.charCode === 32) {
+              e.preventDefault();
+              this.clearSearchInput();
+            }
+          }}
+          role='button'
+          tabIndex={0}
+          aria-label={this.state.searchInputEmpty ? 'Search' : 'Clear'}
+        >
+          <i
+            className={`g3-icon g3-icon--${
+              this.state.searchInputEmpty ? 'search' : 'cross'
+            } g3-filter-section__search-input-close`}
+          />
+        </span>
+      </div>
+    );
+  }
+
+  renderShowMoreButton() {
+    let totalCount = 0;
+    for (const o of this.props.options) {
+      if (o.count > 0 || !this.props.hideZero || o.count === -1)
+        totalCount += 1;
+    }
+    return (
+      totalCount > this.props.initVisibleItemNumber && (
+        <div
+          className='g3-filter-section__show-more'
+          onClick={() => this.toggleShowMore()}
+          onKeyPress={(e) => {
+            if (e.charCode === 13 || e.charCode === 32) {
+              e.preventDefault();
+              this.toggleShowMore();
+            }
+          }}
+          role='button'
+          tabIndex={0}
+          aria-label={this.state.showingMore ? 'Show less' : 'Show more'}
+        >
+          {this.state.showingMore
+            ? 'less'
+            : `${(
+                totalCount - this.props.initVisibleItemNumber
+              ).toLocaleString()} more`}
+        </div>
+      )
+    );
+  }
 
   render() {
     // Takes in parent component's filterStatus or self state's filterStatus
@@ -468,9 +468,9 @@ class FilterSection extends React.Component {
         ) : (
           sectionHeader
         )}
-        {isTextFilter && this.getSearchInput()}
-        {this.props.isArrayField && this.getAndOrToggle()}
-        {isSearchFilter && this.getSearchFilter(Option)}
+        {isTextFilter && this.renderSearchInput()}
+        {this.props.isArrayField && this.renderAndOrToggle()}
+        {isSearchFilter && this.renderSearchFilter(Option)}
         <div className='g3-filter-section__options'>
           {(isTextFilter || isSearchFilter) &&
             this.state.isExpanded &&
@@ -552,7 +552,7 @@ class FilterSection extends React.Component {
           {isTextFilter &&
             this.state.isExpanded &&
             this.state.searchInputEmpty &&
-            this.getShowMoreButton()}
+            this.renderShowMoreButton()}
         </div>
       </div>
     );

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -19,7 +19,7 @@ const filterVisibleStatusObj = (
   const res = {};
   for (const [i, o] of optionList.entries()) {
     res[o.text] =
-      typeof inputText === 'undefined' || inputText === ''
+      typeof inputText === 'undefined' || inputText.trim() === ''
         ? showingMore || i < initVisibleItemNumber
         : o.text.toLowerCase().indexOf(inputText.toLowerCase()) >= 0;
   }
@@ -269,18 +269,6 @@ class FilterSection extends React.Component {
   };
 
   updateVisibleOptions(inputText) {
-    // if empty input, all should be visible
-    if (typeof inputText === 'undefined' || inputText.trim() === '') {
-      this.setState((prevState) => ({
-        optionsVisibleStatus: filterVisibleStatusObj(
-          this.props.options,
-          this.props.initVisibleItemNumber,
-          prevState.showingMore
-        ),
-      }));
-    }
-
-    // if not empty, filter out those matched
     this.setState((prevState) => ({
       optionsVisibleStatus: filterVisibleStatusObj(
         this.props.options,

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -260,13 +260,13 @@ class FilterSection extends React.Component {
     );
   }
 
-  clearSearchInput() {
+  clearSearchInput = () => {
     this.inputElem.current.value = '';
     this.setState({
       searchInputEmpty: true,
     });
     this.updateVisibleOptions();
-  }
+  };
 
   updateVisibleOptions(inputText) {
     // if empty input, all should be visible

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -260,9 +260,7 @@ class FilterSection extends React.Component {
       >
         <input
           className='g3-filter-section__search-input-box body'
-          onChange={() => {
-            this.handleSearchInputChange();
-          }}
+          onChange={this.handleSearchInputChange}
           ref={this.inputElem}
         />
         <span
@@ -302,7 +300,7 @@ class FilterSection extends React.Component {
       totalCount > this.props.initVisibleItemNumber && (
         <div
           className='g3-filter-section__show-more'
-          onClick={() => this.toggleShowMore()}
+          onClick={this.toggleShowMore}
           onKeyPress={(e) => {
             if (e.charCode === 13 || e.charCode === 32) {
               e.preventDefault();
@@ -378,7 +376,7 @@ class FilterSection extends React.Component {
             <div className='g3-filter-section__selected-count-chip'>
               <div
                 className='g3-filter-section__range-filter-clear-btn'
-                onClick={(e) => this.handleClearButtonClick(e)}
+                onClick={this.handleClearButtonClick}
                 onKeyPress={(e) => {
                   if (e.keyCode === 13 || e.keyCode === 32) {
                     e.preventDefault();
@@ -409,14 +407,14 @@ class FilterSection extends React.Component {
                     &nbsp;selected
                   </>
                 }
-                onClearButtonClick={(ev) => this.handleClearButtonClick(ev)}
+                onClearButtonClick={this.handleClearButtonClick}
               />
             </div>
           )}
         </div>
         {isTextFilter && this.props.isArrayField && (
           <div
-            onClick={() => this.toggleShowAndOrToggle()}
+            onClick={this.toggleShowAndOrToggle}
             onKeyPress={(e) => {
               if (e.charCode === 13 || e.charCode === 32) {
                 e.preventDefault();
@@ -436,7 +434,7 @@ class FilterSection extends React.Component {
         )}
         {isTextFilter && (
           <div
-            onClick={() => this.toggleShowSearch()}
+            onClick={this.toggleShowSearch}
             onKeyPress={(e) => {
               if (e.charCode === 13 || e.charCode === 32) {
                 e.preventDefault();
@@ -494,9 +492,7 @@ class FilterSection extends React.Component {
                     filterStatus[option.text] ? 'enabled' : 'disabled'
                   }`}
                   label={option.text}
-                  onSelect={(label) =>
-                    this.handleSelectSingleSelectFilter(label)
-                  }
+                  onSelect={this.handleSelectSingleSelectFilter}
                   selected={filterStatus[option.text]}
                   count={isSearchFilter ? null : option.count}
                   hideZero={this.props.hideZero}
@@ -536,9 +532,7 @@ class FilterSection extends React.Component {
                   label={option.text}
                   min={option.min}
                   max={option.max}
-                  onAfterDrag={(lb, ub, min, max, step) =>
-                    this.handleDragRangeFilter(lb, ub, min, max, step)
-                  }
+                  onAfterDrag={this.handleDragRangeFilter}
                   lowerBound={lowerBound}
                   upperBound={upperBound}
                   inactive={

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -62,13 +62,13 @@ class FilterSection extends React.Component {
     this.combineModeFieldName = '__combineMode';
   }
 
-  handleSetCombineModeOption(combineModeIn) {
+  handleSetCombineModeOption = (combineModeIn) => {
     // Combine mode: AND or OR
     this.setState({ combineMode: combineModeIn });
     this.props.onCombineOptionToggle(this.combineModeFieldName, combineModeIn);
-  }
+  };
 
-  handleClearButtonClick(ev) {
+  handleClearButtonClick = (ev) => {
     // Prevent this click from triggering any onClick events in parent component
     ev.stopPropagation();
     // Clear the filters
@@ -77,17 +77,17 @@ class FilterSection extends React.Component {
       resetClickCounter: prevState.resetClickCounter + 1,
     }));
     this.props.onClear();
-  }
+  };
 
-  handleSearchInputChange() {
+  handleSearchInputChange = () => {
     const currentInput = this.inputElem.current.value;
     this.setState({
       searchInputEmpty: !currentInput || currentInput.length === 0,
     });
     this.updateVisibleOptions(currentInput);
-  }
+  };
 
-  handleSelectSingleSelectFilter(label) {
+  handleSelectSingleSelectFilter = (label) => {
     this.setState((prevState) => {
       const newFilterStatus = { ...prevState.filterStatus };
       const oldSelected = newFilterStatus[label];
@@ -99,9 +99,15 @@ class FilterSection extends React.Component {
       };
     });
     this.props.onSelect(label);
-  }
+  };
 
-  handleDragRangeFilter(lowerBound, upperBound, minValue, maxValue, rangeStep) {
+  handleDragRangeFilter = (
+    lowerBound,
+    upperBound,
+    minValue,
+    maxValue,
+    rangeStep
+  ) => {
     this.setState(() => {
       const newFilterStatus = [lowerBound, upperBound];
       return {
@@ -115,7 +121,7 @@ class FilterSection extends React.Component {
       maxValue,
       rangeStep
     );
-  }
+  };
 
   getSearchInput() {
     return (
@@ -268,7 +274,7 @@ class FilterSection extends React.Component {
     this.updateVisibleOptions();
   };
 
-  updateVisibleOptions(inputText) {
+  updateVisibleOptions = (inputText) => {
     this.setState((prevState) => ({
       optionsVisibleStatus: filterVisibleStatusObj(
         this.props.options,
@@ -277,9 +283,9 @@ class FilterSection extends React.Component {
         inputText
       ),
     }));
-  }
+  };
 
-  toggleSection(open) {
+  toggleSection = (open) => {
     let targetStatus;
     if (typeof open === 'undefined') {
       targetStatus = !this.state.isExpanded;
@@ -288,25 +294,25 @@ class FilterSection extends React.Component {
     }
     this.props.onToggle(targetStatus);
     this.setState({ isExpanded: targetStatus });
-  }
+  };
 
-  toggleShowSearch() {
+  toggleShowSearch = () => {
     // If and/or toggle is shown, hide it before showing the search input.
     this.setState((prevState) => ({
       showingSearch: !prevState.showingSearch,
       showingAndOrToggle: false,
     }));
-  }
+  };
 
-  toggleShowAndOrToggle() {
+  toggleShowAndOrToggle = () => {
     // If search input is shown, hide it before showing the and/or toggle.
     this.setState((prevState) => ({
       showingAndOrToggle: !prevState.showingAndOrToggle,
       showingSearch: false,
     }));
-  }
+  };
 
-  toggleShowMore() {
+  toggleShowMore = () => {
     this.setState((prevState) => ({
       showingMore: !prevState.showingMore,
       optionsVisibleStatus: filterVisibleStatusObj(
@@ -315,7 +321,7 @@ class FilterSection extends React.Component {
         !prevState.showingMore
       ),
     }));
-  }
+  };
 
   render() {
     // Takes in parent component's filterStatus or self state's filterStatus


### PR DESCRIPTION
Ticket: [PEDS-477](https://pcdc.atlassian.net/browse/PEDS-477)

This PR fixes the incorrect scope issue when calling `clearSearchInput()` method in `<FilterSection>`, first introduced [here](https://github.com/chicagopcdc/data-portal/commit/043cbc00f629f3ccee32c818b131e8bb950376de#diff-8ad6e4e22956a32f778797e091aa60cc601549608a820d5a5fc029124b55fc30) (line 140). The PR also includes some refactoring efforts to improve readability and performance of `<FilterSection>`.