### PR TITLE
Fix unresponsive filter search input PEDS-527

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -155,7 +155,8 @@ function FilterSection({
       ...prevState,
       isSearchInputEmpty: !currentInput || currentInput.length === 0,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        prevState.isShowingMoreOptions
+        prevState.isShowingMoreOptions,
+        currentInput
       ),
     }));
   }


### PR DESCRIPTION
Ticket: [PEDS-527](https://pcdc.atlassian.net/browse/PEDS-527)

This PR fixes the bug where filter section search input is unresponsive, as shown below:

<image src="https://user-images.githubusercontent.com/22449454/136467069-16cd6fef-122d-48e5-aa46-dffb5a14665a.png" width=360 />

This bug was introduced by erroneous refactoring of `<FilterSection>` (https://github.com/chicagopcdc/data-portal/commit/53d6ee5dffbb8b4a5513460151c467c1568e9473) in https://github.com/chicagopcdc/data-portal/pull/197, which missed passing the current input search value to `getOptionsVisibleStatus()` helper function.
