### PR TITLE
Cache anchored tabs options PEDS-481

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -214,7 +214,7 @@ function GuppyWrapper({
         { accessibleCount, totalCount },
         { aggsData, initialTabsOptions, tabsOptions },
       ]) => {
-        if (isMounted.current)
+        if (isMounted.current) {
           setState((prevState) => ({
             ...prevState,
             accessibleCount,
@@ -225,6 +225,10 @@ function GuppyWrapper({
             tabsOptions,
             totalCount,
           }));
+
+          if (anchorValue !== undefined)
+            setAnchoredTabsOptionsCache({ [anchorValue]: tabsOptions });
+        }
       }
     );
   }

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -328,7 +328,10 @@ function GuppyWrapper({
     }).then((allFields) => {
       if (isMounted.current) {
         setState((prevState) => ({ ...prevState, allFields }));
-        fetchAggsDataFromGuppy({ filter: state.filter });
+        fetchAggsDataFromGuppy({
+          anchorValue: filterConfig.anchor !== undefined ? '' : undefined,
+          filter: state.filter,
+        });
         fetchRawDataFromGuppy({
           fields:
             rawDataFieldsConfig?.length > 0 ? rawDataFieldsConfig : allFields,


### PR DESCRIPTION
Ticket: [PEDS-481](https://pcdc.atlassian.net/browse/PEDS-481)

This PR implements a simple caching for tabs options counts for "anchored" tabs. The cached values are reused on anchor value change and updated on filter change.