### PR TITLE
Fix /DD page crash when dictionary is not loaded yet PEDS-510

### DIFF
--- a/src/DataDictionary/utils.js
+++ b/src/DataDictionary/utils.js
@@ -161,14 +161,13 @@ export const graphStyleConfig = {
   nodeIconRadius: 10,
 };
 
-export const parseDictionaryNodes = (dictionary) =>
-  Object.keys(dictionary)
-    .filter((id) => id.charAt(0) !== '_' && id === dictionary[id].id)
-    .map((id) => {
-      const originNode = dictionary[id];
-      return originNode;
-    })
-    .filter((node) => node.category && node.id);
+export const parseDictionaryNodes = (dictionary = {}) => {
+  const nodes = [];
+  for (const [id, node] of Object.entries(dictionary))
+    if (!id.startsWith('_') && id === node.id && node.category !== undefined)
+      nodes.push(node);
+  return nodes;
+};
 
 export const getPropertyDescription = (property) => {
   let description;

--- a/src/DataDictionary/utils.test.js
+++ b/src/DataDictionary/utils.test.js
@@ -5,6 +5,7 @@ import {
   getSearchHistoryItems,
   addSearchHistoryItems,
   clearSearchHistoryItems,
+  parseDictionaryNodes,
 } from './utils';
 
 describe('the DataDictionaryNode', () => {
@@ -107,5 +108,39 @@ describe('the DataDictionaryNode', () => {
     const ls3 = addSearchHistoryItems(item2);
     expect(ls3).toEqual([item2, item1]);
     expect(clearSearchHistoryItems()).toEqual([]);
+  });
+});
+
+describe('The data dictionary', () => {
+  it('is parsed to get relevant nodes only', () => {
+    const emptyDictionary = undefined;
+    const emptyNodes = [];
+    expect(parseDictionaryNodes(emptyDictionary)).toEqual(emptyNodes);
+
+    const dictionary = {
+      // invalid key, invalid node
+      _v: {},
+      // invalid key, valid node
+      _w: {
+        id: '_w',
+        category: 'foo',
+      },
+      // valid key, invalid node (unmatching id)
+      x: {
+        id: '',
+        category: 'foo',
+      },
+      // valid key, valid node
+      y: {
+        id: 'y',
+        category: 'foo',
+      },
+      // valid key, invalid node (missing category)
+      z: {
+        id: 'z',
+      },
+    };
+    const parsedNodes = [{ id: 'y', category: 'foo' }];
+    expect(parseDictionaryNodes(dictionary)).toEqual(parsedNodes);
   });
 });


### PR DESCRIPTION
Ticket: [PEDS-510](https://pcdc.atlassian.net/browse/PEDS-510)

This PR fixes the app crashing when navigating directly to `/DD` for the first time (i.e. no cached data). This is seemingly caused by the invocation of`parseDictionaryNodes()` before the app finishes lazily/dynamically loading `dictionary.json` (https://github.com/chicagopcdc/data-portal/pull/211) and makes it available as the function's input.

The PR sets an empty object `{}` as the default parameter value to avoid the crash. The PR also optimizes and creates tests for `parseDictionaryNodes()`.