### PR TITLE
Fix node popup unclickable close button PEDS-518

### DIFF
--- a/src/DataDictionary/graph/NodePopup/NodePopup.css
+++ b/src/DataDictionary/graph/NodePopup/NodePopup.css
@@ -60,6 +60,7 @@
   right: 10px;
   top: 10px;
   cursor: pointer;
+  z-index: 1;
 }
 
 .node-popup__close-icon {


### PR DESCRIPTION
Ticket: [PEDS-518](https://pcdc.atlassian.net/browse/PEDS-518)

This PR fixes the unclickable close button of the popup in dictionary page graph view. See image below:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/22449454/134544675-9d81e93f-a7d9-4b43-8fea-06953c695b52.png">

This bug was introduced by commit https://github.com/chicagopcdc/data-portal/commit/b98f9aad0dcfe0b16f6a2de5a0a430489777163c, which was part of PR https://github.com/chicagopcdc/data-portal/pull/163. By re-ordering elements in the popup, the commit made the close button sit below other elements, rendering it not clickable.

The fix simply increases `z-index` for the close button element.