### PR TITLE
Use anchor filter UI PEDS-469

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -23,6 +23,7 @@ import '../typedef';
  * @property {boolean} [hideZero]
  * @property {FilterState} [initialAppliedFilters]
  * @property {SimpleAggsData} initialTabsOptions
+ * @property {(anchorValue: string) => void} onAnchorValueChange
  * @property {FilterChangeHandler} onFilterChange
  * @property {(x: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
@@ -42,6 +43,7 @@ function ConnectedFilter({
   hideZero = false,
   initialAppliedFilters = {},
   initialTabsOptions = {},
+  onAnchorValueChange,
   onFilterChange,
   onPatientIdsChange,
   patientIds,
@@ -100,6 +102,7 @@ function ConnectedFilter({
       className={className}
       tabs={filterTabs}
       filterConfig={filterConfig}
+      onAnchorValueChange={onAnchorValueChange}
       onFilterChange={onFilterChange}
       onPatientIdsChange={onPatientIdsChange}
       patientIds={patientIds}
@@ -142,6 +145,7 @@ ConnectedFilter.propTypes = {
   hideZero: PropTypes.bool,
   initialAppliedFilters: PropTypes.object,
   initialTabsOptions: PropTypes.object,
+  onAnchorValueChange: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -15,6 +15,7 @@ import '../typedef';
 /**
  * @typedef {Object} ConnectedFilterProps
  * @property {{ [x: string]: OptionFilter }} [adminAppliedPreFilters]
+ * @property {AnchorConfig} anchorConfig
  * @property {string} className
  * @property {FilterState} filter
  * @property {FilterConfig} filterConfig
@@ -34,6 +35,7 @@ import '../typedef';
 /** @param {ConnectedFilterProps} props */
 function ConnectedFilter({
   adminAppliedPreFilters = {},
+  anchorConfig,
   className = '',
   filter,
   filterConfig,
@@ -98,6 +100,7 @@ function ConnectedFilter({
 
   return (
     <FilterGroup
+      anchorConfig={anchorConfig}
       className={className}
       tabs={filterTabs}
       filterConfig={filterConfig}
@@ -112,6 +115,11 @@ function ConnectedFilter({
 
 ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
+  anchorConfig: PropTypes.shape({
+    fieldName: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.string),
+    tabs: PropTypes.arrayOf(PropTypes.string),
+  }),
   className: PropTypes.string,
   filter: PropTypes.object.isRequired,
   filterConfig: PropTypes.shape({

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -8,7 +8,6 @@ import {
   getFilterSections,
   updateCountsInInitialTabsOptions,
   sortTabsOptions,
-  unnestAggsData,
 } from '../Utils/filters';
 import '../typedef';
 
@@ -27,8 +26,8 @@ import '../typedef';
  * @property {(x: FilterState) => void} onFilterChange
  * @property {(x: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
- * @property {AggsData} receivedAggsData
  * @property {number} [tierAccessLimit]
+ * @property {SimpleAggsData} tabsOptions
  */
 
 /** @param {ConnectedFilterProps} props */
@@ -46,7 +45,7 @@ function ConnectedFilter({
   onFilterChange,
   onPatientIdsChange,
   patientIds,
-  receivedAggsData,
+  tabsOptions = {},
   tierAccessLimit,
 }) {
   if (
@@ -56,7 +55,6 @@ function ConnectedFilter({
   )
     return null;
 
-  const tabsOptions = unnestAggsData(receivedAggsData);
   const processedTabsOptions = sortTabsOptions(
     updateCountsInInitialTabsOptions(initialTabsOptions, tabsOptions, filter)
   );
@@ -147,7 +145,7 @@ ConnectedFilter.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),
-  receivedAggsData: PropTypes.object.isRequired,
+  tabsOptions: PropTypes.object,
   tierAccessLimit: PropTypes.number,
 };
 

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -26,7 +26,6 @@ import '../typedef';
  * @property {SimpleAggsData} initialTabsOptions
  * @property {(x: FilterState) => void} onFilterChange
  * @property {(x: string[]) => void} [onPatientIdsChange]
- * @property {(x: AggsData) => AggsData} [onProcessFilterAggsData]
  * @property {string[]} [patientIds]
  * @property {AggsData} receivedAggsData
  * @property {number} [tierAccessLimit]
@@ -46,7 +45,6 @@ function ConnectedFilter({
   initialTabsOptions = {},
   onFilterChange,
   onPatientIdsChange,
-  onProcessFilterAggsData = (data) => data,
   patientIds,
   receivedAggsData,
   tierAccessLimit,
@@ -58,7 +56,7 @@ function ConnectedFilter({
   )
     return null;
 
-  const tabsOptions = unnestAggsData(onProcessFilterAggsData(receivedAggsData));
+  const tabsOptions = unnestAggsData(receivedAggsData);
   const processedTabsOptions = sortTabsOptions(
     updateCountsInInitialTabsOptions(initialTabsOptions, tabsOptions, filter)
   );
@@ -148,7 +146,6 @@ ConnectedFilter.propTypes = {
   initialTabsOptions: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired,
   onPatientIdsChange: PropTypes.func,
-  onProcessFilterAggsData: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   receivedAggsData: PropTypes.object.isRequired,
   tierAccessLimit: PropTypes.number,

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -23,7 +23,7 @@ import '../typedef';
  * @property {boolean} [hideZero]
  * @property {FilterState} [initialAppliedFilters]
  * @property {SimpleAggsData} initialTabsOptions
- * @property {(x: FilterState) => void} onFilterChange
+ * @property {FilterChangeHandler} onFilterChange
  * @property {(x: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
  * @property {number} [tierAccessLimit]

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -160,19 +160,19 @@ function GuppyWrapper({
           }`
         );
 
-      const receivedAggsData = data._aggregation[guppyConfig.dataType];
-      const fullAggsData =
+      const mainAggsData = data._aggregation.main;
+      const unfilteredAggsData =
         Object.keys(filter).length === 0
-          ? receivedAggsData
-          : data._aggregation.fullAggsData;
+          ? mainAggsData
+          : data._aggregation.unfiltered;
 
       return {
-        aggsData: excludeSelfFilterFromAggsData(receivedAggsData, filter),
+        aggsData: excludeSelfFilterFromAggsData(mainAggsData, filter),
         initialTabsOptions:
-          fullAggsData === undefined
+          unfilteredAggsData === undefined
             ? initialTabsOptions
-            : unnestAggsData(fullAggsData),
-        tabsOptions: unnestAggsData(receivedAggsData),
+            : unnestAggsData(unfilteredAggsData),
+        tabsOptions: unnestAggsData(mainAggsData),
       };
     });
   }

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -42,7 +42,7 @@ import '../typedef';
  * @property {boolean} isLoadingAggsData
  * @property {boolean} isLoadingRawData
  * @property {Object[]} rawData
- * @property {AggsData} receivedAggsData
+ * @property {SimpleAggsData} tabsOptions
  * @property {number} totalCount
  */
 
@@ -68,8 +68,8 @@ function GuppyWrapper({
     initialTabsOptions: undefined,
     isLoadingAggsData: false,
     isLoadingRawData: false,
-    receivedAggsData: {},
     rawData: [],
+    tabsOptions: {},
     totalCount: 0,
   });
   const controller = useRef(new AbortController());
@@ -136,7 +136,7 @@ function GuppyWrapper({
               ? prevState.initialTabsOptions
               : unnestAggsData(fullAggsData),
           isLoadingAggsData: false,
-          receivedAggsData,
+          tabsOptions: unnestAggsData(receivedAggsData),
           totalCount,
         }));
     });

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   queryGuppyForAggregationChartData,
   queryGuppyForAggregationCountData,
-  queryGuppyForAggregationFilterData,
+  queryGuppyForAggregationOptionsData,
   queryGuppyForRawData,
   queryGuppyForSubAggregationData,
   queryGuppyForTotalCounts,
@@ -144,10 +144,10 @@ function GuppyWrapper({
    * @param {FilterState} filter
    * @param {SimpleAggsData} initialTabsOptions
    */
-  function fetchAggsFilterDataFromGuppy(filter, initialTabsOptions) {
+  function fetchAggsOptionsDataFromGuppy(filter, initialTabsOptions) {
     const isFilterEmpty = Object.keys(filter).length === 0;
 
-    return queryGuppyForAggregationFilterData({
+    return queryGuppyForAggregationOptionsData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
       fields: filterConfig.tabs.flatMap(({ fields }) => fields),
@@ -186,7 +186,7 @@ function GuppyWrapper({
     Promise.all([
       fetchAggsChartDataFromGuppy(filter),
       fetchAggsCountDataFromGuppy(filter),
-      fetchAggsFilterDataFromGuppy(filter, state.initialTabsOptions),
+      fetchAggsOptionsDataFromGuppy(filter, state.initialTabsOptions),
     ]).then(
       ([
         { aggsChartData },

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -141,7 +141,10 @@ function GuppyWrapper({
     });
   }
 
-  /** @param {FilterState} filter */
+  /**
+   * @param {FilterState} filter
+   * @param {SimpleAggsData} initialTabsOptions
+   */
   function fetchAggsFilterDataFromGuppy(filter, initialTabsOptions) {
     const isFilterEmpty = Object.keys(filter).length === 0;
 

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -142,15 +142,14 @@ function GuppyWrapper({
 
   /**
    * @param {FilterState} filter
-   * @param {SimpleAggsData} initialTabsOptions
    */
-  function fetchAggsOptionsDataFromGuppy(filter, initialTabsOptions) {
+  function fetchAggsOptionsDataFromGuppy(filter) {
     return queryGuppyForAggregationOptionsData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
       fields: filterConfig.tabs.flatMap(({ fields }) => fields),
       gqlFilter: getGQLFilter(augmentFilter(filter)),
-      isInitialQuery: initialTabsOptions === undefined,
+      isInitialQuery: state.initialTabsOptions === undefined,
       signal: controller.current.signal,
     }).then(({ data, errors }) => {
       if (data === undefined)
@@ -170,7 +169,7 @@ function GuppyWrapper({
         aggsData: excludeSelfFilterFromAggsData(mainAggsData, filter),
         initialTabsOptions:
           unfilteredAggsData === undefined
-            ? initialTabsOptions
+            ? state.initialTabsOptions
             : unnestAggsData(unfilteredAggsData),
         tabsOptions: unnestAggsData(mainAggsData),
       };
@@ -185,7 +184,7 @@ function GuppyWrapper({
     Promise.all([
       fetchAggsChartDataFromGuppy(filter),
       fetchAggsCountDataFromGuppy(filter),
-      fetchAggsOptionsDataFromGuppy(filter, state.initialTabsOptions),
+      fetchAggsOptionsDataFromGuppy(filter),
     ]).then(
       ([
         { aggsChartData },

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -317,7 +317,12 @@ function GuppyWrapper({
   const rawDataFields =
     rawDataFieldsConfig?.length > 0 ? rawDataFieldsConfig : state.allFields;
 
+  const isInitialRenderRef = useRef(true);
   useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+      return;
+    }
     fetchAggsDataFromGuppy(state.filter);
     fetchRawDataFromGuppy({
       fields: rawDataFields,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -147,13 +147,17 @@ function GuppyWrapper({
    * @param {string} args.anchorValue
    * @param {FilterState} args.filter
    */
-  function fetchAggsOptionsDataFromGuppy({ anchorValue, filter }) {
+  function fetchAggsOptionsDataFromGuppy({
+    anchorValue,
+    filter,
+    filterTabs = filterConfig.tabs,
+  }) {
     return queryGuppyForAggregationOptionsData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
       anchorConfig,
       anchorValue,
-      filterTabs: filterConfig.tabs,
+      filterTabs,
       gqlFilter: getGQLFilter(augmentFilter(filter)),
       isInitialQuery: state.initialTabsOptions === undefined,
       signal: controller.current.signal,
@@ -434,12 +438,19 @@ function GuppyWrapper({
   function handleAnchorValueChange(anchorValue) {
     controller.current.abort();
     controller.current = new AbortController();
-    fetchAggsOptionsDataFromGuppy({ anchorValue, filter: state.filter }).then(
-      ({ tabsOptions }) => {
-        if (isMounted.current)
-          setState((prevState) => ({ ...prevState, tabsOptions }));
-      }
-    );
+    fetchAggsOptionsDataFromGuppy({
+      anchorValue,
+      filter: state.filter,
+      filterTabs: filterConfig.tabs.filter(({ title }) =>
+        anchorConfig.tabs.includes(title)
+      ),
+    }).then(({ tabsOptions }) => {
+      if (isMounted.current)
+        setState((prevState) => ({
+          ...prevState,
+          tabsOptions: { ...prevState.tabsOptions, ...tabsOptions },
+        }));
+    });
   }
 
   /**

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -8,7 +8,6 @@ import {
   queryGuppyForSubAggregationData,
   queryGuppyForTotalCounts,
   downloadDataFromGuppy,
-  getAllFieldsFromFilterConfigs,
   getAllFieldsFromGuppy,
   getGQLFilter,
 } from '../Utils/queries';
@@ -151,7 +150,7 @@ function GuppyWrapper({
     return queryGuppyForAggregationFilterData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
-      fields: getAllFieldsFromFilterConfigs(filterConfig.tabs),
+      fields: filterConfig.tabs.flatMap(({ fields }) => fields),
       gqlFilter: getGQLFilter(augmentFilter(filter)),
       shouldGetFullAggsData: initialTabsOptions === undefined && !isFilterEmpty,
       signal: controller.current.signal,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -429,6 +429,20 @@ function GuppyWrapper({
   }
 
   /**
+   * @param {string} anchorValue
+   */
+  function handleAnchorValueChange(anchorValue) {
+    controller.current.abort();
+    controller.current = new AbortController();
+    fetchAggsOptionsDataFromGuppy({ anchorValue, filter: state.filter }).then(
+      ({ tabsOptions }) => {
+        if (isMounted.current)
+          setState((prevState) => ({ ...prevState, tabsOptions }));
+      }
+    );
+  }
+
+  /**
    * @param {Object} args
    * @param {string} args.anchorValue
    * @param {FilterState} args.filter
@@ -457,6 +471,7 @@ function GuppyWrapper({
     downloadRawDataByTypeAndFilter,
     fetchAndUpdateRawData,
     getTotalCountsByTypeAndFilter,
+    onAnchorValueChange: handleAnchorValueChange,
     onFilterChange: handleFilterChange,
   });
 }

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -102,19 +102,17 @@ function GuppyWrapper({
       fields: Object.keys(chartConfig),
       gqlFilter: getGQLFilter(augmentFilter(filter)),
       signal: controller.current.signal,
-    }).then((res) => {
-      if (!res.data)
+    }).then(({ data, errors }) => {
+      if (data === undefined)
         throw new Error(
           `error querying guppy${
-            res.errors && res.errors.length > 0
-              ? `: ${res.errors[0].message}`
-              : ''
+            errors?.length > 0 ? `: ${errors[0].message}` : ''
           }`
         );
 
       return {
         aggsChartData: excludeSelfFilterFromAggsData(
-          res.data._aggregation[guppyConfig.dataType],
+          data._aggregation[guppyConfig.dataType],
           filter
         ),
       };
@@ -128,19 +126,17 @@ function GuppyWrapper({
       type: guppyConfig.dataType,
       gqlFilter: getGQLFilter(augmentFilter(filter)),
       signal: controller.current.signal,
-    }).then((res) => {
-      if (!res.data)
+    }).then(({ data, errors }) => {
+      if (data === undefined)
         throw new Error(
           `error querying guppy${
-            res.errors && res.errors.length > 0
-              ? `: ${res.errors[0].message}`
-              : ''
+            errors?.length > 0 ? `: ${errors[0].message}` : ''
           }`
         );
 
       return {
-        accessibleCount: res.data._aggregation.accessible._totalCount,
-        totalCount: res.data._aggregation.all._totalCount,
+        accessibleCount: data._aggregation.accessible._totalCount,
+        totalCount: data._aggregation.all._totalCount,
       };
     });
   }
@@ -156,20 +152,18 @@ function GuppyWrapper({
       gqlFilter: getGQLFilter(augmentFilter(filter)),
       shouldGetFullAggsData: initialTabsOptions === undefined && !isFilterEmpty,
       signal: controller.current.signal,
-    }).then((res) => {
-      if (!res.data)
+    }).then(({ data, errors }) => {
+      if (data === undefined)
         throw new Error(
           `error querying guppy${
-            res.errors && res.errors.length > 0
-              ? `: ${res.errors[0].message}`
-              : ''
+            errors?.length > 0 ? `: ${errors[0].message}` : ''
           }`
         );
 
-      const receivedAggsData = res.data._aggregation[guppyConfig.dataType];
+      const receivedAggsData = data._aggregation[guppyConfig.dataType];
       const fullAggsData = isFilterEmpty
         ? receivedAggsData
-        : res.data._aggregation.fullAggsData;
+        : data._aggregation.fullAggsData;
 
       return {
         aggsData: excludeSelfFilterFromAggsData(receivedAggsData, filter),

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -145,14 +145,12 @@ function GuppyWrapper({
    * @param {SimpleAggsData} initialTabsOptions
    */
   function fetchAggsOptionsDataFromGuppy(filter, initialTabsOptions) {
-    const isFilterEmpty = Object.keys(filter).length === 0;
-
     return queryGuppyForAggregationOptionsData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
       fields: filterConfig.tabs.flatMap(({ fields }) => fields),
       gqlFilter: getGQLFilter(augmentFilter(filter)),
-      shouldGetFullAggsData: initialTabsOptions === undefined && !isFilterEmpty,
+      isInitialQuery: initialTabsOptions === undefined,
       signal: controller.current.signal,
     }).then(({ data, errors }) => {
       if (data === undefined)
@@ -163,9 +161,10 @@ function GuppyWrapper({
         );
 
       const receivedAggsData = data._aggregation[guppyConfig.dataType];
-      const fullAggsData = isFilterEmpty
-        ? receivedAggsData
-        : data._aggregation.fullAggsData;
+      const fullAggsData =
+        Object.keys(filter).length === 0
+          ? receivedAggsData
+          : data._aggregation.fullAggsData;
 
       return {
         aggsData: excludeSelfFilterFromAggsData(receivedAggsData, filter),

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -47,66 +47,6 @@ function histogramQueryStrForEachField(field) {
  * @param {string} args.type
  * @param {string[]} args.fields
  * @param {GqlFilter} [args.gqlFilter]
- * @param {boolean} [args.shouldGetFullAggsData]
- * @param {AbortSignal} [args.signal]
- */
-export function queryGuppyForAggregationData({
-  path,
-  type,
-  fields,
-  gqlFilter,
-  shouldGetFullAggsData = false,
-  signal,
-}) {
-  const fullAggsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
-    ${fields.map((field) => histogramQueryStrForEachField(field))}
-  }`;
-  const query = (gqlFilter !== undefined
-    ? `query ($filter: JSON) {
-        _aggregation {
-          ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-            ${fields.map((field) => histogramQueryStrForEachField(field))}
-          }
-          accessible: ${type} (filter: $filter, accessibility: accessible) {
-            _totalCount
-          }
-          all: ${type} (filter: $filter, accessibility: all) {
-            _totalCount
-          }
-          ${shouldGetFullAggsData ? fullAggsDataQueryFragment : ''}
-        }
-      }`
-    : `query {
-        _aggregation {
-          ${type} (accessibility: all) {
-            ${fields.map((field) => histogramQueryStrForEachField(field))}
-          }
-          accessible: ${type} (accessibility: accessible) {
-            _totalCount
-          }
-          all: ${type} (accessibility: all) {
-            _totalCount
-          }
-        }
-      }`
-  ).replace(/\s+/g, ' ');
-
-  return fetch(`${path}${graphqlEndpoint}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query, variables: { filter: gqlFilter } }),
-    signal,
-  }).then((response) => response.json());
-}
-
-/**
- * @param {object} args
- * @param {string} args.path
- * @param {string} args.type
- * @param {string[]} args.fields
- * @param {GqlFilter} [args.gqlFilter]
  * @param {AbortSignal} [args.signal]
  */
 export function queryGuppyForAggregationChartData({

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -136,7 +136,7 @@ export function queryGuppyForAggregationCountData({
  * @param {boolean} [args.shouldGetFullAggsData]
  * @param {string} args.type
  */
-function buildQueryForAggregationFilterData({
+function buildQueryForAggregationOptionsData({
   fields,
   gqlFilter,
   shouldGetFullAggsData = false,
@@ -174,7 +174,7 @@ function buildQueryForAggregationFilterData({
  * @param {boolean} [args.shouldGetFullAggsData]
  * @param {AbortSignal} [args.signal]
  */
-export function queryGuppyForAggregationFilterData({
+export function queryGuppyForAggregationOptionsData({
   path,
   type,
   fields,
@@ -182,7 +182,7 @@ export function queryGuppyForAggregationFilterData({
   shouldGetFullAggsData,
   signal,
 }) {
-  const query = buildQueryForAggregationFilterData({
+  const query = buildQueryForAggregationOptionsData({
     fields,
     gqlFilter,
     shouldGetFullAggsData,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -139,10 +139,11 @@ export function queryGuppyForAggregationCountData({
 function buildQueryForAggregationOptionsData({
   fields,
   gqlFilter,
-  shouldGetFullAggsData = false,
+  isInitialQuery = false,
   type,
 }) {
-  if (gqlFilter === undefined)
+  const isFilterEmpty = gqlFilter === undefined;
+  if (isFilterEmpty)
     return `query {
       _aggregation {
         ${type} (accessibility: all) {
@@ -160,7 +161,7 @@ function buildQueryForAggregationOptionsData({
       ${type} (filter: $filter, filterSelf: false, accessibility: all) {
         ${fields.map((field) => histogramQueryStrForEachField(field))}
       }
-      ${shouldGetFullAggsData ? fullAggsDataQueryFragment : ''}
+      ${isInitialQuery && !isFilterEmpty ? fullAggsDataQueryFragment : ''}
     }
   }`.replace(/\s+/g, ' ');
 }
@@ -171,7 +172,7 @@ function buildQueryForAggregationOptionsData({
  * @param {string} args.type
  * @param {string[]} args.fields
  * @param {GqlFilter} [args.gqlFilter]
- * @param {boolean} [args.shouldGetFullAggsData]
+ * @param {boolean} [args.isInitialQuery]
  * @param {AbortSignal} [args.signal]
  */
 export function queryGuppyForAggregationOptionsData({
@@ -179,13 +180,13 @@ export function queryGuppyForAggregationOptionsData({
   type,
   fields,
   gqlFilter,
-  shouldGetFullAggsData,
+  isInitialQuery,
   signal,
 }) {
   const query = buildQueryForAggregationOptionsData({
     fields,
     gqlFilter,
-    shouldGetFullAggsData,
+    isInitialQuery,
     type,
   });
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -574,11 +574,6 @@ export function getGQLFilter(filterState) {
   return { AND: [...simpleFilters, ...nestedFilters] };
 }
 
-/** @param {object} filterTabConfigs */
-export function getAllFieldsFromFilterConfigs(filterTabConfigs) {
-  return filterTabConfigs.flatMap(({ fields }) => fields);
-}
-
 /**
  * Download all data from guppy using fields, filter, and sort args.
  * @param {object} args

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -201,7 +201,7 @@ export function getQueryInfoForAggregationOptionsData({
  * @param {boolean} [args.isInitialQuery]
  * @param {string} args.type
  */
-export function buildQueryForAggregationFilterData({
+export function buildQueryForAggregationOptionsData({
   fieldsByGroup,
   isFilterEmpty,
   isInitialQuery = false,
@@ -279,7 +279,7 @@ export function queryGuppyForAggregationOptionsData({
     gqlFilter,
   });
 
-  const query = buildQueryForAggregationFilterData({
+  const query = buildQueryForAggregationOptionsData({
     fieldsByGroup,
     isFilterEmpty: gqlFilter === undefined,
     isInitialQuery,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -138,11 +138,10 @@ export function queryGuppyForAggregationCountData({
  */
 function buildQueryForAggregationOptionsData({
   fields,
-  gqlFilter,
+  isFilterEmpty,
   isInitialQuery = false,
   type,
 }) {
-  const isFilterEmpty = gqlFilter === undefined;
   if (isFilterEmpty)
     return `query {
       _aggregation {
@@ -187,7 +186,7 @@ export function queryGuppyForAggregationOptionsData({
 }) {
   const query = buildQueryForAggregationOptionsData({
     fields,
-    gqlFilter,
+    isFilterEmpty: gqlFilter === undefined,
     isInitialQuery,
     type,
   });

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -101,6 +101,48 @@ export function queryGuppyForAggregationData({
   }).then((response) => response.json());
 }
 
+/**
+ * @param {object} args
+ * @param {string} args.path
+ * @param {string} args.type
+ * @param {string[]} args.fields
+ * @param {GqlFilter} [args.gqlFilter]
+ * @param {AbortSignal} [args.signal]
+ */
+export function queryGuppyForAggregationChartData({
+  path,
+  type,
+  fields,
+  gqlFilter,
+  signal,
+}) {
+  const query = (gqlFilter !== undefined
+    ? `query ($filter: JSON) {
+        _aggregation {
+          ${type} (filter: $filter, filterSelf: false, accessibility: all) {
+            ${fields.map((field) => histogramQueryStrForEachField(field))}
+          }
+        }
+      }`
+    : `query {
+        _aggregation {
+          ${type} (accessibility: all) {
+            ${fields.map((field) => histogramQueryStrForEachField(field))}
+          }
+        }
+      }`
+  ).replace(/\s+/g, ' ');
+
+  return fetch(`${path}${graphqlEndpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables: { filter: gqlFilter } }),
+    signal,
+  }).then((response) => response.json());
+}
+
 /** @param {string} path */
 export function queryGuppyForStatus(path) {
   return fetch(`${path}${statusEndpoint}`, {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -60,14 +60,14 @@ export function queryGuppyForAggregationChartData({
     ? `query ($filter: JSON) {
         _aggregation {
           ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-            ${fields.map((field) => histogramQueryStrForEachField(field))}
+            ${fields.map(histogramQueryStrForEachField)}
           }
         }
       }`
     : `query {
         _aggregation {
           ${type} (accessibility: all) {
-            ${fields.map((field) => histogramQueryStrForEachField(field))}
+            ${fields.map(histogramQueryStrForEachField)}
           }
         }
       }`
@@ -147,19 +147,19 @@ function buildQueryForAggregationOptionsData({
     return `query {
       _aggregation {
         ${type} (accessibility: all) {
-          ${fields.map((field) => histogramQueryStrForEachField(field))}
+          ${fields.map(histogramQueryStrForEachField)}
         }
       }
     }`.replace(/\s+/g, ' ');
 
   const fullAggsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
-    ${fields.map((field) => histogramQueryStrForEachField(field))}
+    ${fields.map(histogramQueryStrForEachField)}
   }`;
 
   return `query ($filter: JSON) {
     _aggregation {
       ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-        ${fields.map((field) => histogramQueryStrForEachField(field))}
+        ${fields.map(histogramQueryStrForEachField)}
       }
       ${isInitialQuery && !isFilterEmpty ? fullAggsDataQueryFragment : ''}
     }

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -186,7 +186,7 @@ export function getQueryInfoForAggregationOptionsData({
       fieldsByGroup.main = [...(fieldsByGroup?.main ?? []), ...fields];
     }
 
-  if (fieldsByGroup.main.length > 0) gqlFilterByGroup.filter_main = gqlFilter;
+  if (fieldsByGroup.main?.length > 0) gqlFilterByGroup.filter_main = gqlFilter;
 
   return {
     fieldsByGroup,
@@ -213,17 +213,22 @@ export function buildQueryForAggregationOptionsData({
       queryVariables.push(`$filter_${group}: JSON`);
 
   const { main, ...fieldsByAnchoredGroup } = fieldsByGroup;
-  const mainHistogramQueryFragment = main.map(buildHistogramQueryStrForField);
-  const mainQueryFragment = isFilterEmpty
-    ? `main: ${type} (accessibility: all) {
+  const hasMainFields = main !== undefined;
+  const mainHistogramQueryFragment = hasMainFields
+    ? main.map(buildHistogramQueryStrForField)
+    : '';
+  const mainQueryFragment = hasMainFields
+    ? `main: ${type} ${
+        isFilterEmpty
+          ? '(accessibility: all)'
+          : '(filter: $filter_main, filterSelf: false, accessibility: all)'
+      } {
       ${mainHistogramQueryFragment}
     }`
-    : `main: ${type} (filter: $filter_main, filterSelf: false, accessibility: all) {
-      ${mainHistogramQueryFragment}
-    }`;
+    : '';
 
   const unfilteredQueryFragment =
-    isInitialQuery && !isFilterEmpty
+    hasMainFields && isInitialQuery && !isFilterEmpty
       ? `unfiltered: ${type} (accessibility: all) {
         ${mainHistogramQueryFragment}
       }`

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -212,18 +212,20 @@ export function buildQueryForAggregationFilterData({
     if (!(isFilterEmpty && group === 'main'))
       queryVariables.push(`$filter_${group}: JSON`);
 
-  const { main: mainFields, ...fieldsByAnchoredGroup } = fieldsByGroup;
+  const { main, ...fieldsByAnchoredGroup } = fieldsByGroup;
+  const mainHistogramQueryFragment = main.map(buildHistogramQueryStrForField);
   const mainQueryFragment = isFilterEmpty
     ? `main: ${type} (accessibility: all) {
-        ${fieldsByGroup.main.map(buildHistogramQueryStrForField)}
-      }`
+      ${mainHistogramQueryFragment}
+    }`
     : `main: ${type} (filter: $filter_main, filterSelf: false, accessibility: all) {
-        ${fieldsByGroup.main.map(buildHistogramQueryStrForField)}
-      }`;
+      ${mainHistogramQueryFragment}
+    }`;
+
   const unfilteredQueryFragment =
     isInitialQuery && !isFilterEmpty
       ? `unfiltered: ${type} (accessibility: all) {
-        ${fieldsByGroup.main.map(buildHistogramQueryStrForField)}
+        ${mainHistogramQueryFragment}
       }`
       : '';
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -146,22 +146,24 @@ function buildQueryForAggregationOptionsData({
   if (isFilterEmpty)
     return `query {
       _aggregation {
-        ${type} (accessibility: all) {
+        main: ${type} (accessibility: all) {
           ${fields.map(buildHistogramQueryStrForField)}
         }
       }
     }`.replace(/\s+/g, ' ');
 
-  const fullAggsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
-    ${fields.map(buildHistogramQueryStrForField)}
-  }`;
-
+  const unfilteredQueryFragment =
+    isInitialQuery && !isFilterEmpty
+      ? `unfiltered: ${type} (accessibility: all) {
+        ${fields.map(buildHistogramQueryStrForField)}
+      }`
+      : '';
   return `query ($filter: JSON) {
     _aggregation {
-      ${type} (filter: $filter, filterSelf: false, accessibility: all) {
+      main: ${type} (filter: $filter, filterSelf: false, accessibility: all) {
         ${fields.map(buildHistogramQueryStrForField)}
       }
-      ${isInitialQuery && !isFilterEmpty ? fullAggsDataQueryFragment : ''}
+      ${unfilteredQueryFragment}
     }
   }`.replace(/\s+/g, ' ');
 }

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -61,14 +61,14 @@ export function queryGuppyForAggregationChartData({
     ? `query ($filter: JSON) {
         _aggregation {
           ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-            ${fields.map(buildHistogramQueryStrForField)}
+            ${fields.map(buildHistogramQueryStrForField).join('\n')}
           }
         }
       }`
     : `query {
         _aggregation {
           ${type} (accessibility: all) {
-            ${fields.map(buildHistogramQueryStrForField)}
+            ${fields.map(buildHistogramQueryStrForField).join('\n')}
           }
         }
       }`
@@ -215,7 +215,7 @@ export function buildQueryForAggregationOptionsData({
   const { main, ...fieldsByAnchoredGroup } = fieldsByGroup;
   const hasMainFields = main !== undefined;
   const mainHistogramQueryFragment = hasMainFields
-    ? main.map(buildHistogramQueryStrForField)
+    ? main.map(buildHistogramQueryStrForField).join('\n')
     : '';
   const mainQueryFragment = hasMainFields
     ? `main: ${type} ${
@@ -238,7 +238,7 @@ export function buildQueryForAggregationOptionsData({
   for (const [group, fields] of Object.entries(fieldsByAnchoredGroup))
     anchoredPathQueryFragments.push(`
       anchored_${group}: ${type} (filter: $filter_${group}, filterSelf: false, accessibility: all) {
-        ${fields.map(buildHistogramQueryStrForField)}
+        ${fields.map(buildHistogramQueryStrForField).join('\n')}
       }
     `);
 
@@ -248,7 +248,7 @@ export function buildQueryForAggregationOptionsData({
     _aggregation {
       ${mainQueryFragment}
       ${unfilteredQueryFragment}
-      ${anchoredPathQueryFragments.join('')}
+      ${anchoredPathQueryFragments.join('\n')}
     }
   }`.replace(/\s+/g, ' ');
 }

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -133,7 +133,7 @@ export function queryGuppyForAggregationCountData({
 /**
  * @param {Object} args
  * @param {{ fieldName: string; tabs: string[] }} [args.anchorConfig]
- * @param {string} [args.anchorLabel]
+ * @param {string} [args.anchorValue]
  * @param {{ title: string; fields: string[] }[]} args.filterTabs
  * @param {GqlFilter} [args.gqlFilter]
  */

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -58,7 +58,7 @@ export function queryGuppyForAggregationData({
   shouldGetFullAggsData = false,
   signal,
 }) {
-  const fullAagsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
+  const fullAggsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
     ${fields.map((field) => histogramQueryStrForEachField(field))}
   }`;
   const query = (gqlFilter !== undefined
@@ -73,7 +73,7 @@ export function queryGuppyForAggregationData({
           all: ${type} (filter: $filter, accessibility: all) {
             _totalCount
           }
-          ${shouldGetFullAggsData ? fullAagsDataQueryFragment : ''}
+          ${shouldGetFullAggsData ? fullAggsDataQueryFragment : ''}
         }
       }`
     : `query {

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -27,7 +27,7 @@ function jsonToFormat(json, format) {
  * @param {string} field
  * @returns {string}
  */
-function histogramQueryStrForEachField(field) {
+function buildHistogramQueryStrForField(field) {
   const [fieldName, ...nestedFieldNames] = field.split('.');
   return nestedFieldNames.length === 0
     ? `${fieldName} {
@@ -37,7 +37,7 @@ function histogramQueryStrForEachField(field) {
         }
       }`
     : `${fieldName} {
-        ${histogramQueryStrForEachField(nestedFieldNames.join('.'))}
+        ${buildHistogramQueryStrForField(nestedFieldNames.join('.'))}
       }`;
 }
 
@@ -60,14 +60,14 @@ export function queryGuppyForAggregationChartData({
     ? `query ($filter: JSON) {
         _aggregation {
           ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-            ${fields.map(histogramQueryStrForEachField)}
+            ${fields.map(buildHistogramQueryStrForField)}
           }
         }
       }`
     : `query {
         _aggregation {
           ${type} (accessibility: all) {
-            ${fields.map(histogramQueryStrForEachField)}
+            ${fields.map(buildHistogramQueryStrForField)}
           }
         }
       }`
@@ -147,19 +147,19 @@ function buildQueryForAggregationOptionsData({
     return `query {
       _aggregation {
         ${type} (accessibility: all) {
-          ${fields.map(histogramQueryStrForEachField)}
+          ${fields.map(buildHistogramQueryStrForField)}
         }
       }
     }`.replace(/\s+/g, ' ');
 
   const fullAggsDataQueryFragment = `fullAggsData: ${type} (accessibility: all) {
-    ${fields.map(histogramQueryStrForEachField)}
+    ${fields.map(buildHistogramQueryStrForField)}
   }`;
 
   return `query ($filter: JSON) {
     _aggregation {
       ${type} (filter: $filter, filterSelf: false, accessibility: all) {
-        ${fields.map(histogramQueryStrForEachField)}
+        ${fields.map(buildHistogramQueryStrForField)}
       }
       ${isInitialQuery && !isFilterEmpty ? fullAggsDataQueryFragment : ''}
     }

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -202,6 +202,9 @@ describe('Get query info objects for aggregation options data', () => {
     { title: 't0', fields: ['f0', 'f1'] },
     { title: 't1', fields: ['f2.foo', 'f2.bar', 'f3.baz'] },
   ];
+  const anchoredFilterTabs = filterTabs.filter(({ title }) =>
+    anchorConfig.tabs.includes(title)
+  );
   const gqlFilter = {
     AND: [
       { IN: { f0: ['x'] } },
@@ -235,6 +238,17 @@ describe('Get query info objects for aggregation options data', () => {
     };
     expect(queryInfo).toEqual(expected);
   });
+  test('No filter, no anchor value, anchored tabs only', () => {
+    const queryInfo = getQueryInfoForAggregationOptionsData({
+      anchorConfig,
+      filterTabs: anchoredFilterTabs,
+    });
+    const expected = {
+      fieldsByGroup: { main: ['f2.foo', 'f2.bar', 'f3.baz'] },
+      gqlFilterByGroup: { filter_main: undefined },
+    };
+    expect(queryInfo).toEqual(expected);
+  });
   test('No filter, with anchor value', () => {
     const queryInfo = getQueryInfoForAggregationOptionsData({
       anchorConfig,
@@ -244,6 +258,29 @@ describe('Get query info objects for aggregation options data', () => {
     const expected = {
       fieldsByGroup: {
         main: ['f0', 'f1'],
+        f2: ['f2.foo', 'f2.bar'],
+        f3: ['f3.baz'],
+      },
+      gqlFilterByGroup: {
+        filter_main: undefined,
+        filter_f2: {
+          AND: [{ nested: { path: 'f2', AND: [{ IN: { a: ['a0'] } }] } }],
+        },
+        filter_f3: {
+          AND: [{ nested: { path: 'f3', AND: [{ IN: { a: ['a0'] } }] } }],
+        },
+      },
+    };
+    expect(queryInfo).toEqual(expected);
+  });
+  test('No filter, with anchor value, anchored tabs only', () => {
+    const queryInfo = getQueryInfoForAggregationOptionsData({
+      anchorConfig,
+      anchorValue,
+      filterTabs: anchoredFilterTabs,
+    });
+    const expected = {
+      fieldsByGroup: {
         f2: ['f2.foo', 'f2.bar'],
         f3: ['f3.baz'],
       },
@@ -282,6 +319,18 @@ describe('Get query info objects for aggregation options data', () => {
     };
     expect(queryInfo).toEqual(expected);
   });
+  test('With filter, no anchor value, anchored tabs only', () => {
+    const queryInfo = getQueryInfoForAggregationOptionsData({
+      anchorConfig,
+      filterTabs: anchoredFilterTabs,
+      gqlFilter,
+    });
+    const expected = {
+      fieldsByGroup: { main: ['f2.foo', 'f2.bar', 'f3.baz'] },
+      gqlFilterByGroup: { filter_main: gqlFilter },
+    };
+    expect(queryInfo).toEqual(expected);
+  });
   test('With filter, with anchor value', () => {
     const queryInfo = getQueryInfoForAggregationOptionsData({
       anchorConfig,
@@ -297,6 +346,48 @@ describe('Get query info objects for aggregation options data', () => {
       },
       gqlFilterByGroup: {
         filter_main: gqlFilter,
+        filter_f2: {
+          AND: [
+            { IN: { f0: ['x'] } },
+            { AND: [{ GTE: { f1: 0 } }, { LTE: { f1: 1 } }] },
+            {
+              nested: {
+                path: 'f2',
+                AND: [{ IN: { foo: ['y'] } }, { IN: { a: ['a0'] } }],
+              },
+            },
+          ],
+        },
+        filter_f3: {
+          AND: [
+            { IN: { f0: ['x'] } },
+            { AND: [{ GTE: { f1: 0 } }, { LTE: { f1: 1 } }] },
+            {
+              nested: {
+                path: 'f2',
+                AND: [{ IN: { foo: ['y'] } }],
+              },
+            },
+            { nested: { path: 'f3', AND: [{ IN: { a: ['a0'] } }] } },
+          ],
+        },
+      },
+    };
+    expect(queryInfo).toEqual(expected);
+  });
+  test('No filter, with anchor value, anchored tabs only', () => {
+    const queryInfo = getQueryInfoForAggregationOptionsData({
+      anchorConfig,
+      anchorValue,
+      filterTabs: anchoredFilterTabs,
+      gqlFilter,
+    });
+    const expected = {
+      fieldsByGroup: {
+        f2: ['f2.foo', 'f2.bar'],
+        f3: ['f3.baz'],
+      },
+      gqlFilterByGroup: {
         filter_f2: {
           AND: [
             { IN: { f0: ['x'] } },

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -149,5 +149,6 @@
  * @property {(type: string, filter: FilterState, fields: string[]) => void} downloadRawDataByTypeAndFilter
  * @property {(type: string, filter: FilterState) => void} getTotalCountsByTypeAndFilter
  * @property {(args: { offset: number; size: number; sort: GqlSort }) => void} fetchAndUpdateRawData
+ * @property {(anchorValue: string) => void} onAnchorValueChange
  * @property {FilterChangeHandler} onFilterChange
  */

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -142,7 +142,7 @@
  * @property {boolean} isLoadingAggsData
  * @property {boolean} isLoadingRawData
  * @property {Array} rawData
- * @property {AggsData} receivedAggsData
+ * @property {SimpleAggsData} tabsOptions
  * @property {number} totalCount
  * @property {(args: { format: string; sort: GqlSort }) => void} downloadRawData
  * @property {(args: { fields: string[]; sort: GqlSort }) => void} downloadRawDataByFields

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -129,6 +129,10 @@
  */
 
 /**
+ * @typedef {(args: { anchorValue?: string; filter: FilterState }) => void} FilterChangeHandler
+ */
+
+/**
  * @typedef {Object} GuppyData
  * @property {number} accessibleCount
  * @property {AggsData} aggsData
@@ -145,5 +149,5 @@
  * @property {(type: string, filter: FilterState, fields: string[]) => void} downloadRawDataByTypeAndFilter
  * @property {(type: string, filter: FilterState) => void} getTotalCountsByTypeAndFilter
  * @property {(args: { offset: number; size: number; sort: GqlSort }) => void} fetchAndUpdateRawData
- * @property {(filter: FilterState) => void} onFilterChange
+ * @property {FilterChangeHandler} onFilterChange
  */

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -7,6 +7,7 @@ import './ExplorerFilter.css';
 /**
  * @typedef {Object} ExplorerFilterProps
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
+ * @property {AnchorConfig} anchorConfig
  * @property {string} className
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
@@ -50,6 +51,11 @@ function ExplorerFilter({
 
 ExplorerFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
+  anchorConfig: PropTypes.shape({
+    fieldName: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.string),
+    tabs: PropTypes.arrayOf(PropTypes.string),
+  }),
   className: PropTypes.string,
   filterConfig: FilterConfigType.isRequired,
   guppyConfig: GuppyConfigType.isRequired,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -20,7 +20,7 @@ import './ExplorerFilter.css';
  * @property {FilterState} filter
  * @property {SimpleAggsData} initialTabsOptions
  * @property {FilterChangeHandler} onFilterChange
- * @property {AggsData} receivedAggsData
+ * @property {SimpleAggsData} tabsOptions
  */
 
 /** @param {ExplorerFilterProps} props */
@@ -68,7 +68,7 @@ ExplorerFilter.propTypes = {
   filter: PropTypes.object, // from GuppyWrapper
   initialTabsOptions: PropTypes.object, // from GuppyWrapper
   onFilterChange: PropTypes.func, // from GuppyWrapper
-  receivedAggsData: PropTypes.object, // from GuppWrapper
+  tabsOptions: PropTypes.object, // from GuppWrapper
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -19,7 +19,7 @@ import './ExplorerFilter.css';
  * @property {number} tierAccessLimit
  * @property {FilterState} filter
  * @property {SimpleAggsData} initialTabsOptions
- * @property {(x: FilterState) => void} onFilterChange
+ * @property {FilterChangeHandler} onFilterChange
  * @property {AggsData} receivedAggsData
  */
 

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -19,6 +19,7 @@ import './ExplorerFilter.css';
  * @property {number} tierAccessLimit
  * @property {FilterState} filter
  * @property {SimpleAggsData} initialTabsOptions
+ * @property {(anchorValue: string) => void} onAnchorValueChange
  * @property {FilterChangeHandler} onFilterChange
  * @property {SimpleAggsData} tabsOptions
  */
@@ -67,6 +68,7 @@ ExplorerFilter.propTypes = {
   tierAccessLimit: PropTypes.number,
   filter: PropTypes.object, // from GuppyWrapper
   initialTabsOptions: PropTypes.object, // from GuppyWrapper
+  onAnchorValueChange: PropTypes.func, // from GuppyWrapper
   onFilterChange: PropTypes.func, // from GuppyWrapper
   tabsOptions: PropTypes.object, // from GuppWrapper
 };

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -63,14 +63,14 @@ function isSurvivalAnalysisEnabled(survivalAnalysisConfig) {
 
 /**
  * @param {Object} args
- * @param {SimpleAggsData} args.aggsData
+ * @param {SimpleAggsData} args.aggsChartData
  * @param {ChartConfig} args.chartConfig
  * @param {FilterState} args.filter
  * @param {string} args.nodeCountTitle
  * @param {number} args.totalCount
  */
 function getChartData({
-  aggsData,
+  aggsChartData,
   chartConfig,
   filter,
   nodeCountTitle,
@@ -81,9 +81,9 @@ function getChartData({
   const stackedBarCharts = [];
 
   for (const field of Object.keys(chartConfig)) {
-    if (aggsData?.[`${field}`]?.histogram !== undefined) {
+    if (aggsChartData[field]?.histogram !== undefined) {
       const { chartType: type, title } = chartConfig[field];
-      const { histogram } = aggsData[field];
+      const { histogram } = aggsChartData[field];
       switch (type) {
         case 'count':
           countItems.push({
@@ -135,6 +135,7 @@ function getChartData({
  * @property {number} accessibleCount
  * @property {number} totalCount
  * @property {AggsData} aggsData
+ * @property {AggsData} aggsChartData
  * @property {Object[]} rawData
  * @property {string[]} allFields
  * @property {FilterState} filter
@@ -161,6 +162,7 @@ function ExplorerVisualization({
   accessibleCount = 0,
   totalCount = 0,
   aggsData = {},
+  aggsChartData = {},
   rawData = [],
   allFields = [],
   filter = {},
@@ -188,7 +190,7 @@ function ExplorerVisualization({
   const [explorerView, setExplorerView] = useState(explorerViews[0]);
 
   const chartData = getChartData({
-    aggsData,
+    aggsChartData,
     chartConfig,
     filter,
     nodeCountTitle,
@@ -323,6 +325,7 @@ ExplorerVisualization.propTypes = {
   accessibleCount: PropTypes.number, // inherited from GuppyWrapper
   totalCount: PropTypes.number, // inherited from GuppyWrapper
   aggsData: PropTypes.object, // inherited from GuppyWrapper
+  aggsChartData: PropTypes.object, // inherited from GuppyWrapper
   rawData: PropTypes.array, // inherited from GuppyWrapper
   allFields: PropTypes.array, // inherited from GuppyWrapper
   filter: PropTypes.object, // inherited from GuppyWrapper

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -235,6 +235,7 @@ class GuppyDataExplorer extends React.Component {
                   tierAccessLimit={this.props.tierAccessLimit}
                   filter={data.filter}
                   initialTabsOptions={data.initialTabsOptions}
+                  onAnchorValueChange={data.onAnchorValueChange}
                   onFilterChange={data.onFilterChange}
                   tabsOptions={data.tabsOptions}
                 />

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -199,6 +199,7 @@ class GuppyDataExplorer extends React.Component {
             adminAppliedPreFilters={this.props.adminAppliedPreFilters}
             initialAppliedFilters={this.state.initialAppliedFilters}
             anchorConfig={this.props.anchorConfig}
+            chartConfig={this.props.chartConfig}
             filterConfig={this.props.filterConfig}
             guppyConfig={this.props.guppyConfig}
             onFilterChange={this.handleFilterChange}
@@ -252,6 +253,7 @@ class GuppyDataExplorer extends React.Component {
                   tierAccessLimit={this.props.tierAccessLimit}
                   accessibleCount={data.accessibleCount}
                   aggsData={data.aggsData}
+                  aggsChartData={data.aggsChartData}
                   allFields={data.allFields}
                   filter={data.filter}
                   isLoadingAggsData={data.isLoadingAggsData}

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -236,7 +236,7 @@ class GuppyDataExplorer extends React.Component {
                   filter={data.filter}
                   initialTabsOptions={data.initialTabsOptions}
                   onFilterChange={data.onFilterChange}
-                  receivedAggsData={data.receivedAggsData}
+                  tabsOptions={data.tabsOptions}
                 />
                 <ExplorerVisualization
                   className='guppy-data-explorer__visualization'

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -23,11 +23,13 @@ import './typedef';
 /**
  * @param {URLSearchParams} searchParams
  * @param {FilterConfig} filterConfig
+ * @param {boolean} isAnchorFilterEnabled
  * @param {PatientIdsConfig} [patientIdsConfig]
  */
 function extractExplorerStateFromURL(
   searchParams,
   filterConfig,
+  isAnchorFilterEnabled,
   patientIdsConfig
 ) {
   /** @type {FilterState} */
@@ -35,7 +37,7 @@ function extractExplorerStateFromURL(
   if (searchParams.has('filter'))
     try {
       const filterInUrl = JSON.parse(decodeURI(searchParams.get('filter')));
-      if (validateFilter(filterInUrl, filterConfig))
+      if (validateFilter(filterInUrl, filterConfig, isAnchorFilterEnabled))
         initialAppliedFilters = filterInUrl;
       else throw new Error(undefined);
     } catch (e) {
@@ -55,6 +57,7 @@ function extractExplorerStateFromURL(
 
 /**
  * @typedef {Object} GuppyDataExplorerProps
+ * @property {AnchorConfig} anchorConfig
  * @property {GuppyConfig} guppyConfig
  * @property {FilterConfig} filterConfig
  * @property {TableConfig} tableConfig
@@ -85,6 +88,7 @@ class GuppyDataExplorer extends React.Component {
     const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
       new URLSearchParams(props.history.location.search),
       props.filterConfig,
+      props.anchorConfig !== undefined,
       props.patientIdsConfig
     );
     /** @type {GuppyDataExplorerState} */
@@ -104,6 +108,7 @@ class GuppyDataExplorer extends React.Component {
       const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
         new URLSearchParams(this.props.history.location.search),
         this.props.filterConfig,
+        this.props.anchorConfig !== undefined,
         this.props.patientIdsConfig
       );
       this._hasAppliedFilters = Object.keys(initialAppliedFilters).length > 0;
@@ -193,6 +198,7 @@ class GuppyDataExplorer extends React.Component {
           <GuppyWrapper
             adminAppliedPreFilters={this.props.adminAppliedPreFilters}
             initialAppliedFilters={this.state.initialAppliedFilters}
+            anchorConfig={this.props.anchorConfig}
             filterConfig={this.props.filterConfig}
             guppyConfig={this.props.guppyConfig}
             onFilterChange={this.handleFilterChange}
@@ -216,6 +222,7 @@ class GuppyDataExplorer extends React.Component {
                 />
                 <ExplorerFilter
                   adminAppliedPreFilters={this.props.adminAppliedPreFilters}
+                  anchorConfig={this.props.anchorConfig}
                   className='guppy-data-explorer__filter'
                   filterConfig={this.props.filterConfig}
                   guppyConfig={this.props.guppyConfig}
@@ -271,6 +278,11 @@ class GuppyDataExplorer extends React.Component {
 }
 
 GuppyDataExplorer.propTypes = {
+  anchorConfig: PropTypes.shape({
+    fieldName: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.string),
+    tabs: PropTypes.arrayOf(PropTypes.string),
+  }),
   guppyConfig: GuppyConfigType.isRequired,
   filterConfig: FilterConfigType.isRequired,
   tableConfig: TableConfigType.isRequired,

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -25,6 +25,13 @@ export default function Explorer() {
   const tabConfig = explorerConfig[tabIndex];
   const isMultiTabExplorer = explorerConfig.length > 1;
 
+  /** @type {AnchorConfig} */
+  const anchorConfig = {
+    fieldName: 'disease_phase',
+    options: ['Initial Diagnosis', 'Relapse'],
+    tabs: ['Disease', 'Molecular'],
+  };
+
   return (
     <div className='guppy-explorer'>
       {isMultiTabExplorer && (
@@ -63,6 +70,7 @@ export default function Explorer() {
       )}
       <div className={isMultiTabExplorer ? 'guppy-explorer__main' : ''}>
         <GuppyDataExplorer
+          anchorConfig={anchorConfig}
           adminAppliedPreFilters={tabConfig.adminAppliedPreFilters}
           chartConfig={tabConfig.charts}
           filterConfig={tabConfig.filters}

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -112,14 +112,15 @@ function isValid(filterContent) {
  * - filter keys include only fields specified in the configuration
  * @param {*} value
  * @param {FilterConfig} filterConfig
+ * @param {boolean} isAnchorFilterEnabled
  */
-export function validateFilter(value, filterConfig) {
+export function validateFilter(value, filterConfig, isAnchorFilterEnabled) {
   if (!isPlainObject(value)) return false;
 
   const allFields = filterConfig.tabs.flatMap(({ fields }) => fields);
   const testFieldSet = new Set(allFields);
   for (const [field, filterContent] of Object.entries(value)) {
-    if ('filter' in filterContent)
+    if (isAnchorFilterEnabled && 'filter' in filterContent)
       for (const [anchoredField, anchoredfilterContent] of Object.entries(
         filterContent.filter
       ))

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -98,6 +98,13 @@ function isRangeFilter(value) {
   );
 }
 
+function isValid(filterContent) {
+  return (
+    isPlainObject(filterContent) &&
+    (isTextFilter(filterContent) || isRangeFilter(filterContent))
+  );
+}
+
 /**
  * Validates the provide filter value based on configuration.
  * Performs the following checks:
@@ -111,13 +118,16 @@ export function validateFilter(value, filterConfig) {
 
   const allFields = filterConfig.tabs.flatMap(({ fields }) => fields);
   const testFieldSet = new Set(allFields);
-  for (const [field, filterContent] of Object.entries(value))
-    if (
-      isPlainObject(filterContent) &&
-      (isTextFilter(filterContent) || isRangeFilter(filterContent))
-    )
-      testFieldSet.add(field);
+  for (const [field, filterContent] of Object.entries(value)) {
+    if ('filter' in filterContent)
+      for (const [anchoredField, anchoredfilterContent] of Object.entries(
+        filterContent.filter
+      ))
+        if (isValid(anchoredfilterContent)) testFieldSet.add(anchoredField);
+        else return false;
+    else if (isValid(filterContent)) testFieldSet.add(field);
     else return false;
+  }
 
   return allFields.length === testFieldSet.size;
 }

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -8,6 +8,7 @@ import {
   updateCombineMode,
   updateRangeValue,
   updateSelectedValue,
+  getSelectedAnchors,
 } from './utils';
 
 describe('Get expanded status array for all tabs', () => {
@@ -702,5 +703,69 @@ describe('Update an option filter', () => {
       filterStatus: [{ 'a:a0': [{ foo: false }] }],
     };
     expect(updated).toEqual(expected);
+  });
+});
+
+describe('Get selected anchor values from filter status', () => {
+  test('No filter selected', () => {
+    const filterStatus = [
+      [{}],
+      {
+        '': [{}, {}],
+        'a:a0': [{}, {}],
+        'a:a1': [{}, {}],
+      },
+    ];
+    const anchors = getSelectedAnchors(filterStatus);
+    const expected = [[], []];
+    expect(anchors).toEqual(expected);
+  });
+  test('With non-anchored filter selected', () => {
+    const anchors = getSelectedAnchors([
+      [{ x: true }],
+      {
+        '': [{}, {}],
+        'a:a0': [{}, {}],
+        'a:a1': [{}, {}],
+      },
+    ]);
+    const expected = [[], []];
+    expect(anchors).toEqual(expected);
+  });
+  test('With anchored filter without anchor value selected', () => {
+    const anchors = getSelectedAnchors([
+      [{}],
+      {
+        '': [{ y: true }, {}],
+        'a:a0': [{}, {}],
+        'a:a1': [{}, {}],
+      },
+    ]);
+    const expected = [[], []];
+    expect(anchors).toEqual(expected);
+  });
+  test('With anchored filter with anchor value selected', () => {
+    const anchors = getSelectedAnchors([
+      [{}, {}],
+      {
+        '': [{ y: true }, {}],
+        'a:a0': [{}, { z: true }],
+        'a:a1': [{}, {}],
+      },
+    ]);
+    const expected = [[], ['a0']];
+    expect(anchors).toEqual(expected);
+  });
+  test('With anchored filter with multiple anchor values selected', () => {
+    const anchors = getSelectedAnchors([
+      [{}, {}],
+      {
+        '': [{ y: true }, {}],
+        'a:a0': [{}, { z: true }],
+        'a:a1': [{ y: true }, {}],
+      },
+    ]);
+    const expected = [[], ['a0', 'a1']];
+    expect(anchors).toEqual(expected);
   });
 });

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -23,6 +23,7 @@ import '../typedef';
  * @property {FilterConfig} filterConfig
  * @property {boolean} hideZero
  * @property {FilterState} initialAppliedFilters
+ * @property {(anchorValue: string) => void} onAnchorValueChange
  * @property {FilterChangeHandler} onFilterChange
  * @property {(patientIds: string[]) => void} onPatientIdsChange
  * @property {string[]} patientIds
@@ -36,6 +37,7 @@ function FilterGroup({
   filterConfig,
   hideZero = true,
   initialAppliedFilters = {},
+  onAnchorValueChange = () => {},
   onFilterChange = () => {},
   onPatientIdsChange,
   patientIds,
@@ -59,6 +61,10 @@ function FilterGroup({
     anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
       ? `${anchorConfig.fieldName}:${anchorValue}`
       : '';
+  function handleAnchorValueChange(value) {
+    setAnchorValue(value);
+    onAnchorValueChange(value);
+  }
 
   const [expandedStatusControl, setExpandedStatusControl] = useState(false);
   const expandedStatusText = expandedStatusControl
@@ -254,7 +260,7 @@ function FilterGroup({
         <AnchorFilter
           anchorFieldName={anchorConfig.fieldName}
           anchorValue={anchorValue}
-          onChange={setAnchorValue}
+          onChange={handleAnchorValueChange}
           options={anchorConfig.options}
           optionsInUse={selectedAnchors[tabIndex]}
         />
@@ -316,6 +322,7 @@ FilterGroup.propTypes = {
   }).isRequired,
   hideZero: PropTypes.bool,
   initialAppliedFilters: PropTypes.object,
+  onAnchorValueChange: PropTypes.func,
   onFilterChange: PropTypes.func,
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -23,7 +23,7 @@ import '../typedef';
  * @property {FilterConfig} filterConfig
  * @property {boolean} hideZero
  * @property {FilterState} initialAppliedFilters
- * @property {(filter: FilterState) => void} onFilterChange
+ * @property {FilterChangeHandler} onFilterChange
  * @property {(patientIds: string[]) => void} onPatientIdsChange
  * @property {string[]} patientIds
  * @property {JSX.Element[]} tabs

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -41,12 +41,6 @@ function FilterGroup({
   patientIds,
   tabs,
 }) {
-  const [anchorValue, setAnchorValue] = useState('');
-  const anchorLabel =
-    anchorConfig !== undefined && anchorValue !== ''
-      ? `${anchorConfig.fieldName}:${anchorValue}`
-      : '';
-
   const filterTabs = filterConfig.tabs.map(
     ({ title, fields, searchFields }) => ({
       title,
@@ -94,6 +88,12 @@ function FilterGroup({
     setFilterResults(newFilterResults);
     onFilterChange(newFilterResults);
   }, [initialAppliedFilters]);
+
+  const [anchorValue, setAnchorValue] = useState('');
+  const anchorLabel =
+    anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
+      ? `${anchorConfig.fieldName}:${anchorValue}`
+      : '';
 
   const filterTabStatus = showAnchorFilter
     ? filterStatus[tabIndex][anchorLabel]

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -54,6 +54,12 @@ function FilterGroup({
     anchorConfig !== undefined && anchorConfig.tabs.includes(tabTitle);
   const showPatientIdsFilter = patientIds !== undefined;
 
+  const [anchorValue, setAnchorValue] = useState('');
+  const anchorLabel =
+    anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
+      ? `${anchorConfig.fieldName}:${anchorValue}`
+      : '';
+
   const [expandedStatusControl, setExpandedStatusControl] = useState(false);
   const expandedStatusText = expandedStatusControl
     ? 'Collapse all'
@@ -86,14 +92,8 @@ function FilterGroup({
 
     setFilterStatus(newFilterStatus);
     setFilterResults(newFilterResults);
-    onFilterChange(newFilterResults);
+    onFilterChange({ anchorValue, filter: newFilterResults });
   }, [initialAppliedFilters]);
-
-  const [anchorValue, setAnchorValue] = useState('');
-  const anchorLabel =
-    anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
-      ? `${anchorConfig.fieldName}:${anchorValue}`
-      : '';
 
   const filterTabStatus = showAnchorFilter
     ? filterStatus[tabIndex][anchorLabel]
@@ -123,7 +123,7 @@ function FilterGroup({
     });
     setFilterResults(updated.filterResults);
     setFilterStatus(updated.filterStatus);
-    onFilterChange(updated.filterResults);
+    onFilterChange({ anchorValue, filter: updated.filterResults });
   }
 
   /**
@@ -156,7 +156,7 @@ function FilterGroup({
       'selectedValues' in filterValues &&
       filterValues.selectedValues.length > 0
     )
-      onFilterChange(updated.filterResults);
+      onFilterChange({ anchorValue, filter: updated.filterResults });
   }
 
   /**
@@ -175,7 +175,7 @@ function FilterGroup({
     });
     setFilterStatus(updated.filterStatus);
     setFilterResults(updated.filterResults);
-    onFilterChange(updated.filterResults);
+    onFilterChange({ anchorValue, filter: updated.filterResults });
   }
 
   /**
@@ -209,7 +209,7 @@ function FilterGroup({
     });
     setFilterStatus(updated.filterStatus);
     setFilterResults(updated.filterResults);
-    onFilterChange(updated.filterResults);
+    onFilterChange({ anchorValue, filter: updated.filterResults });
   }
 
   function toggleSections() {

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -54,7 +54,8 @@ function FilterGroup({
   const tabTitle = filterTabs[tabIndex].title;
   const showAnchorFilter =
     anchorConfig !== undefined && anchorConfig.tabs.includes(tabTitle);
-  const showPatientIdsFilter = patientIds !== undefined;
+  const showPatientIdsFilter =
+    patientIds !== undefined && tabTitle === 'Subject';
 
   const [anchorValue, setAnchorValue] = useState('');
   const anchorLabel =

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -381,3 +381,30 @@ export function updateSelectedValue({
     filterResults: newFilterResults,
   };
 }
+
+/** @param {FilterSectionStatus} filterSectionStatus */
+function checkIfFilterSectionActive(filterSectionStatus) {
+  return Array.isArray(filterSectionStatus)
+    ? filterSectionStatus.length > 0
+    : Object.values(filterSectionStatus).some(Boolean);
+}
+
+/** @param {FilterStatus} filterStatus */
+export function getSelectedAnchors(filterStatus) {
+  /** @type {string[][]} */
+  const selectedAnchors = [];
+  for (const tabStatus of filterStatus) {
+    /** @type {string[]} */
+    const selectedAnchorsForTab = [];
+    if (!Array.isArray(tabStatus))
+      for (const [anchorLabel, anchoredTabStatus] of Object.entries(tabStatus))
+        if (
+          anchorLabel !== '' &&
+          anchoredTabStatus.some(checkIfFilterSectionActive)
+        )
+          selectedAnchorsForTab.push(anchorLabel.split(':')[1]);
+
+    selectedAnchors.push(selectedAnchorsForTab);
+  }
+  return selectedAnchors;
+}

--- a/src/stories/GuppyComponents/connectedFilter.jsx
+++ b/src/stories/GuppyComponents/connectedFilter.jsx
@@ -36,7 +36,6 @@ const sampleAggsData = {
 
 storiesOf('ConnectedFilter', module).add('Filter', () => {
   const [filter, setFilter] = React.useState({});
-  const processFilterAggsData = (aggsData) => aggsData;
   return (
     <ConnectedFilter
       filterConfig={filterConfig}
@@ -46,7 +45,6 @@ storiesOf('ConnectedFilter', module).add('Filter', () => {
         action('filter change');
       }}
       fieldMapping={fieldMapping}
-      onProcessFilterAggsData={processFilterAggsData}
       tierAccessLimit={guppyConfig.tierAccessLimit}
       filter={filter}
       initialTabsOptions={sampleAggsData}


### PR DESCRIPTION
Ticket: [PEDS-469](https://pcdc.atlassian.net/browse/PEDS-469)

This PR finally implements the use of anchored filter UI on the exploration page. The feature enables users to:

* Set an specific anchor value on each tab that uses the anchor (per configuration)
* See relevant counts for each select filter option on anchored tabs for the select anchor value

The PR includes much refactoring work done to facilitate this implementation as well as new tests for new utilities and functionalities.

The PR also adds a specific anchor (`disease_phase`)  with certain values (`'Initial Diagnosis'` and `'Relapse'`) for select set of tabs (`'Disease'` and  `'Molecular'`). A follow-up work is planned to enable specifying the anchor setting as part of portal configuration to replace the hard-coded values.

The PR also makes the patient IDs filters to be used only on the `"Subject"` tab.