### PR TITLE
Remove themeoverrides.css PEDS-487

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ index.html
 data/schema.graphql
 data/schema.json
 src/params.js
-src/css/themeoverrides.css
 __generated__/
 *.log
 .DS_Store

--- a/custom/customize.sh
+++ b/custom/customize.sh
@@ -27,12 +27,6 @@ if [ -f custom/privacy_policy.md ]; then
   cp custom/privacy_policy.md src/privacy_policy.md
 fi
 
-if [ -f custom/css/$APP.css ]; then
-  cp custom/css/$APP.css src/css/themeoverrides.css
-else
-  echo "/* generated file - see customize.sh */" > src/css/themeoverrides.css
-fi
-
 if [ -d custom/sponsors/$APP-sponsors ]; then
   cp -r custom/sponsors/$APP-sponsors src/img/sponsors
 fi

--- a/dev.html
+++ b/dev.html
@@ -17,16 +17,5 @@
       type="text/javascript"
       src="https://localhost:9443/main.bundle.js"
     ></script>
-    <link
-      id="gen3-theme-overrides"
-      rel="stylesheet"
-      type="text/css"
-      href="/src/css/themeoverrides.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://localhost:9443/src/css/themeoverrides.css"
-    />
   </body>
 </html>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -16,11 +16,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <link
-      id="gen3-theme-overrides"
-      rel="stylesheet"
-      type="text/css"
-      href="<%= htmlWebpackPlugin.options.basename %>/src/css/themeoverrides.css"
-    />
   </body>
 </html>


### PR DESCRIPTION
Ticket: [PEDS-487](https://pcdc.atlassian.net/browse/PEDS-487)

This PR removes the support for using `themoverrides.css` file to override specific styles. `themoverrides.css` has never been used before and is not needed since we took the ownership of the source code for our use case. On the other hand, we can stops the app from making pointless requests for the non-exsiting stylesheet by removing its support.