### PR TITLE
Fix /:project page crash when dictionary is not loaded yet PEDS-523

### DIFF
--- a/src/DataModelGraph/ReduxDataModelGraph.js
+++ b/src/DataModelGraph/ReduxDataModelGraph.js
@@ -11,11 +11,11 @@ import { submissionApiPath } from '../localconf';
  * @method getCounts
  * @param {Array<string>} typeList
  * @param {string} project
- * @param {Object} dictionary
- * @return {Function(dispatch => updates-redux-state)} async dispatch function
- *     that fetches data from backend and updates redux when dispatched
+ * @param {Object} [dictionary]
+ * @return {import('redux-thunk').ThunkAction<Promise, any, any, any>}
+ * async thunk action that fetches data from backend and updates redux when dispatched
  */
-export const getCounts = (typeList, project, dictionary) => {
+export const getCounts = (typeList, project, dictionary = {}) => {
   let query = '{';
 
   function appendCountToQuery(element) {

--- a/src/Submission/ReduxMapFiles.js
+++ b/src/Submission/ReduxMapFiles.js
@@ -15,7 +15,7 @@ const fetchUnmappedFiles = (user, total, start, fetchLimit) => (dispatch) => {
         switch (status) {
           case 200:
             total = total.concat(data.records);
-            if (data.records.length === fetchLimit) {
+            if (data.records?.length === fetchLimit) {
               return dispatch(
                 fetchUnmappedFiles(
                   user,

--- a/src/Submission/ReduxSubmissionHeader.js
+++ b/src/Submission/ReduxSubmissionHeader.js
@@ -17,7 +17,7 @@ const fetchUnmappedFileStats = (username, totalSize, start, fetchLimit) => (
         switch (status) {
           case 200:
             totalSize = totalSize.concat(data.records);
-            if (data.records.length === fetchLimit) {
+            if (data.records?.length === fetchLimit) {
               return dispatch(
                 fetchUnmappedFileStats(
                   username,


### PR DESCRIPTION
Ticket: [PEDS-523](https://pcdc.atlassian.net/browse/PEDS-523)

This PR fixes the app crashing when navigating directly to `/:project` for the first time (i.e. no cached data). This is from the same cause that led to https://github.com/chicagopcdc/data-portal/pull/224.

The PR sets an empty object `{}` as the default parameter value for `getCount()` to avoid the crash. The PR also fixes minor bugs found in certain submission related pages caused by no records data.