### PR TITLE
Cache flat model schema PEDS-499

### DIFF
--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -94,10 +94,12 @@ class GqlEditor extends React.Component {
     ];
 
     if (config.dataExplorerConfig) {
+      const graphqlSchemaFlat = buildClientSchema(this.props.schemaFlat.data);
+
       options.push({
         name: 'Flat Model',
         endpoint: fetchFlatGraphQL,
-        schema: null,
+        schema: graphqlSchemaFlat,
       });
     }
 
@@ -122,24 +124,14 @@ class GqlEditor extends React.Component {
             </div>
           ) : null}
         </div>
-        {index === 0 ? (
-          <GraphiQL
-            fetcher={options[index].endpoint}
-            query={parameters.query}
-            schema={options[index].schema}
-            variables={parameters.variables}
-            onEditQuery={editQuery}
-            onEditVariables={editVariables}
-          />
-        ) : (
-          <GraphiQL
-            fetcher={options[index].endpoint}
-            query={parameters.query}
-            variables={parameters.variables}
-            onEditQuery={editQuery}
-            onEditVariables={editVariables}
-          />
-        )}
+        <GraphiQL
+          fetcher={options[index].endpoint}
+          query={parameters.query}
+          schema={options[index].schema}
+          variables={parameters.variables}
+          onEditQuery={editQuery}
+          onEditVariables={editVariables}
+        />
       </div>
     );
   }
