### PR TITLE
Fix broken redirect to public pages PEDS-536

### DIFF
--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -150,7 +150,9 @@ function ProtectedContent({
   const isMounted = useRef(false);
   /** @param {ProtectedContentState} currentState */
   function updateState(currentState) {
-    if (isMounted.current) setState({ ...currentState, dataLoaded: true });
+    const newState = { ...currentState, dataLoaded: true };
+    if (isPublic) newState.redirectTo = null;
+    if (isMounted.current) setState(newState);
   }
   useEffect(() => {
     isMounted.current = true;


### PR DESCRIPTION
Ticket: PEDS-536

This PR is a patch to `master` and fixes a bug that causes any redirect to public pages to fail to render `children` as intended.

This was due to uncleared `state.redirectTo` component state in `<ProtectedContent>` when `isPublic` prop is set to `true`. This behavior was harmless previously because switching routes always led to re-mount `<ProtectedContent>` component and thereby reset the component state with `state.redirectedTo` set to `null`. However, an effort to simplify routing code by removing an arrow function that wraps the actual page component (e.g. https://github.com/chicagopcdc/data-portal/commit/d44b051d44fb685aa080edee22311518863bd31c) changed this, letting React to keep the mounted `<ProtectedContent>` on switching routes. This PR addresses this problem by ensuring that `state.redirectTo` value is reset to `null` for public pages.