### PR TITLE
Fix SVG graph node click handler PEDS-490

### DIFF
--- a/src/DataModelGraph/SvgGraph.jsx
+++ b/src/DataModelGraph/SvgGraph.jsx
@@ -96,7 +96,7 @@ export function createSvgGraph(nodesIn, edges) {
       return '';
     })
     .attr('id', (d) => d.id)
-    .on('click', (d) => {
+    .on('click', (_, d) => {
       for (let i = 0; i < nodesForQuery.length; i += 1) {
         if (d.id === nodesForQuery[i]) {
           window.open(


### PR DESCRIPTION
Ticket: [PEDS-490](https://pcdc.atlassian.net/browse/PEDS-490)

This PR fixes the unresponsive click handler for SVG graph node on `/:project` page. This failure was caused by a breaking change to `selection.on()` API for `d3-selection` (from v1 to v2) that was not properly accounted for during migrating the library to v3 in https://github.com/chicagopcdc/data-portal/pull/172. See [`d3-selection` API documentation](https://github.com/d3/d3-selection/tree/v3.0.0#selection_on) for more on this.