### PR TITLE
Stop scrolling to top on Explorer filter change PEDS-525

### DIFF
--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -151,11 +151,14 @@ class GuppyDataExplorer extends React.Component {
     }
 
     if (!this._isBrowserNavigation)
-      this.props.history.push({
-        search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
-          '&'
-        ),
-      });
+      this.props.history.push(
+        {
+          search: Array.from(searchParams.entries(), (e) => e.join('=')).join(
+            '&'
+          ),
+        },
+        { scrollY: window.scrollY }
+      );
   };
 
   handlePatientIdsChange = this.props.patientIdsConfig?.filter

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -154,7 +154,7 @@ function ProtectedContent({
   }
   useEffect(() => {
     isMounted.current = true;
-    window.scrollTo(0, 0);
+    window.scrollTo(0, location.state?.scrollY ?? 0);
 
     if (isMounted.current)
       getReduxStore().then((store) =>


### PR DESCRIPTION
Ticket: [PEDS-525](https://pcdc.atlassian.net/browse/PEDS-525)

This PR fixes the unwanted scroll-to-top on the Explorer page filter change, which is detrimental to UX. This was triggered by a `useEffect()` hook in `<ProtectedContent>` component, which is triggered by `location` change (https://github.com/chicagopcdc/data-portal/commit/8f822ce022d22074631947a74b5ac1dea642c3ab) and calls `window.scrollTo(0, 0)`. Since each filter change updates `location.search` to encode a change filter state information as URL search param (`?filter`), the `useEffect()` hook was triggered.

The fix passes the `window.scrollY` to `location.state` and uses it when invoking `window.scrollTo()` inside the hook. I.e. if the `location` update was initiated by filter change, scroll position won't be updated. 