### PR TITLE
Disable React DevTools in production PEDS-533

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,10 @@ const plugins = [
         process.env.REACT_APP_DISABLE_SOCKET || 'true'
       ),
     },
+    // disable React DevTools in production; see https://github.com/facebook/react/pull/11448
+    ...(process.env.NODE_ENV === 'production'
+      ? { __REACT_DEVTOOLS_GLOBAL_HOOK__: '({ isDisabled: true })' }
+      : {}),
   }),
   new HtmlWebpackPlugin({
     title: process.env.TITLE || 'PCDC Data Portal',


### PR DESCRIPTION
Ticket: [PEDS-533](https://pcdc.atlassian.net/browse/PEDS-533)

This PR disables [React Developer Tools](https://github.com/facebook/react/tree/main/packages/react-devtools#react-devtools) for production bundle to deter users from probing/manipulating application state.