### PR TITLE
Make anchored filters a config option PEDS-480

### DIFF
--- a/docs/anchored_filters.md
+++ b/docs/anchored_filters.md
@@ -8,7 +8,7 @@ The anchor can only be applied to nested field filters, and the field used for t
 
 The use of anchored filters can be specified using a portal configuration option for data explorer filters that looks like the following:
 
-```json
+```jsonc
 {
   "dataExplorerConfig": {
     "filters": {

--- a/docs/anchored_filters.md
+++ b/docs/anchored_filters.md
@@ -1,0 +1,155 @@
+## Anchored filters
+
+Anchored filters refer to explorer filters that are grouped by the combination of a sepecific "anchor" field and its value. Here, the "anchor" is a loose metaphor for how the select field-value serves to fix a certain set of filters to be applied in a limited fashion.
+
+The anchor can only be applied to nested field filters, and the field used for the anchor should be a common attribute of these nested field filters. Otherwise, the use of anchored filters will fail.
+
+### Configuration
+
+The use of anchored filters can be specified using a portal configuration option for data explorer filters that looks like the following:
+
+```json
+{
+  "dataExplorerConfig": {
+    "filters": {
+      "anchor": {
+        "field": "",
+        "options": [""],
+        "tabs": [""]
+      },
+      "tabs": [
+        // ...
+      ]
+    }
+  }
+}
+```
+
+- `"field"` is the name of the field to use as anchor. It must be a common attribute to all nested field filters to be used as anchored filters. Additionally, the anchor must be an _option_ (as opposed to _range_) type filter
+- `"options"` is an array of values for the anchor field to be used for anchored filters.
+- `"tabs"` is an array of tab titles where the tabs will contain nested field filters to be used as anchored filters.
+
+## UI
+
+If anchored filters configuration is set, the specified filter tabs in the anchored filter configuration will get a special filter section on the top. This special filter section contains a radio button group to set anchor value to use. Only one anchor value can be selected at a time. The default option is to not set an anchor value and is labelled "Any".
+
+Each anchor value gets its own set of filters, which is also reflected on the filter UI state, i.e. the checked/unchecked status as well as the relevant data count for each select filter option and min/max values for each range filter.
+
+## Filter state data structure
+
+The filter state data structure for anchored filters is simply additive to the original and does not change how normal, i.e. non-anchored, filters are encoded in the client-side filter state object.
+
+The following is the updated filter state data structure modeled in TypeScript:
+
+```ts
+type OptionFilter = {
+  __combineMode?: 'AND' | 'OR';
+  selectedValues: string[];
+};
+
+type RangeFilter = {
+  lowerBound: number;
+  upperBound: number;
+};
+
+type SimpleFilterState = {
+  [fieldName: string]: OptionFilter | RangeFilter;
+};
+
+type FilterState = {
+  [fieldNameOrAnchorLabel: string]:
+    | OptionFilter
+    | RangeFilter
+    | { filter: SimpleFilterState }; // for anchored filters
+};
+```
+
+An anchor label value is formated as `[anchorField]:[anchorValue]`, where `[anchorField]` is the `dataExplorerConfig.filters.anchor.field` value in the portal configuration and `[anchorValue]` is one of the `dataExplorerConfig.filters.anchor.options` values in the portal configuration that is selected by the user.
+
+The anchor label is used only if anchor value is set to be a non-empty value (i.e. not "Any").
+
+### Example
+
+```ts
+const filterState: FilterState = {
+  sex: {
+    selectedValues: ['Female'],
+  },
+  'disease_phase:Initial Diagnosis': {
+    filter: {
+      'histologies.histology_grade': {
+        selectedValues: ['Differentiating'],
+      },
+    },
+  },
+  'disease_phase:Relapse': {
+    filter: {
+      'tumor_assessments.tumor_classification': {
+        selectedValues: ['Primary'],
+      },
+    },
+  },
+};
+```
+
+## GraphQL Query filter
+
+When anchored filters are used in the translated GraphQL queries, the anchor field-value combination will be injected as an additional filter piece to each affected nested field filter piece. In this way, the anchored filters will be used in conjunction with the anchoring filter (i.e. joined by `"AND"`).
+
+The example filter state above would be converted to the following GraphQL filter object:
+
+```js
+const gqlFilter = {
+  AND: [
+    {
+      IN: {
+        sex: ['Female'],
+      },
+    },
+    {
+      nested: {
+        path: 'histologies',
+        AND: [
+          {
+            AND: [
+              {
+                IN: {
+                  histology_grade: ['Differentiating'],
+                },
+              },
+              // injected anchored filter piece
+              {
+                IN: {
+                  disease_phase: ['Initial Diagnosis'],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      nested: {
+        path: 'tumor_assessments',
+        AND: [
+          {
+            AND: [
+              {
+                IN: {
+                  tumor_classification: ['Primary'],
+                },
+              },
+              // injected anchored filter piece
+              {
+                IN: {
+                  disease_phase: ['Relapse'],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+```

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -115,7 +115,7 @@ function ConnectedFilter({
 ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
   anchorConfig: PropTypes.shape({
-    fieldName: PropTypes.string,
+    field: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.string),
     tabs: PropTypes.arrayOf(PropTypes.string),
   }),

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -13,8 +13,6 @@ import '../typedef';
 
 /**
  * @typedef {Object} ConnectedFilterProps
- * @property {{ [x: string]: OptionFilter }} [adminAppliedPreFilters]
- * @property {AnchorConfig} anchorConfig
  * @property {string} className
  * @property {FilterState} filter
  * @property {FilterConfig} filterConfig
@@ -34,7 +32,6 @@ import '../typedef';
 /** @param {ConnectedFilterProps} props */
 function ConnectedFilter({
   adminAppliedPreFilters = {},
-  anchorConfig,
   className = '',
   filter,
   filterConfig,
@@ -98,7 +95,6 @@ function ConnectedFilter({
 
   return (
     <FilterGroup
-      anchorConfig={anchorConfig}
       className={className}
       tabs={filterTabs}
       filterConfig={filterConfig}
@@ -114,14 +110,14 @@ function ConnectedFilter({
 
 ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
-  anchorConfig: PropTypes.shape({
-    field: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.string),
-    tabs: PropTypes.arrayOf(PropTypes.string),
-  }),
   className: PropTypes.string,
   filter: PropTypes.object.isRequired,
   filterConfig: PropTypes.shape({
+    anchor: PropTypes.shape({
+      field: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+      tabs: PropTypes.arrayOf(PropTypes.string),
+    }),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -21,7 +21,6 @@ import '../typedef';
 
 /**
  * @typedef {Object} GuppyWrapperProps
- * @property {AnchorConfig} anchorConfig
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
  * @property {((data: GuppyData) => JSX.Element)} children
@@ -49,7 +48,6 @@ import '../typedef';
 
 /** @param {GuppyWrapperProps} props */
 function GuppyWrapper({
-  anchorConfig,
   chartConfig,
   filterConfig,
   guppyConfig,
@@ -155,7 +153,7 @@ function GuppyWrapper({
     return queryGuppyForAggregationOptionsData({
       path: guppyConfig.path,
       type: guppyConfig.dataType,
-      anchorConfig,
+      anchorConfig: filterConfig.anchor,
       anchorValue,
       filterTabs,
       gqlFilter: getGQLFilter(augmentFilter(filter)),
@@ -442,7 +440,7 @@ function GuppyWrapper({
       anchorValue,
       filter: state.filter,
       filterTabs: filterConfig.tabs.filter(({ title }) =>
-        anchorConfig.tabs.includes(title)
+        filterConfig.anchor.tabs.includes(title)
       ),
     }).then(({ tabsOptions }) => {
       if (isMounted.current)
@@ -498,6 +496,11 @@ GuppyWrapper.propTypes = {
   }).isRequired,
   children: PropTypes.func.isRequired,
   filterConfig: PropTypes.shape({
+    anchor: PropTypes.shape({
+      field: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+      tabs: PropTypes.arrayOf(PropTypes.string),
+    }),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -145,7 +145,7 @@ export function getQueryInfoForAggregationOptionsData({
 }) {
   const isUsingAnchor = anchorConfig !== undefined && anchorValue !== '';
   const anchorFilterPiece = isUsingAnchor
-    ? { IN: { [anchorConfig.fieldName]: [anchorValue] } }
+    ? { IN: { [anchorConfig.field]: [anchorValue] } }
     : undefined;
 
   const fieldsByGroup = {};

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -132,7 +132,7 @@ export function queryGuppyForAggregationCountData({
 
 /**
  * @param {Object} args
- * @param {{ fieldName: string; tabs: string[] }} [args.anchorConfig]
+ * @param {AnchorConfig} [args.anchorConfig]
  * @param {string} [args.anchorValue]
  * @param {{ title: string; fields: string[] }[]} args.filterTabs
  * @param {GqlFilter} [args.gqlFilter]

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -70,6 +70,13 @@
  */
 
 /**
+ * @typedef {Object} AnchorConfig
+ * @property {string} field
+ * @property {string[]} options
+ * @property {string[]} tabs
+ */
+
+/**
  * @typedef {Object} FilterTabsOption
  * @property {string} title
  * @property {string[]} fields
@@ -78,6 +85,7 @@
 
 /**
  * @typedef {Object} FilterConfig
+ * @property {AnchorConfig} anchor
  * @property {FilterTabsOption[]} tabs
  */
 

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -7,7 +7,6 @@ import './ExplorerFilter.css';
 /**
  * @typedef {Object} ExplorerFilterProps
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
- * @property {AnchorConfig} anchorConfig
  * @property {string} className
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
@@ -52,11 +51,6 @@ function ExplorerFilter({
 
 ExplorerFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
-  anchorConfig: PropTypes.shape({
-    field: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.string),
-    tabs: PropTypes.arrayOf(PropTypes.string),
-  }),
   className: PropTypes.string,
   filterConfig: FilterConfigType.isRequired,
   guppyConfig: GuppyConfigType.isRequired,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -53,7 +53,7 @@ function ExplorerFilter({
 ExplorerFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
   anchorConfig: PropTypes.shape({
-    fieldName: PropTypes.string,
+    field: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.string),
     tabs: PropTypes.arrayOf(PropTypes.string),
   }),

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -282,7 +282,7 @@ class GuppyDataExplorer extends React.Component {
 
 GuppyDataExplorer.propTypes = {
   anchorConfig: PropTypes.shape({
-    fieldName: PropTypes.string,
+    field: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.string),
     tabs: PropTypes.arrayOf(PropTypes.string),
   }),

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -57,7 +57,6 @@ function extractExplorerStateFromURL(
 
 /**
  * @typedef {Object} GuppyDataExplorerProps
- * @property {AnchorConfig} anchorConfig
  * @property {GuppyConfig} guppyConfig
  * @property {FilterConfig} filterConfig
  * @property {TableConfig} tableConfig
@@ -88,7 +87,7 @@ class GuppyDataExplorer extends React.Component {
     const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
       new URLSearchParams(props.history.location.search),
       props.filterConfig,
-      props.anchorConfig !== undefined,
+      props.filterConfig.anchor !== undefined,
       props.patientIdsConfig
     );
     /** @type {GuppyDataExplorerState} */
@@ -108,7 +107,7 @@ class GuppyDataExplorer extends React.Component {
       const { initialAppliedFilters, patientIds } = extractExplorerStateFromURL(
         new URLSearchParams(this.props.history.location.search),
         this.props.filterConfig,
-        this.props.anchorConfig !== undefined,
+        this.props.filterConfig.anchor !== undefined,
         this.props.patientIdsConfig
       );
       this._hasAppliedFilters = Object.keys(initialAppliedFilters).length > 0;
@@ -198,7 +197,6 @@ class GuppyDataExplorer extends React.Component {
           <GuppyWrapper
             adminAppliedPreFilters={this.props.adminAppliedPreFilters}
             initialAppliedFilters={this.state.initialAppliedFilters}
-            anchorConfig={this.props.anchorConfig}
             chartConfig={this.props.chartConfig}
             filterConfig={this.props.filterConfig}
             guppyConfig={this.props.guppyConfig}
@@ -223,7 +221,6 @@ class GuppyDataExplorer extends React.Component {
                 />
                 <ExplorerFilter
                   adminAppliedPreFilters={this.props.adminAppliedPreFilters}
-                  anchorConfig={this.props.anchorConfig}
                   className='guppy-data-explorer__filter'
                   filterConfig={this.props.filterConfig}
                   guppyConfig={this.props.guppyConfig}
@@ -281,11 +278,6 @@ class GuppyDataExplorer extends React.Component {
 }
 
 GuppyDataExplorer.propTypes = {
-  anchorConfig: PropTypes.shape({
-    field: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.string),
-    tabs: PropTypes.arrayOf(PropTypes.string),
-  }),
   guppyConfig: GuppyConfigType.isRequired,
   filterConfig: FilterConfigType.isRequired,
   tableConfig: TableConfigType.isRequired,

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -18,6 +18,11 @@ export const GuppyConfigType = PropTypes.shape({
 });
 
 export const FilterConfigType = PropTypes.shape({
+  anchor: PropTypes.shape({
+    field: PropTypes.string,
+    options: PropTypes.arrayOf(PropTypes.string),
+    tabs: PropTypes.arrayOf(PropTypes.string),
+  }),
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -25,13 +25,6 @@ export default function Explorer() {
   const tabConfig = explorerConfig[tabIndex];
   const isMultiTabExplorer = explorerConfig.length > 1;
 
-  /** @type {AnchorConfig} */
-  const anchorConfig = {
-    field: 'disease_phase',
-    options: ['Initial Diagnosis', 'Relapse'],
-    tabs: ['Disease', 'Molecular'],
-  };
-
   return (
     <div className='guppy-explorer'>
       {isMultiTabExplorer && (
@@ -70,7 +63,6 @@ export default function Explorer() {
       )}
       <div className={isMultiTabExplorer ? 'guppy-explorer__main' : ''}>
         <GuppyDataExplorer
-          anchorConfig={anchorConfig}
           adminAppliedPreFilters={tabConfig.adminAppliedPreFilters}
           chartConfig={tabConfig.charts}
           filterConfig={tabConfig.filters}

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -27,7 +27,7 @@ export default function Explorer() {
 
   /** @type {AnchorConfig} */
   const anchorConfig = {
-    fieldName: 'disease_phase',
+    field: 'disease_phase',
     options: ['Initial Diagnosis', 'Relapse'],
     tabs: ['Disease', 'Molecular'],
   };

--- a/src/gen3-ui-component/components/filters/AnchorFilter.jsx
+++ b/src/gen3-ui-component/components/filters/AnchorFilter.jsx
@@ -5,7 +5,7 @@ import { capitalizeFirstLetter } from '../../../utils';
 
 /**
  * @typedef {Object} AnchorFilterProps
- * @property {string} anchorFieldName
+ * @property {string} anchorField
  * @property {string} anchorValue
  * @property {string} [defaultOptionLabel]
  * @property {string} [defaultOptionValue]
@@ -16,7 +16,7 @@ import { capitalizeFirstLetter } from '../../../utils';
 
 /** @param {AnchorFilterProps} props */
 function AnchorFilter({
-  anchorFieldName,
+  anchorField,
   anchorValue,
   defaultOptionLabel = 'Any',
   defaultOptionValue = '',
@@ -52,14 +52,14 @@ function AnchorFilter({
                 : ''
             }`}
           >
-            {capitalizeFirstLetter(anchorFieldName)}
+            {capitalizeFirstLetter(anchorField)}
           </span>
         </div>
       </div>
       {[defaultOptionValue, ...options].map((option) => (
         <label key={option} className={`g3-single-select-filter`}>
           <input
-            name={anchorFieldName}
+            name={anchorField}
             type='radio'
             style={{ margin: '0 14px' }}
             value={option}
@@ -82,7 +82,7 @@ function AnchorFilter({
 }
 
 AnchorFilter.propTypes = {
-  anchorFieldName: PropTypes.string.isRequired,
+  anchorField: PropTypes.string.isRequired,
   anchorValue: PropTypes.string.isRequired,
   defaultOptionLabel: PropTypes.string,
   defaultOptionValue: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -60,7 +60,7 @@ function FilterGroup({
   const [anchorValue, setAnchorValue] = useState('');
   const anchorLabel =
     anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
-      ? `${anchorConfig.fieldName}:${anchorValue}`
+      ? `${anchorConfig.field}:${anchorValue}`
       : '';
   function handleAnchorValueChange(value) {
     setAnchorValue(value);
@@ -259,7 +259,7 @@ function FilterGroup({
       </div>
       {showAnchorFilter && (
         <AnchorFilter
-          anchorFieldName={anchorConfig.fieldName}
+          anchorField={anchorConfig.field}
           anchorValue={anchorValue}
           onChange={handleAnchorValueChange}
           options={anchorConfig.options}
@@ -307,7 +307,7 @@ function FilterGroup({
 
 FilterGroup.propTypes = {
   anchorConfig: PropTypes.shape({
-    fieldName: PropTypes.string,
+    field: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.string),
     tabs: PropTypes.arrayOf(PropTypes.string),
   }),

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -18,7 +18,6 @@ import '../typedef';
 
 /**
  * @typedef {Object} FilterGroupProps
- * @property {AnchorConfig} anchorConfig
  * @property {string} className
  * @property {FilterConfig} filterConfig
  * @property {boolean} hideZero
@@ -32,7 +31,6 @@ import '../typedef';
 
 /** @param {FilterGroupProps} props */
 function FilterGroup({
-  anchorConfig,
   className = '',
   filterConfig,
   hideZero = true,
@@ -53,14 +51,15 @@ function FilterGroup({
   const [tabIndex, setTabIndex] = useState(0);
   const tabTitle = filterTabs[tabIndex].title;
   const showAnchorFilter =
-    anchorConfig !== undefined && anchorConfig.tabs.includes(tabTitle);
+    filterConfig.anchor !== undefined &&
+    filterConfig.anchor.tabs.includes(tabTitle);
   const showPatientIdsFilter =
     patientIds !== undefined && tabTitle === 'Subject';
 
   const [anchorValue, setAnchorValue] = useState('');
   const anchorLabel =
-    anchorConfig !== undefined && anchorValue !== '' && showAnchorFilter
-      ? `${anchorConfig.field}:${anchorValue}`
+    filterConfig.anchor !== undefined && anchorValue !== '' && showAnchorFilter
+      ? `${filterConfig.anchor.field}:${anchorValue}`
       : '';
   function handleAnchorValueChange(value) {
     setAnchorValue(value);
@@ -78,7 +77,7 @@ function FilterGroup({
   const [filterResults, setFilterResults] = useState(initialAppliedFilters);
   const [filterStatus, setFilterStatus] = useState(
     getFilterStatus({
-      anchorConfig,
+      anchorConfig: filterConfig.anchor,
       filterResults: initialAppliedFilters,
       filterTabs,
     })
@@ -91,7 +90,7 @@ function FilterGroup({
     }
 
     const newFilterStatus = getFilterStatus({
-      anchorConfig,
+      anchorConfig: filterConfig.anchor,
       filterResults: initialAppliedFilters,
       filterTabs,
     });
@@ -259,10 +258,10 @@ function FilterGroup({
       </div>
       {showAnchorFilter && (
         <AnchorFilter
-          anchorField={anchorConfig.field}
+          anchorField={filterConfig.anchor.field}
           anchorValue={anchorValue}
           onChange={handleAnchorValueChange}
-          options={anchorConfig.options}
+          options={filterConfig.anchor.options}
           optionsInUse={selectedAnchors[tabIndex]}
         />
       )}
@@ -306,13 +305,13 @@ function FilterGroup({
 }
 
 FilterGroup.propTypes = {
-  anchorConfig: PropTypes.shape({
-    field: PropTypes.string,
-    options: PropTypes.arrayOf(PropTypes.string),
-    tabs: PropTypes.arrayOf(PropTypes.string),
-  }),
   className: PropTypes.string,
   filterConfig: PropTypes.shape({
+    anchor: PropTypes.shape({
+      field: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+      tabs: PropTypes.arrayOf(PropTypes.string),
+    }),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -22,7 +22,7 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
 
   if (anchorConfig !== undefined)
     for (const anchorValue of anchorConfig.options)
-      filterResultsByAnchor[`${anchorConfig.fieldName}:${anchorValue}`] = {};
+      filterResultsByAnchor[`${anchorConfig.field}:${anchorValue}`] = {};
 
   for (const [filterKey, filterValues] of Object.entries(filterResults))
     if ('filter' in filterValues) {

--- a/src/gen3-ui-component/components/filters/typedef.js
+++ b/src/gen3-ui-component/components/filters/typedef.js
@@ -14,7 +14,7 @@
 
 /**
  * @typedef {Object} AnchorConfig
- * @property {string} fieldName
+ * @property {string} field
  * @property {string[]} options
  * @property {string[]} tabs
  */

--- a/src/stories/gen3-ui-component/filters.jsx
+++ b/src/stories/gen3-ui-component/filters.jsx
@@ -312,7 +312,7 @@ storiesOf('Filters', module)
     return (
       <div>
         <AnchorFilter
-          anchorFieldName='Disease Phase'
+          anchorField='Disease Phase'
           anchorValue={anchorValue}
           options={['Initial Diagnosis', 'Relapse']}
           optionsInUse={['Initial Diagnosis']}


### PR DESCRIPTION
Ticket: [PEDS-480](https://pcdc.atlassian.net/browse/PEDS-480)

This PR creates a new portal config option for anchored filters feature on the Exploration page.

The new configuration option is placed under `dataExplorerConfig` and looks like the following:
```jsonc
{
  "dataExplorerConfig": {
    "filters": {
      "anchor": {
        "field": "",
        "options": [""],
        "tabs": [""]
      }
    }
  }
}
```

For more details, see the newly added documentation for anchored filters, also included in this PR ([rendered page](https://github.com/chicagopcdc/data-portal/blob/feat/make-anchored-filters-config-option/docs/anchored_filters.md)).