### PR TITLE
Stop session update on graphql query PEDS-500

### DIFF
--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import GraphiQL from 'graphiql';
-
 import PropTypes from 'prop-types';
 import Button from '../gen3-ui-component/components/Button';
 import Spinner from '../components/Spinner';
 import { headers, graphqlPath, guppyGraphQLUrl } from '../localconf';
-import sessionMonitor from '../SessionMonitor';
 import './GqlEditor.less';
 import 'graphiql/graphiql.css';
 
@@ -13,42 +11,37 @@ const parameters = {};
 const defaultValue = 0;
 
 const fetchGraphQL = (graphQLParams) =>
-  // We first update the session so that the user will be notified
-  // if their auth is insufficient to perform the query.
-  sessionMonitor.updateSession().then(() =>
-    fetch(graphqlPath, {
-      credentials: 'include',
-      headers: { ...headers },
-      method: 'POST',
-      body: JSON.stringify(graphQLParams),
-    })
-      .then((response) => response.text())
-      .then((responseBody) => {
-        try {
-          return JSON.parse(responseBody);
-        } catch (error) {
-          return responseBody;
-        }
-      })
-  );
+  fetch(graphqlPath, {
+    credentials: 'include',
+    headers: { ...headers },
+    method: 'POST',
+    body: JSON.stringify(graphQLParams),
+  })
+    .then((response) => response.text())
+    .then((responseBody) => {
+      try {
+        return JSON.parse(responseBody);
+      } catch (error) {
+        return responseBody;
+      }
+    });
 
 const fetchFlatGraphQL = (graphQLParams) =>
-  sessionMonitor.updateSession().then(() =>
-    fetch(guppyGraphQLUrl, {
-      credentials: 'include',
-      headers: { ...headers },
-      method: 'POST',
-      body: JSON.stringify(graphQLParams),
-    })
-      .then((response) => response.text())
-      .then((responseBody) => {
-        try {
-          return JSON.parse(responseBody);
-        } catch (error) {
-          return responseBody;
-        }
-      })
-  );
+  fetch(guppyGraphQLUrl, {
+    credentials: 'include',
+    headers: { ...headers },
+    method: 'POST',
+    body: JSON.stringify(graphQLParams),
+  })
+    .then((response) => response.text())
+    .then((responseBody) => {
+      try {
+        return JSON.parse(responseBody);
+      } catch (error) {
+        return responseBody;
+      }
+    });
+
 class GqlEditor extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Ticket: [PEDS-500](https://pcdc.atlassian.net/browse/PEDS-500)

This PR removes session update (i.e. calling `sessonMonitor.updateSession()`) before sending each GraphQL query on /query page. Despite the stated rationale for session update to check for user auth, the update seems redundant for the following reasons:

1. /user/user data is already made available before user visits /query page because the route is under `<ProtectedContent>` and is not public
2. Simply re-fetching /user/user data does not update the auth information
3. If the purpose is to keep the token alive by calling /user/user, this is already achieved by the normal `sessionMonitor` interval