### PR TITLE
Handle anchored filters in <FilterGroup> util functions PEDS-469

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -138,6 +138,59 @@ describe('Remove empty filter in filter results', () => {
     };
     expect(removed).toEqual(expected);
   });
+  test('Single empty filter with anchor', () => {
+    const removed = removeEmptyFilter({
+      'a:a0': {
+        filter: {
+          x: {},
+          y: { lowerBound: 0, upperBound: 1 },
+          z: { __combineMode: 'AND' },
+        },
+      },
+    });
+    const expected = {
+      'a:a0': {
+        filter: {
+          y: { lowerBound: 0, upperBound: 1 },
+          z: { __combineMode: 'AND' },
+        },
+      },
+    };
+    expect(removed).toEqual(expected);
+  });
+  test('Empty filters only with anchor', () => {
+    const removed = removeEmptyFilter({
+      'a:a0': {
+        filter: {
+          x: {},
+          y: {},
+        },
+      },
+    });
+    const expected = {};
+    expect(removed).toEqual(expected);
+  });
+  test('Empty filters with and without anchor', () => {
+    const removed = removeEmptyFilter({
+      x: { selectedValues: ['foo', 'bar'] },
+      y: {},
+      'a:a0': {
+        filter: {
+          x: {},
+          y: { lowerBound: 0, upperBound: 1 },
+        },
+      },
+    });
+    const expected = {
+      x: { selectedValues: ['foo', 'bar'] },
+      'a:a0': {
+        filter: {
+          y: { lowerBound: 0, upperBound: 1 },
+        },
+      },
+    };
+    expect(removed).toEqual(expected);
+  });
 });
 
 describe('Check if a tab has active filter', () => {

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -504,6 +504,19 @@ describe('Toggles combine mode in option filter', () => {
     };
     expect(updated).toEqual(expected);
   });
+  test('Missing anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ '': [{}], 'a:a0': [{}] }],
+      filterResults: {},
+      anchorLabel: 'a:a0',
+      combineModeValue: 'AND',
+    });
+    const expected = {
+      filterResults: { 'a:a0': { filter: { x: { __combineMode: 'AND' } } } },
+      filterStatus: [{ '': [{}], 'a:a0': [{ __combineMode: 'AND' }] }],
+    };
+    expect(updated).toEqual(expected);
+  });
   test('Exisiting combine mode in anchored filter', () => {
     const updated = helper({
       filterStatus: [
@@ -582,6 +595,22 @@ describe('Update a range filter', () => {
       filterResults: {
         'a:a0': { filter: { x: { lowerBound: 0, upperBound: 1 } } },
       },
+      anchorLabel: 'a:a0',
+      lowerBound: 1,
+      upperBound: 2,
+    });
+    const expected = {
+      filterResults: {
+        'a:a0': { filter: { x: { lowerBound: 1, upperBound: 2 } } },
+      },
+      filterStatus: [{ 'a:a0': [[1, 2]] }],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Simple update in missing anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ 'a:a0': [{}] }],
+      filterResults: {},
       anchorLabel: 'a:a0',
       lowerBound: 1,
       upperBound: 2,

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -144,6 +144,114 @@ describe('Get filter status from filter results', () => {
     const expected = [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]];
     expect(filerStatus).toEqual(expected);
   });
+  test('Single anchored tab', () => {
+    const anchorConfig = {
+      fieldName: 'a',
+      options: ['a0', 'a1'],
+      tabs: ['t'],
+    };
+    const filterResults = {
+      'a:a0': { filter: { x: { selectedValues: ['foo', 'bar'] } } },
+      'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+    };
+    const filterTabs = [{ title: 't', fields: ['x', 'y'] }];
+    const filerStatus = getFilterStatus({
+      anchorConfig,
+      filterResults,
+      filterTabs,
+    });
+    const expected = [
+      {
+        '': [{}, {}],
+        'a:a0': [{ foo: true, bar: true }, {}],
+        'a:a1': [{}, [0, 1]],
+      },
+    ];
+    expect(filerStatus).toEqual(expected);
+  });
+  test('Multiple anchored tabs', () => {
+    const anchorConfig = {
+      fieldName: 'a',
+      options: ['a0', 'a1'],
+      tabs: ['t0', 't1'],
+    };
+    const filterResults = {
+      'a:a0': { filter: { x: { selectedValues: ['foo', 'bar'] } } },
+      'a:a1': {
+        filter: {
+          y: { lowerBound: 0, upperBound: 1 },
+          z: { selectedValues: ['baz'] },
+        },
+      },
+    };
+    const filterTabs = [
+      { title: 't0', fields: ['x', 'z'] },
+      { title: 't1', fields: ['y'] },
+    ];
+    const filerStatus = getFilterStatus({
+      anchorConfig,
+      filterResults,
+      filterTabs,
+    });
+    const expected = [
+      {
+        '': [{}, {}],
+        'a:a0': [{ foo: true, bar: true }, {}],
+        'a:a1': [{}, { baz: true }],
+      },
+      {
+        '': [{}],
+        'a:a0': [{}],
+        'a:a1': [[0, 1]],
+      },
+    ];
+    expect(filerStatus).toEqual(expected);
+  });
+  test('Multiple tabs, both anchored and not', () => {
+    const anchorConfig = {
+      fieldName: 'a',
+      options: ['a0', 'a1'],
+      tabs: ['t1', 't2'],
+    };
+    const filterResults = {
+      x: { selectedValues: ['foo', 'bar'] },
+      'a:a0': {
+        filter: {
+          y: { lowerBound: 0, upperBound: 1 },
+          z: { selectedValues: ['baz'] },
+        },
+      },
+      'a:a1': {
+        filter: {
+          z: { selectedValues: ['baz'] },
+        },
+      },
+    };
+    const filterTabs = [
+      { title: 't0', fields: ['x'] },
+      { title: 't1', fields: ['y'] },
+      { title: 't2', fields: ['z'] },
+    ];
+    const filerStatus = getFilterStatus({
+      anchorConfig,
+      filterResults,
+      filterTabs,
+    });
+    const expected = [
+      [{ foo: true, bar: true }],
+      {
+        '': [{}],
+        'a:a0': [[0, 1]],
+        'a:a1': [{}],
+      },
+      {
+        '': [{}],
+        'a:a0': [{ baz: true }],
+        'a:a1': [{ baz: true }],
+      },
+    ];
+    expect(filerStatus).toEqual(expected);
+  });
 });
 
 describe('Clear a single filter section', () => {

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -1,5 +1,6 @@
 import {
   getExpandedStatus,
+  getFilterResultsByAnchor,
   getFilterStatus,
   clearFilterSection,
   removeEmptyFilter,
@@ -23,6 +24,60 @@ describe('Get expanded status array for all tabs', () => {
     const collapsed = getExpandedStatus(filterTabs, false);
     const expected = [[false, false], [false]];
     expect(collapsed).toEqual(expected);
+  });
+});
+
+describe('Get filter results by anchor label', () => {
+  const anchorConfig = {
+    fieldName: 'a',
+    options: ['a0', 'a1'],
+    tabs: ['t1'],
+  };
+  test('Filter results with no anchor only', () => {
+    const received = getFilterResultsByAnchor(anchorConfig, {
+      x: { selectedValues: ['foo', 'bar'] },
+      y: { lowerBound: 0, upperBound: 1 },
+    });
+    const expected = {
+      '': {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
+      'a:a0': {},
+      'a:a1': {},
+    };
+    expect(received).toEqual(expected);
+  });
+  test('Filter results with a single anchor label only', () => {
+    const received = getFilterResultsByAnchor(anchorConfig, {
+      'a:a0': {
+        filter: {
+          x: { selectedValues: ['foo'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
+      },
+    });
+    const expected = {
+      '': {},
+      'a:a0': {
+        x: { selectedValues: ['foo'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
+      'a:a1': {},
+    };
+    expect(received).toEqual(expected);
+  });
+  test('Filter result with multiple anchor labels only', () => {
+    const received = getFilterResultsByAnchor(anchorConfig, {
+      'a:a0': { filter: { x: { selectedValues: ['foo'] } } },
+      'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+    });
+    const expected = {
+      '': {},
+      'a:a0': { x: { selectedValues: ['foo'] } },
+      'a:a1': { y: { lowerBound: 0, upperBound: 1 } },
+    };
+    expect(received).toEqual(expected);
   });
 });
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -85,14 +85,14 @@ describe('Get filter status from filter results', () => {
   test('Single tab, single option filter', () => {
     const filterResults = { x: { selectedValues: ['foo', 'bar'] } };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
-    const filerStatus = getFilterStatus(filterResults, filterTabs);
+    const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[{ foo: true, bar: true }]];
     expect(filerStatus).toEqual(expected);
   });
   test('Single tab, single range filter', () => {
     const filterResults = { x: { lowerBound: 0, upperBound: 1 } };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
-    const filerStatus = getFilterStatus(filterResults, filterTabs);
+    const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[[0, 1]]];
     expect(filerStatus).toEqual(expected);
   });
@@ -102,7 +102,7 @@ describe('Get filter status from filter results', () => {
       y: { lowerBound: 0, upperBound: 1 },
     };
     const filterTabs = [{ title: 'a', fields: ['x', 'y'] }];
-    const filerStatus = getFilterStatus(filterResults, filterTabs);
+    const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[{ foo: true, bar: true }, [0, 1]]];
     expect(filerStatus).toEqual(expected);
   });
@@ -116,7 +116,7 @@ describe('Get filter status from filter results', () => {
       { title: 'a', fields: ['x', 'z'] },
       { title: 'b', fields: ['y'] },
     ];
-    const filerStatus = getFilterStatus(filterResults, filterTabs);
+    const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]];
     expect(filerStatus).toEqual(expected);
   });

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -533,12 +533,19 @@ describe('Toggles combine mode in option filter', () => {
 
 describe('Update a range filter', () => {
   const [minValue, maxValue] = [0, 5];
-  function helper({ lowerBound, upperBound }) {
+  function helper({
+    filterStatus = [[[0, 1]]],
+    filterResults = { x: { lowerBound: 0, upperBound: 1 } },
+    anchorLabel,
+    lowerBound,
+    upperBound,
+  }) {
     return updateRangeValue({
-      filterStatus: [[[0, 1]]],
-      filterResults: { x: { lowerBound: 0, upperBound: 1 } },
-      filterTabs: [{ title: 'a', fields: ['x'] }],
+      filterStatus,
+      filterResults,
+      filterTabs: [{ title: 't', fields: ['x'] }],
       tabIndex: 0,
+      anchorLabel,
       sectionIndex: 0,
       lowerBound,
       upperBound,
@@ -566,6 +573,40 @@ describe('Update a range filter', () => {
     const expected = {
       filterResults: {},
       filterStatus: [[[minValue, maxValue]]],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Simple update in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ 'a:a0': [[0, 1]] }],
+      filterResults: {
+        'a:a0': { filter: { x: { lowerBound: 0, upperBound: 1 } } },
+      },
+      anchorLabel: 'a:a0',
+      lowerBound: 1,
+      upperBound: 2,
+    });
+    const expected = {
+      filterResults: {
+        'a:a0': { filter: { x: { lowerBound: 1, upperBound: 2 } } },
+      },
+      filterStatus: [{ 'a:a0': [[1, 2]] }],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('lowerBound and upperBound equal max and min values in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ 'a:a0': [[0, 1]] }],
+      filterResults: {
+        'a:a0': { filter: { x: { lowerBound: 0, upperBound: 1 } } },
+      },
+      anchorLabel: 'a:a0',
+      lowerBound: minValue,
+      upperBound: maxValue,
+    });
+    const expected = {
+      filterResults: {},
+      filterStatus: [{ 'a:a0': [[minValue, maxValue]] }],
     };
     expect(updated).toEqual(expected);
   });

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -34,9 +34,12 @@ describe('Get filter results by anchor label', () => {
     tabs: ['t1'],
   };
   test('Filter results with no anchor only', () => {
-    const received = getFilterResultsByAnchor(anchorConfig, {
-      x: { selectedValues: ['foo', 'bar'] },
-      y: { lowerBound: 0, upperBound: 1 },
+    const received = getFilterResultsByAnchor({
+      anchorConfig,
+      filterResults: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
     });
     const expected = {
       '': {
@@ -49,11 +52,14 @@ describe('Get filter results by anchor label', () => {
     expect(received).toEqual(expected);
   });
   test('Filter results with a single anchor label only', () => {
-    const received = getFilterResultsByAnchor(anchorConfig, {
-      'a:a0': {
-        filter: {
-          x: { selectedValues: ['foo'] },
-          y: { lowerBound: 0, upperBound: 1 },
+    const received = getFilterResultsByAnchor({
+      anchorConfig,
+      filterResults: {
+        'a:a0': {
+          filter: {
+            x: { selectedValues: ['foo'] },
+            y: { lowerBound: 0, upperBound: 1 },
+          },
         },
       },
     });
@@ -68,9 +74,12 @@ describe('Get filter results by anchor label', () => {
     expect(received).toEqual(expected);
   });
   test('Filter result with multiple anchor labels only', () => {
-    const received = getFilterResultsByAnchor(anchorConfig, {
-      'a:a0': { filter: { x: { selectedValues: ['foo'] } } },
-      'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+    const received = getFilterResultsByAnchor({
+      anchorConfig,
+      filterResults: {
+        'a:a0': { filter: { x: { selectedValues: ['foo'] } } },
+        'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+      },
     });
     const expected = {
       '': {},

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -444,12 +444,18 @@ describe('Check if a tab has active filter', () => {
 });
 
 describe('Toggles combine mode in option filter', () => {
-  function helper({ filterStatus, filterResults, combineModeValue }) {
+  function helper({
+    filterStatus,
+    filterResults,
+    anchorLabel,
+    combineModeValue,
+  }) {
     return toggleCombineOption({
       filterStatus,
       filterResults,
       filterTabs: [{ title: 'a', fields: ['x'] }],
       tabIndex: 0,
+      anchorLabel,
       sectionIndex: 0,
       combineModeFieldName: '__combineMode',
       combineModeValue,
@@ -476,6 +482,50 @@ describe('Toggles combine mode in option filter', () => {
     const expected = {
       filterResults: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
       filterStatus: [[{ foo: true, __combineMode: 'AND' }]],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Missing combine mode in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ '': [{}], 'a:a0': [{ foo: true }] }],
+      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      anchorLabel: 'a:a0',
+      combineModeValue: 'AND',
+    });
+    const expected = {
+      filterResults: {
+        'a:a0': {
+          filter: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
+        },
+      },
+      filterStatus: [
+        { '': [{}], 'a:a0': [{ foo: true, __combineMode: 'AND' }] },
+      ],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Exisiting combine mode in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [
+        { '': [{}], 'a:a0': [{ foo: true, __combineMode: 'OR' }] },
+      ],
+      filterResults: {
+        'a:a0': {
+          filter: { x: { selectedValues: ['foo'], __combineMode: 'OR' } },
+        },
+      },
+      anchorLabel: 'a:a0',
+      combineModeValue: 'AND',
+    });
+    const expected = {
+      filterResults: {
+        'a:a0': {
+          filter: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
+        },
+      },
+      filterStatus: [
+        { '': [{}], 'a:a0': [{ foo: true, __combineMode: 'AND' }] },
+      ],
     };
     expect(updated).toEqual(expected);
   });

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -5,7 +5,7 @@ import {
   clearFilterSection,
   removeEmptyFilter,
   tabHasActiveFilters,
-  toggleCombineOption,
+  updateCombineMode,
   updateRangeValue,
   updateSelectedValue,
 } from './utils';
@@ -450,7 +450,7 @@ describe('Toggles combine mode in option filter', () => {
     anchorLabel,
     combineModeValue,
   }) {
-    return toggleCombineOption({
+    return updateCombineMode({
       filterStatus,
       filterResults,
       filterTabs: [{ title: 'a', fields: ['x'] }],

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -431,6 +431,16 @@ describe('Check if a tab has active filter', () => {
     const hasActiveFilters = tabHasActiveFilters(filterTabStatus);
     expect(hasActiveFilters).toEqual(true);
   });
+  test('No active anchored filter', () => {
+    const filterTabStatus = { '': [{}, {}], 'a:a0': [{}, {}] };
+    const hasActiveFilters = tabHasActiveFilters(filterTabStatus);
+    expect(hasActiveFilters).toEqual(false);
+  });
+  test('One active anchored range filter', () => {
+    const filterTabStatus = { '': [{}, {}], 'a:a0': [{}, [0, 1]] };
+    const hasActiveFilters = tabHasActiveFilters(filterTabStatus);
+    expect(hasActiveFilters).toEqual(true);
+  });
 });
 
 describe('Toggles combine mode in option filter', () => {

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -255,19 +255,27 @@ describe('Get filter status from filter results', () => {
 });
 
 describe('Clear a single filter section', () => {
-  function helper({ tabIndex, sectionIndex }) {
+  function helper({
+    filterResults = {
+      x: { selectedValues: ['foo', 'bar'] },
+      y: { lowerBound: 0, upperBound: 1 },
+      z: { selectedValues: ['baz'] },
+    },
+    filterStatus = [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]],
+    filterTabs = [
+      { title: 't0', fields: ['x', 'z'] },
+      { title: 't1', fields: ['y'] },
+    ],
+    tabIndex,
+    anchorLabel,
+    sectionIndex,
+  }) {
     return clearFilterSection({
-      filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
-        z: { selectedValues: ['baz'] },
-      },
-      filterStatus: [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]],
-      filterTabs: [
-        { title: 'a', fields: ['x', 'z'] },
-        { title: 'b', fields: ['y'] },
-      ],
+      filterResults,
+      filterStatus,
+      filterTabs,
       tabIndex,
+      anchorLabel,
       sectionIndex,
     });
   }
@@ -292,6 +300,33 @@ describe('Clear a single filter section', () => {
     });
     const expected = {
       filterStatus: [[{ foo: true, bar: true }, { baz: true }], [{}]],
+      filterResults: {
+        x: { selectedValues: ['foo', 'bar'] },
+        z: { selectedValues: ['baz'] },
+      },
+    };
+    expect(cleared).toEqual(expected);
+  });
+  test('Anchored filter', () => {
+    const cleared = helper({
+      filterResults: {
+        x: { selectedValues: ['foo', 'bar'] },
+        z: { selectedValues: ['baz'] },
+        'a:a0': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+      },
+      filterStatus: [
+        [{ foo: true, bar: true }, { baz: true }],
+        { '': [{}], 'a:a0': [[0, 1]] },
+      ],
+      anchorLabel: 'a:a0',
+      tabIndex: 1,
+      sectionIndex: 0,
+    });
+    const expected = {
+      filterStatus: [
+        [{ foo: true, bar: true }, { baz: true }],
+        { '': [{}], 'a:a0': [{}] },
+      ],
       filterResults: {
         x: { selectedValues: ['foo', 'bar'] },
         z: { selectedValues: ['baz'] },

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -613,12 +613,13 @@ describe('Update a range filter', () => {
 });
 
 describe('Update an option filter', () => {
-  function helper({ filterStatus, filterResults, selectedValue }) {
+  function helper({ filterStatus, filterResults, anchorLabel, selectedValue }) {
     return updateSelectedValue({
       filterStatus,
       filterResults,
       filterTabs: [{ title: 'a', fields: ['x'] }],
       tabIndex: 0,
+      anchorLabel,
       sectionIndex: 0,
       selectedValue,
     });
@@ -644,6 +645,32 @@ describe('Update an option filter', () => {
     const expected = {
       filterResults: {},
       filterStatus: [[{ foo: false }]],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Select value in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ 'a:a0': [{}] }],
+      filterResults: {},
+      anchorLabel: 'a:a0',
+      selectedValue: 'foo',
+    });
+    const expected = {
+      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      filterStatus: [{ 'a:a0': [{ foo: true }] }],
+    };
+    expect(updated).toEqual(expected);
+  });
+  test('Unselect value in anchored filter', () => {
+    const updated = helper({
+      filterStatus: [{ 'a:a0': [{ foo: true }] }],
+      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      anchorLabel: 'a:a0',
+      selectedValue: 'foo',
+    });
+    const expected = {
+      filterResults: {},
+      filterStatus: [{ 'a:a0': [{ foo: false }] }],
     };
     expect(updated).toEqual(expected);
   });

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -28,6 +28,21 @@ describe('Get expanded status array for all tabs', () => {
 });
 
 describe('Get filter results by anchor label', () => {
+  test('Missing anchor config', () => {
+    const received = getFilterResultsByAnchor({
+      filterResults: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
+    });
+    const expected = {
+      '': {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
+    };
+    expect(received).toEqual(expected);
+  });
   const anchorConfig = {
     fieldName: 'a',
     options: ['a0', 'a1'],

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -54,10 +54,13 @@ function FilterGroup({
 
   const [filterResults, setFilterResults] = useState(initialAppliedFilters);
   const [filterStatus, setFilterStatus] = useState(
-    getFilterStatus(initialAppliedFilters, filterTabs)
+    getFilterStatus({ filterResults: initialAppliedFilters, filterTabs })
   );
   useEffect(() => {
-    const newFilterStatus = getFilterStatus(initialAppliedFilters, filterTabs);
+    const newFilterStatus = getFilterStatus({
+      filterResults: initialAppliedFilters,
+      filterTabs,
+    });
     const newFilterResults = initialAppliedFilters;
 
     setFilterStatus(newFilterStatus);

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -7,7 +7,7 @@ import {
   getFilterStatus,
   clearFilterSection,
   tabHasActiveFilters,
-  toggleCombineOption,
+  updateCombineMode,
   updateRangeValue,
   updateSelectedValue,
 } from './utils';
@@ -102,7 +102,7 @@ function FilterGroup({
     combineModeFieldName,
     combineModeValue
   ) {
-    const updated = toggleCombineOption({
+    const updated = updateCombineMode({
       filterStatus,
       filterResults,
       filterTabs,

--- a/src/gen3-ui-component/components/filters/FilterGroup/typedef.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/typedef.js
@@ -6,6 +6,12 @@
 
 /** @typedef {OptionFilterStatus | RangeFilterStatus} FilterSectionStatus */
 
+/** @typedef {FilterSectionStatus[]} FilterTabStatus */
+
+/** @typedef {{ [anchorLabel: string]: FilterTabStatus }} AnchoredFilterTabStatus */
+
+/** @typedef {(FilterTabStatus | AnchoredFilterTabStatus)[]} FilterStatus */
+
 /**
  * @typedef {Object} AnchorConfig
  * @property {string} fieldName

--- a/src/gen3-ui-component/components/filters/FilterGroup/typedef.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/typedef.js
@@ -5,3 +5,10 @@
 /** @typedef {[lowerBound: number, upperBound: number]} RangeFilterStatus */
 
 /** @typedef {OptionFilterStatus | RangeFilterStatus} FilterSectionStatus */
+
+/**
+ * @typedef {Object} AnchorConfig
+ * @property {string} fieldName
+ * @property {string[]} options
+ * @property {string[]} tabs
+ */

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -12,27 +12,35 @@ export function getExpandedStatus(filterTabs, expandedStatusControl) {
 }
 
 /**
+ * @param {string[]} fields
+ * @param {SimpleFilterState} filterResults
+ */
+function getFilterTabStatus(fields, filterResults) {
+  return fields.map((field) => {
+    if (field in filterResults) {
+      const filterValues = filterResults[field];
+      if ('selectedValues' in filterValues) {
+        const status = {};
+        for (const selected of filterValues.selectedValues)
+          status[selected] = true;
+        return status;
+      }
+      if ('lowerBound' in filterValues) {
+        return [filterValues.lowerBound, filterValues.upperBound];
+      }
+    }
+    return {};
+  });
+}
+
+/**
  * @param {FilterState} filterResults
  * @param {FilterTabsOption[]} filterTabs
  * @returns {FilterSectionStatus[][]}
  */
 export function getFilterStatus(filterResults, filterTabs) {
   return filterTabs.map(({ fields }) =>
-    fields.map((field) => {
-      if (Object.keys(filterResults).includes(field)) {
-        const filterValues = filterResults[field];
-        if ('selectedValues' in filterValues) {
-          const status = {};
-          for (const selected of filterValues.selectedValues)
-            status[selected] = true;
-          return status;
-        }
-        if ('lowerBound' in filterValues) {
-          return [filterValues.lowerBound, filterValues.upperBound];
-        }
-      }
-      return {};
-    })
+    getFilterTabStatus(fields, filterResults)
   );
 }
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -176,7 +176,7 @@ export function tabHasActiveFilters(filterTabStatus) {
  * @param {string} args.combineModeFieldName
  * @param {string} args.combineModeValue
  */
-export function toggleCombineOption({
+export function updateCombineMode({
   filterStatus,
   filterResults,
   filterTabs,

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -12,6 +12,27 @@ export function getExpandedStatus(filterTabs, expandedStatusControl) {
 }
 
 /**
+ * @param {AnchorConfig} anchorConfig
+ * @param {FilterState} filterResults
+ */
+export function getFilterResultsByAnchor(anchorConfig, filterResults) {
+  /** @type {{ [anchorLabel: string]: SimpleFilterState }} */
+  const filterResultsByAnchor = { '': {} };
+
+  for (const anchorValue of anchorConfig.options)
+    filterResultsByAnchor[`${anchorConfig.fieldName}:${anchorValue}`] = {};
+
+  for (const [filterKey, filterValues] of Object.entries(filterResults))
+    if ('filter' in filterValues) {
+      filterResultsByAnchor[filterKey] = filterValues.filter;
+    } else {
+      filterResultsByAnchor[''][filterKey] = filterValues;
+    }
+
+  return filterResultsByAnchor;
+}
+
+/**
  * @param {string[]} fields
  * @param {SimpleFilterState} filterResults
  */

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -37,6 +37,7 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
 /**
  * @param {string[]} fields
  * @param {SimpleFilterState} filterResults
+ * @returns {FilterTabStatus}
  */
 function getFilterTabStatus(fields, filterResults) {
   return fields.map((field) => {

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -117,6 +117,7 @@ export function removeEmptyFilter(filterResults) {
  * @param {FilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
+ * @param {string} args.anchorLabel
  * @param {number} args.sectionIndex
  */
 export function clearFilterSection({
@@ -124,16 +125,23 @@ export function clearFilterSection({
   filterResults,
   filterTabs,
   tabIndex,
+  anchorLabel,
   sectionIndex,
 }) {
   // update filter status
   const newFilterStatus = cloneDeep(filterStatus);
-  newFilterStatus[tabIndex][sectionIndex] = {};
+  const newFilterTabStatus = newFilterStatus[tabIndex];
+  if (Array.isArray(newFilterTabStatus)) newFilterTabStatus[sectionIndex] = {};
+  else newFilterTabStatus[anchorLabel][sectionIndex] = {};
 
   // update filter results; clear the results for this filter
   let newFilterResults = cloneDeep(filterResults);
-  const field = filterTabs[tabIndex].fields[sectionIndex];
-  newFilterResults[field] = {};
+  const fieldName = filterTabs[tabIndex].fields[sectionIndex];
+  if (anchorLabel === undefined || anchorLabel === '') {
+    newFilterResults[fieldName] = {};
+  } else {
+    newFilterResults[anchorLabel].filter[fieldName] = {};
+  }
   newFilterResults = removeEmptyFilter(newFilterResults);
 
   // update component state

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -20,8 +20,9 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
   /** @type {{ [anchorLabel: string]: SimpleFilterState }} */
   const filterResultsByAnchor = { '': {} };
 
-  for (const anchorValue of anchorConfig.options)
-    filterResultsByAnchor[`${anchorConfig.fieldName}:${anchorValue}`] = {};
+  if (anchorConfig !== undefined)
+    for (const anchorValue of anchorConfig.options)
+      filterResultsByAnchor[`${anchorConfig.fieldName}:${anchorValue}`] = {};
 
   for (const [filterKey, filterValues] of Object.entries(filterResults))
     if ('filter' in filterValues) {

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -59,14 +59,27 @@ function getFilterTabStatus(fields, filterResults) {
 
 /**
  * @param {Object} args
+ * @param {AnchorConfig} args.anchorConfig
  * @param {FilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
- * @returns {FilterSectionStatus[][]}
+ * @returns {FilterStatus}
  */
-export function getFilterStatus({ filterResults, filterTabs }) {
-  return filterTabs.map(({ fields }) =>
-    getFilterTabStatus(fields, filterResults)
-  );
+export function getFilterStatus({ anchorConfig, filterResults, filterTabs }) {
+  const filterResultsByAnchor = getFilterResultsByAnchor({
+    anchorConfig,
+    filterResults,
+  });
+  return filterTabs.map(({ title, fields }) => {
+    if (anchorConfig?.tabs.includes(title)) {
+      /** @type {AnchoredFilterTabStatus} */
+      const status = {};
+      for (const [anchor, results] of Object.entries(filterResultsByAnchor))
+        status[anchor] = getFilterTabStatus(fields, results);
+      return status;
+    }
+
+    return getFilterTabStatus(fields, filterResultsByAnchor['']);
+  });
 }
 
 /** @param {FilterState} filterResults */

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -171,6 +171,7 @@ export function tabHasActiveFilters(filterTabStatus) {
  * @param {FilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
+ * @param {string} args.anchorLabel
  * @param {number} args.sectionIndex
  * @param {string} args.combineModeFieldName
  * @param {string} args.combineModeValue
@@ -180,24 +181,45 @@ export function toggleCombineOption({
   filterResults,
   filterTabs,
   tabIndex,
+  anchorLabel,
   sectionIndex,
   combineModeFieldName,
   combineModeValue,
 }) {
   // update filter status
   const newFilterStatus = cloneDeep(filterStatus);
-  newFilterStatus[tabIndex][sectionIndex][
-    combineModeFieldName
-  ] = combineModeValue;
+  const newFilterTabStatus = newFilterStatus[tabIndex];
+  if (Array.isArray(newFilterTabStatus))
+    newFilterTabStatus[sectionIndex][combineModeFieldName] = combineModeValue;
+  else
+    newFilterTabStatus[anchorLabel][sectionIndex][
+      combineModeFieldName
+    ] = combineModeValue;
 
   // update filter results
   let newFilterResults = cloneDeep(filterResults);
-  const field = filterTabs[tabIndex].fields[sectionIndex];
-  if (newFilterResults[field] === undefined) {
-    newFilterResults[field] = { [combineModeFieldName]: combineModeValue };
+  const fieldName = filterTabs[tabIndex].fields[sectionIndex];
+  if (anchorLabel === undefined || anchorLabel === '') {
+    if (newFilterResults[fieldName] === undefined) {
+      newFilterResults[fieldName] = {
+        [combineModeFieldName]: combineModeValue,
+      };
+    } else {
+      newFilterResults[fieldName][combineModeFieldName] = combineModeValue;
+    }
   } else {
-    newFilterResults[field][combineModeFieldName] = combineModeValue;
+    const newAnchoredFilterResults = newFilterResults[anchorLabel].filter;
+    if (newAnchoredFilterResults[fieldName] === undefined) {
+      newAnchoredFilterResults[fieldName] = {
+        [combineModeFieldName]: combineModeValue,
+      };
+    } else {
+      newAnchoredFilterResults[fieldName][
+        combineModeFieldName
+      ] = combineModeValue;
+    }
   }
+
   newFilterResults = removeEmptyFilter(newFilterResults);
 
   // update component state

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -208,6 +208,10 @@ export function toggleCombineOption({
       newFilterResults[fieldName][combineModeFieldName] = combineModeValue;
     }
   } else {
+    if (!(anchorLabel in newFilterResults))
+      newFilterResults[anchorLabel] = { filter: {} };
+    if (!('filter' in newFilterResults[anchorLabel]))
+      newFilterResults[anchorLabel].filter = {};
     const newAnchoredFilterResults = newFilterResults[anchorLabel].filter;
     if (newAnchoredFilterResults[fieldName] === undefined) {
       newAnchoredFilterResults[fieldName] = {
@@ -277,6 +281,10 @@ export function updateRangeValue({
       delete newFilterResults[fieldName];
     }
   } else {
+    if (!(anchorLabel in newFilterResults))
+      newFilterResults[anchorLabel] = { filter: {} };
+    if (!('filter' in newFilterResults[anchorLabel]))
+      newFilterResults[anchorLabel].filter = {};
     const newAnchoredFilterResults = newFilterResults[anchorLabel].filter;
     newAnchoredFilterResults[fieldName] = { lowerBound, upperBound };
     // if lowerbound and upperbound values equal min and max,
@@ -347,6 +355,10 @@ export function updateSelectedValue({
         selectedValues.push(selectedValue);
     }
   } else {
+    if (!(anchorLabel in newFilterResults))
+      newFilterResults[anchorLabel] = { filter: {} };
+    if (!('filter' in newFilterResults[anchorLabel]))
+      newFilterResults[anchorLabel].filter = {};
     const newAnchoredFilterResults = newFilterResults[anchorLabel].filter;
     if (newAnchoredFilterResults[fieldName] === undefined)
       newAnchoredFilterResults[fieldName] = { selectedValues: [selectedValue] };

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -235,6 +235,7 @@ export function toggleCombineOption({
  * @param {FilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
+ * @param {string} args.anchorLabel
  * @param {number} args.sectionIndex
  * @param {number} args.lowerBound
  * @param {number} args.upperBound
@@ -247,6 +248,7 @@ export function updateRangeValue({
   filterResults,
   filterTabs,
   tabIndex,
+  anchorLabel,
   sectionIndex,
   lowerBound,
   upperBound,
@@ -256,19 +258,35 @@ export function updateRangeValue({
 }) {
   // update filter status
   const newFilterStatus = cloneDeep(filterStatus);
-  newFilterStatus[tabIndex][sectionIndex] = [lowerBound, upperBound];
+  const newFilterTabStatus = newFilterStatus[tabIndex];
+  if (Array.isArray(newFilterTabStatus))
+    newFilterTabStatus[sectionIndex] = [lowerBound, upperBound];
+  else newFilterTabStatus[anchorLabel][sectionIndex] = [lowerBound, upperBound];
 
   // update filter results
   let newFilterResults = cloneDeep(filterResults);
-  const field = filterTabs[tabIndex].fields[sectionIndex];
-  newFilterResults[field] = { lowerBound, upperBound };
-  // if lowerbound and upperbound values equal min and max,
-  // remove this range from filter
-  if (
-    Math.abs(lowerBound - minValue) < rangeStep &&
-    Math.abs(upperBound - maxValue) < rangeStep
-  ) {
-    delete newFilterResults[field];
+  const fieldName = filterTabs[tabIndex].fields[sectionIndex];
+  if (anchorLabel === undefined || anchorLabel === '') {
+    newFilterResults[fieldName] = { lowerBound, upperBound };
+    // if lowerbound and upperbound values equal min and max,
+    // remove this range from filter
+    if (
+      Math.abs(lowerBound - minValue) < rangeStep &&
+      Math.abs(upperBound - maxValue) < rangeStep
+    ) {
+      delete newFilterResults[fieldName];
+    }
+  } else {
+    const newAnchoredFilterResults = newFilterResults[anchorLabel].filter;
+    newAnchoredFilterResults[fieldName] = { lowerBound, upperBound };
+    // if lowerbound and upperbound values equal min and max,
+    // remove this range from filter
+    if (
+      Math.abs(lowerBound - minValue) < rangeStep &&
+      Math.abs(upperBound - maxValue) < rangeStep
+    ) {
+      delete newAnchoredFilterResults[fieldName];
+    }
   }
   newFilterResults = removeEmptyFilter(newFilterResults);
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -42,17 +42,23 @@ export function removeEmptyFilter(filterResults) {
   const newFilterResults = {};
   for (const field of Object.keys(filterResults)) {
     const filterValues = filterResults[field];
-    const hasRangeFilter = 'lowerBound' in filterValues;
-    const hasOptionFilter =
-      'selectedValues' in filterValues &&
-      filterValues.selectedValues.length > 0;
-    // Filter settings are prefaced with two underscores, e.g., __combineMode
-    // A given config setting is still informative to Guppy even if the setting becomes empty
-    const hasConfigSetting = Object.keys(filterValues).some((x) =>
-      x.startsWith('__')
-    );
-    if (hasRangeFilter || hasOptionFilter || hasConfigSetting) {
-      newFilterResults[field] = filterValues;
+    if ('filter' in filterValues) {
+      const newAnchoredFilterResults = removeEmptyFilter(filterValues.filter);
+      if (Object.keys(newAnchoredFilterResults).length > 0)
+        newFilterResults[field] = { filter: newAnchoredFilterResults };
+    } else {
+      const hasRangeFilter = 'lowerBound' in filterValues;
+      const hasOptionFilter =
+        'selectedValues' in filterValues &&
+        filterValues.selectedValues.length > 0;
+      // Filter settings are prefaced with two underscores, e.g., __combineMode
+      // A given config setting is still informative to Guppy even if the setting becomes empty
+      const hasConfigSetting = Object.keys(filterValues).some((x) =>
+        x.startsWith('__')
+      );
+      if (hasRangeFilter || hasOptionFilter || hasConfigSetting) {
+        newFilterResults[field] = filterValues;
+      }
     }
   }
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -151,15 +151,18 @@ export function clearFilterSection({
   };
 }
 
-/** @param {FilterSectionStatus[]} filterTabStatus */
+/** @param {FilterTabStatus | AnchoredFilterTabStatus} filterTabStatus */
 export function tabHasActiveFilters(filterTabStatus) {
-  for (const filterSectionStatus of filterTabStatus) {
-    const hasActiveFilters = Object.values(filterSectionStatus).some(
-      (status) => status !== undefined && status !== false
-    );
-    if (hasActiveFilters) return true;
+  if (Array.isArray(filterTabStatus)) {
+    for (const filterSectionStatus of filterTabStatus) {
+      const hasActiveFilters = Object.values(filterSectionStatus).some(
+        (status) => status !== undefined && status !== false
+      );
+      if (hasActiveFilters) return true;
+    }
+    return false;
   }
-  return false;
+  return Object.values(filterTabStatus).some(tabHasActiveFilters);
 }
 
 /**

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -12,10 +12,11 @@ export function getExpandedStatus(filterTabs, expandedStatusControl) {
 }
 
 /**
- * @param {AnchorConfig} anchorConfig
- * @param {FilterState} filterResults
+ * @param {Object} args
+ * @param {AnchorConfig} args.anchorConfig
+ * @param {FilterState} args.filterResults
  */
-export function getFilterResultsByAnchor(anchorConfig, filterResults) {
+export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
   /** @type {{ [anchorLabel: string]: SimpleFilterState }} */
   const filterResultsByAnchor = { '': {} };
 

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -55,11 +55,12 @@ function getFilterTabStatus(fields, filterResults) {
 }
 
 /**
- * @param {FilterState} filterResults
- * @param {FilterTabsOption[]} filterTabs
+ * @param {Object} args
+ * @param {FilterState} args.filterResults
+ * @param {FilterTabsOption[]} args.filterTabs
  * @returns {FilterSectionStatus[][]}
  */
-export function getFilterStatus(filterResults, filterTabs) {
+export function getFilterStatus({ filterResults, filterTabs }) {
   return filterTabs.map(({ fields }) =>
     getFilterTabStatus(fields, filterResults)
   );


### PR DESCRIPTION
Ticket: [PEDS-469](https://pcdc.atlassian.net/browse/PEDS-469)

This PR modifies all utility functions for `<FilterGroup>` relevant to `filterStatus` and `filterResults` states to handle anchored filters. The PR also adds more tests to exercise utility functions for anchored filter cases.

In doing so, the data structure for `filterStatus` is extended to support encoding filter UI status for anchored filters (see changes to `typedef.js`).

Examples:
```js
/**
 * No anchor filters; two tabs, each with two filter sections
 * This is the same as before
 * @type {FilterStatus} previously just FilterSectionStatus[][]
 */
const filterStatus1 = [
  // first filter tab status
  [
    { foo: true },
    [0, 1],
  ],
  // second filter tab status
  [
    { bar: true },
    {},
  ],
]

/**
 * One normal tab and one anchored tab
 * @type {FilterStatus}
 */
const filterStatus2 = [
  // first filter tab status, no anchor
  [
    { foo: true },
    {},
  ],
  // second filter tab status, using "disease_phase" values as anchors
  // available anchor options are "First Diagnosis" and "Relapse"
  {
    // filter status for the second tab with no anchor value
    '':, [
      {},
      {},
    ]
    // filter status for the second tab with anchor value set to "First Diagnosis"
    'disease_phase:First Diagnosis': [
      { bar: true },
      {},
    ],
    // filter status for the second tab with anchor value set to "Relapse"
    'disease_phase:Relapse': [
      {},
      [0, 5],
    ],
  }
]
```

The update utility function now requires `args.anchorConfig` in parameter (see `typedef.js` for the relevant type, `AnchorConfig`).

Example:
```js
/** @type {AnchorConfig} */
const anchorConfig = {
  fieldName: 'disease_phase',
  options: ['First Diagnosis', 'Relapse'],
  tabs: ['Disease', 'Molecular']
}
```

Other minor changes include:
* `getFilterStatus()` now expects a single `args` parameter object
* `toggleCombineOption()` is renamed to `updateCombineMode()`