@@ -147,6 +139,7 @@ class GqlEditor extends React.Component {
 
 GqlEditor.propTypes = {
   schema: PropTypes.object,
+  schemaFlat: PropTypes.object,
   endpointIndex: PropTypes.number,
 };
 

--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -5,13 +5,12 @@ import PropTypes from 'prop-types';
 import Button from '../gen3-ui-component/components/Button';
 import Spinner from '../components/Spinner';
 import { headers, graphqlPath, guppyGraphQLUrl } from '../localconf';
-import { config } from '../params';
 import sessionMonitor from '../SessionMonitor';
 import './GqlEditor.less';
 import 'graphiql/graphiql.css';
 
 const parameters = {};
-const defaultValue = config.dataExplorerConfig ? 1 : 0;
+const defaultValue = 0;
 
 const fetchGraphQL = (graphQLParams) =>
   // We first update the session so that the user will be notified
@@ -86,21 +85,18 @@ class GqlEditor extends React.Component {
 
     const options = [
       {
+        name: 'Flat Model',
+        endpoint: fetchFlatGraphQL,
+        schema: this.props.guppySchema,
+      },
+      {
         name: 'Graph Model',
         endpoint: fetchGraphQL,
         schema: this.props.schema,
       },
     ];
 
-    if (config.dataExplorerConfig) {
-      options.push({
-        name: 'Flat Model',
-        endpoint: fetchFlatGraphQL,
-        schema: this.props.guppySchema,
-      });
-    }
-
-    // If provided endpoint is not 0 or 1, default to 0 (graph model)
+    // If provided endpoint is not 0 or 1, default to 0 (flat model)
     const index =
       this.state.selectedEndpointIndex !== null &&
       this.state.selectedEndpointIndex < options.length

--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import GraphiQL from 'graphiql';
-import { buildClientSchema } from 'graphql/utilities';
+
 import PropTypes from 'prop-types';
 import Button from '../gen3-ui-component/components/Button';
 import Spinner from '../components/Spinner';
@@ -77,7 +77,6 @@ class GqlEditor extends React.Component {
     if (!this.props.schema) {
       return <Spinner />; // loading
     }
-    const graphqlSchema = buildClientSchema(this.props.schema.data);
     const editQuery = (newQuery) => {
       parameters.query = newQuery;
     };
@@ -89,17 +88,15 @@ class GqlEditor extends React.Component {
       {
         name: 'Graph Model',
         endpoint: fetchGraphQL,
-        schema: graphqlSchema,
+        schema: this.props.schema,
       },
     ];
 
     if (config.dataExplorerConfig) {
-      const graphqlSchemaFlat = buildClientSchema(this.props.schemaFlat.data);
-
       options.push({
         name: 'Flat Model',
         endpoint: fetchFlatGraphQL,
-        schema: graphqlSchemaFlat,
+        schema: this.props.schemaFlat,
       });
     }
 

--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -96,7 +96,7 @@ class GqlEditor extends React.Component {
       options.push({
         name: 'Flat Model',
         endpoint: fetchFlatGraphQL,
-        schema: this.props.schemaFlat,
+        schema: this.props.guppySchema,
       });
     }
 
@@ -136,7 +136,7 @@ class GqlEditor extends React.Component {
 
 GqlEditor.propTypes = {
   schema: PropTypes.object,
-  schemaFlat: PropTypes.object,
+  guppySchema: PropTypes.object,
   endpointIndex: PropTypes.number,
 };
 

--- a/src/GraphQLEditor/ReduxGqlEditor.js
+++ b/src/GraphQLEditor/ReduxGqlEditor.js
@@ -6,6 +6,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     schema: state.graphiql.schema,
+    schemaFlat: state.graphiql.schemaFlat,
     endpointIndex: searchParams.has('endpoint')
       ? parseInt(searchParams.get('endpoint'), 10)
       : null,

--- a/src/GraphQLEditor/ReduxGqlEditor.js
+++ b/src/GraphQLEditor/ReduxGqlEditor.js
@@ -6,7 +6,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     schema: state.graphiql.schema,
-    schemaFlat: state.graphiql.schemaFlat,
+    guppySchema: state.graphiql.guppySchema,
     endpointIndex: searchParams.has('endpoint')
       ? parseInt(searchParams.get('endpoint'), 10)
       : null,

--- a/src/GraphQLEditor/reducers.js
+++ b/src/GraphQLEditor/reducers.js
@@ -2,6 +2,8 @@ const graphiql = (state = {}, action) => {
   switch (action.type) {
     case 'RECEIVE_SCHEMA':
       return { ...state, schema: action.schema };
+    case 'RECEIVE_SCHEMA_FLAT':
+      return { ...state, schemaFlat: action.data };
     default:
       return state;
   }

--- a/src/GraphQLEditor/reducers.js
+++ b/src/GraphQLEditor/reducers.js
@@ -2,8 +2,8 @@ const graphiql = (state = {}, action) => {
   switch (action.type) {
     case 'RECEIVE_SCHEMA':
       return { ...state, schema: action.schema };
-    case 'RECEIVE_SCHEMA_FLAT':
-      return { ...state, schemaFlat: action.data };
+    case 'RECEIVE_GUPPY_SCHEMA':
+      return { ...state, guppySchema: action.data };
     default:
       return state;
   }

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -5,7 +5,7 @@ import {
   fetchDictionary,
   fetchProjects,
   fetchSchema,
-  fetchSchemaFlat,
+  fetchGuppySchema,
   fetchUser,
   fetchUserAccess,
 } from '../actions';
@@ -192,7 +192,7 @@ class ProtectedContent extends React.Component {
       dispatch(fetchProjects);
     } else if (LOCATIONS_SCHEMA.includes(path)) {
       if (!graphiql.schema) dispatch(fetchSchema);
-      if (!graphiql.schemaFlat) dispatch(fetchSchemaFlat);
+      if (!graphiql.guppySchema) dispatch(fetchGuppySchema);
     }
   }
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -5,6 +5,7 @@ import {
   fetchDictionary,
   fetchProjects,
   fetchSchema,
+  fetchSchemaFlat,
   fetchUser,
   fetchUserAccess,
 } from '../actions';
@@ -189,8 +190,9 @@ class ProtectedContent extends React.Component {
       dispatch(fetchDictionary);
     } else if (LOCATIONS_PROJECTS.includes(path) && !project.projects) {
       dispatch(fetchProjects);
-    } else if (LOCATIONS_SCHEMA.includes(path) && !graphiql.schema) {
-      dispatch(fetchSchema);
+    } else if (LOCATIONS_SCHEMA.includes(path)) {
+      if (!graphiql.schema) dispatch(fetchSchema);
+      if (!graphiql.schemaFlat) dispatch(fetchSchemaFlat);
     }
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import 'isomorphic-fetch';
-import { getIntrospectionQuery } from 'graphql';
+import { getIntrospectionQuery } from 'graphql/utilities';
 import {
   apiPath,
   userapiPath,

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,9 @@
 import 'isomorphic-fetch';
+import { getIntrospectionQuery } from 'graphql';
 import {
   apiPath,
   userapiPath,
+  guppyGraphQLUrl,
   headers,
   hostname,
   submissionApiOauthPath,
@@ -340,6 +342,19 @@ export const fetchSchema = (dispatch) =>
   fetch('../data/schema.json')
     .then((response) => response.json())
     .then((schema) => dispatch({ type: 'RECEIVE_SCHEMA', schema }));
+
+export const fetchSchemaFlat = (dispatch) =>
+  fetch(guppyGraphQLUrl, {
+    credentials: 'include',
+    headers: { ...headers },
+    method: 'POST',
+    body: JSON.stringify({
+      query: getIntrospectionQuery(),
+      operationName: 'IntrospectionQuery',
+    }),
+  })
+    .then((response) => response.json())
+    .then((data) => dispatch({ type: 'RECEIVE_SCHEMA_FLAT', data }));
 
 export const fetchDictionary = (dispatch) =>
   fetch('../data/dictionary.json')

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import 'isomorphic-fetch';
-import { getIntrospectionQuery } from 'graphql/utilities';
+import { buildClientSchema, getIntrospectionQuery } from 'graphql/utilities';
 import {
   apiPath,
   userapiPath,
@@ -341,7 +341,9 @@ export const fetchProjects = () => (dispatch) =>
 export const fetchSchema = (dispatch) =>
   fetch('../data/schema.json')
     .then((response) => response.json())
-    .then((schema) => dispatch({ type: 'RECEIVE_SCHEMA', schema }));
+    .then(({ data }) =>
+      dispatch({ type: 'RECEIVE_SCHEMA', schema: buildClientSchema(data) })
+    );
 
 export const fetchSchemaFlat = (dispatch) =>
   fetch(guppyGraphQLUrl, {
@@ -354,7 +356,9 @@ export const fetchSchemaFlat = (dispatch) =>
     }),
   })
     .then((response) => response.json())
-    .then((data) => dispatch({ type: 'RECEIVE_SCHEMA_FLAT', data }));
+    .then(({ data }) =>
+      dispatch({ type: 'RECEIVE_SCHEMA_FLAT', data: buildClientSchema(data) })
+    );
 
 export const fetchDictionary = (dispatch) =>
   fetch('../data/dictionary.json')

--- a/src/actions.js
+++ b/src/actions.js
@@ -345,7 +345,7 @@ export const fetchSchema = (dispatch) =>
       dispatch({ type: 'RECEIVE_SCHEMA', schema: buildClientSchema(data) })
     );
 
-export const fetchSchemaFlat = (dispatch) =>
+export const fetchGuppySchema = (dispatch) =>
   fetch(guppyGraphQLUrl, {
     credentials: 'include',
     headers: { ...headers },
@@ -357,7 +357,7 @@ export const fetchSchemaFlat = (dispatch) =>
   })
     .then((response) => response.json())
     .then(({ data }) =>
-      dispatch({ type: 'RECEIVE_SCHEMA_FLAT', data: buildClientSchema(data) })
+      dispatch({ type: 'RECEIVE_GUPPY_SCHEMA', data: buildClientSchema(data) })
     );
 
 export const fetchDictionary = (dispatch) =>


### PR DESCRIPTION
Ticket: [PEDS-499](https://pcdc.atlassian.net/browse/PEDS-499)

This PR lets the app to cache the GraphQL schema object for the "flat model", i.e. guppy backend. Prior to this, the app didn't pass `schema` prop to `<GraphiQL>` component, causing the component to repeatedly fetch the schema on (re)mount. Since schema rarely changes, it is reasonable to cache and reuse it.

This PR also removes the conditional inclusion of "flat model" option in `<GqlEditor>` based the PCDC portal use case that always includes the data explorer with guppy backend.