### PR TITLE
Fix lazy loaded static data format PEDS-497

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -337,14 +337,14 @@ export const fetchProjects = () => (dispatch) =>
  * handled by router
  */
 export const fetchSchema = (dispatch) =>
-  import('../data/schema.json').then((schema) =>
-    dispatch({ type: 'RECEIVE_SCHEMA', schema })
-  );
+  fetch('../data/schema.json')
+    .then((response) => response.json())
+    .then((schema) => dispatch({ type: 'RECEIVE_SCHEMA', schema }));
 
 export const fetchDictionary = (dispatch) =>
-  import('../data/dictionary.json').then((dictionary) =>
-    dispatch({ type: 'RECEIVE_DICTIONARY', data: dictionary })
-  );
+  fetch('../data/dictionary.json')
+    .then((response) => response.json())
+    .then((data) => dispatch({ type: 'RECEIVE_DICTIONARY', data }));
 
 export const fetchVersionInfo = (dispatch) =>
   fetchWithCreds({


### PR DESCRIPTION
Ticket: [PEDS-497](https://pcdc.atlassian.net/browse/PEDS-497)

This PR fixes the unintended side effect of using dynamic `import()` to lazy-load json data as static files (introduced by #211).

More specifically, when `Object.keys()` is used on the loaded module, the returned array includes an additional element of `"default"`. This causes errors in script that relies on calling `Object.keys()` on these data. To prevent this, the files are now loaded with `fetch()`.