### PR TITLE
Fix infinite update from initialAppliedFilters prop PEDS-506

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -29,12 +29,14 @@ import '../typedef';
  * @property {JSX.Element[]} tabs
  */
 
+const defaultInitialAppliedFilters = {};
+
 /** @param {FilterGroupProps} props */
 function FilterGroup({
   className = '',
   filterConfig,
   hideZero = true,
-  initialAppliedFilters = {},
+  initialAppliedFilters = defaultInitialAppliedFilters,
   onAnchorValueChange = () => {},
   onFilterChange = () => {},
   onPatientIdsChange,


### PR DESCRIPTION
Ticket: [PEDS-506](https://pcdc.atlassian.net/browse/PEDS-506)

This PR fixes the infinite update loop bug for `<FilterGroup>` component when using default `initialAppliedFilters` prop value (similar to #216). The bug was first introduced by https://github.com/chicagopcdc/data-portal/commit/60308c2c593b2bf8f1f0ddd8694f847eaac2aabb and doesn't affect the current PCDC use case that does not rely on the default `initialAppliedFilters` value. 

Please refer to the ticket description for more details.

