### PR TITLE
Display data release version on footer PEDS-524

### DIFF
--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -124,3 +124,16 @@
 .footer__link:last-child:after {
   content: '';
 }
+
+.footer__data-release-version-area {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-self: center;
+  justify-content: center;
+  margin: 1rem;
+}
+
+.footer__data-release-version-area--title {
+  font-style: italic;
+  margin-right: 0.25rem;
+}

--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -19,17 +19,6 @@
   }
 }
 
-.footer__spacer-area {
-  display: flex;
-  flex-basis: 50%;
-}
-
-@media screen and (max-width: 1090px) {
-  .footer__spacer-area {
-    display: none;
-  }
-}
-
 .footer__privacy-policy-area {
   display: flex;
   flex-basis: 20%;

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -12,6 +12,14 @@ function Footer({ links, logos, privacyPolicy }) {
   return (
     <footer>
       <nav className='footer__nav' aria-label='Footer Navigation'>
+        {process.env.DATA_RELEASE_VERSION && (
+          <div className='footer__data-release-version-area'>
+            <span className='footer__data-release-version-area--title'>
+              Data Release Version:
+            </span>
+            {process.env.DATA_RELEASE_VERSION}
+          </div>
+        )}
         <div className='footer__spacer-area' />
         {privacyPolicy?.text && (
           <div className='footer__privacy-policy-area'>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -20,7 +20,6 @@ function Footer({ links, logos, privacyPolicy }) {
             {process.env.DATA_RELEASE_VERSION}
           </div>
         )}
-        <div className='footer__spacer-area' />
         {privacyPolicy?.text && (
           <div className='footer__privacy-policy-area'>
             <a

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ const plugins = [
   new webpack.DefinePlugin({
     // <-- key to reducing React's size
     'process.env': {
-      NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'dev'),
+      // NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'dev'),
+      DATA_RELEASE_VERSION: JSON.stringify(process.env.DATA_RELEASE_VERSION),
       LOGOUT_INACTIVE_USERS: !(process.env.LOGOUT_INACTIVE_USERS === 'false'),
       WORKSPACE_TIMEOUT_IN_MINUTES:
         process.env.WORKSPACE_TIMEOUT_IN_MINUTES || 480,


### PR DESCRIPTION
Ticket: [PEDS-524](https://pcdc.atlassian.net/browse/PEDS-524)

This PR adds data release version information to `<Footer>`. The version value is provided via a newly created environment variable `DATA_RELEASE_VERSION`. See below for an example:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/136447110-9d9dab95-cdc8-46c8-b467-036536cd6db1.png">

This PR also removes the "spacer area" in footer, a filler element that is no longer relevant.