### PR TITLE
Fix CSP violation from Google Analytics PEDS-535

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://localhost:9443; frame-src 'self';"
+      content="default-src 'self' blob:; connect-src 'self' blob: localhost https://localhost:9443 wss://localhost:9443 https://*.s3.amazonaws.com https://www.google-analytics.com; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com https://ssl.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://localhost:9443; frame-src 'self';"
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/png" href="/src/img/favicon.ico" />

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; font-src 'self' data:; connect-src 'self' https://login.bionimbus.org  https://*.s3.amazonaws.com https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';;"
+      content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' https://www.google-analytics.com https://ssl.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; object-src 'none'; font-src 'self' data:; connect-src 'self' https://login.bionimbus.org https://*.s3.amazonaws.com https://wayf.incommonfederation.org https://www.google-analytics.com <%= htmlWebpackPlugin.options.connect_src %>; frame-src <%= htmlWebpackPlugin.options.connect_src %> 'self';"
     />
     <meta name="viewport" content="width=device-width" />
     <link


### PR DESCRIPTION
Ticket: [PEDS-535](https://pcdc.atlassian.net/browse/PEDS-535)

This PR fixes the following CSP violation error caused by Google Analytics script:
<image src="https://user-images.githubusercontent.com/22449454/137358949-c096e88b-8dd6-4924-aadf-8deb62f380cc.png" alt="image" width="720" />

The PR adds [all required directives](https://developers.google.com/tag-manager/web/csp?hl=en) to the CSP content for both main index page (generated from `src/index.ejs`) as well as the dev page (`dev.html`).