### PR TITLE
Fix incomplete filter tabs options PEDS-479

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -25,6 +25,7 @@ import '../typedef';
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
  * @property {string[]} patientIds
  * @property {FilterState} initialAppliedFilters
+ * @property {SimpleAggsData} initialTabsOptions
  * @property {AggsData} receivedAggsData
  * @property {boolean} hideZero
  * @property {boolean} hidden
@@ -46,8 +47,6 @@ class ConnectedFilter extends React.Component {
       props.initialAppliedFilters,
       props.adminAppliedPreFilters
     );
-    /** @type {SimpleAggsData} */
-    this.initialTabsOptions = {};
     /** @type {ConnectedFilterState} */
     this.state = {
       initialAggsData: {},
@@ -118,12 +117,10 @@ class ConnectedFilter extends React.Component {
     const tabsOptions = unnestAggsData(
       this.props.onProcessFilterAggsData(this.props.receivedAggsData)
     );
-    if (Object.keys(this.initialTabsOptions).length === 0)
-      this.initialTabsOptions = tabsOptions;
 
     const processedTabsOptions = sortTabsOptions(
       updateCountsInInitialTabsOptions(
-        this.initialTabsOptions,
+        this.props.initialTabsOptions,
         tabsOptions,
         this.state.filter
       )
@@ -147,7 +144,7 @@ class ConnectedFilter extends React.Component {
             searchFields,
             this.props.guppyConfig.fieldMapping,
             processedTabsOptions,
-            this.initialTabsOptions,
+            this.props.initialTabsOptions,
             this.props.adminAppliedPreFilters,
             this.props.guppyConfig,
             this.arrayFields
@@ -219,6 +216,7 @@ ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   initialAppliedFilters: PropTypes.object,
+  initialTabsOptions: PropTypes.object,
   receivedAggsData: PropTypes.object,
   hideZero: PropTypes.bool,
   hidden: PropTypes.bool,
@@ -232,6 +230,7 @@ ConnectedFilter.defaultProps = {
   onProcessFilterAggsData: (data) => data,
   adminAppliedPreFilters: {},
   initialAppliedFilters: {},
+  initialTabsOptions: {},
   receivedAggsData: {},
   hideZero: false,
   hidden: false,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -47,6 +47,7 @@ function histogramQueryStrForEachField(field) {
  * @param {string} args.type
  * @param {string[]} args.fields
  * @param {GqlFilter} [args.gqlFilter]
+ * @param {boolean} [args.shouldGetFullAggsData]
  * @param {AbortSignal} [args.signal]
  */
 export function queryGuppyForAggregationData({
@@ -54,8 +55,12 @@ export function queryGuppyForAggregationData({
   type,
   fields,
   gqlFilter,
+  shouldGetFullAggsData = false,
   signal,
 }) {
+  const fullAagsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
+    ${fields.map((field) => histogramQueryStrForEachField(field))}
+  }`;
   const query = (gqlFilter !== undefined
     ? `query ($filter: JSON) {
         _aggregation {
@@ -68,6 +73,7 @@ export function queryGuppyForAggregationData({
           all: ${type} (filter: $filter, accessibility: all) {
             _totalCount
           }
+          ${shouldGetFullAggsData ? fullAagsDataQueryFragment : ''}
         }
       }`
     : `query {

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,6 +14,7 @@ import './ExplorerFilter.css';
  * @property {number} tierAccessLimit
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
  * @property {FilterState} initialAppliedFilters
+ * @property {SimpleAggsData} initialTabsOptions
  * @property {string[]} patientIds
  * @property {(x: string[]) => void} onPatientIdsChange
  */

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -56,7 +56,13 @@ function FilterGroup({
   const [filterStatus, setFilterStatus] = useState(
     getFilterStatus({ filterResults: initialAppliedFilters, filterTabs })
   );
+  const isInitialRenderRef = useRef(true);
   useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+      return;
+    }
+
     const newFilterStatus = getFilterStatus({
       filterResults: initialAppliedFilters,
       filterTabs,

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -62,6 +62,10 @@ class FilterSection extends React.Component {
     this.combineModeFieldName = '__combineMode';
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.options !== this.props.options) this.updateVisibleOptions();
+  }
+
   handleSetCombineModeOption = (combineModeIn) => {
     // Combine mode: AND or OR
     this.setState({ combineMode: combineModeIn });


### PR DESCRIPTION
Ticket: [PEDS-479](https://pcdc.atlassian.net/browse/PEDS-479)

This PR fixes the problem of incomplete filter tabs options when the explorer page is first loaded with non-empty filter value, e.g. via `?filter` search parameter value. When this happens, the visible filter options are fixed to what was visible on the initial load, and hidden options cannot be brought back to being visible through clearing or otherwise updating filters.

⚠️ The fix relies on always fetching no-filter aggregated data results on the initial load, which can be quite costly. 