### PR TITLE
Fix infinite update from options prop PEDS-505

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -57,6 +57,8 @@ function getNumValuesSelected(filterStatus) {
  * @property {number} resetClickCounter
  */
 
+const defaultOptions = [];
+
 /** @param {FilterSectionProps} props */
 function FilterSection({
   disabledTooltipMessage = '',
@@ -73,7 +75,7 @@ function FilterSection({
   onSelect,
   onToggle = () => {},
   onToggleCombineMode = () => {},
-  options = [],
+  options = defaultOptions,
   tierAccessLimit,
   title = '',
   tooltip,


### PR DESCRIPTION
Ticket: [PEDS-505](https://pcdc.atlassian.net/browse/PEDS-505)

This PR fixes the infinite update loop bug for `<FilterSection>` component when using default `options` prop value. The bug was first introduced by https://github.com/chicagopcdc/data-portal/commit/53d6ee5dffbb8b4a5513460151c467c1568e9473 and doesn't affect the current use PCDC case without any search filter. 

Please refer to the ticket description for more details.

