### PR TITLE
Fix no option filter section PEDS-541

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
+++ b/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
@@ -275,3 +275,9 @@
 .g3-select-filter {
   margin-top: 14px;
 }
+
+.g3-filter-section__no-option {
+  font-style: italic;
+  margin-left: 14px;
+  margin-top: 14px;
+}

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -566,13 +566,16 @@ function FilterSection({
       {isTextFilter && renderSearchInput()}
       {isArrayField && renderCombineOptionButton()}
       {isSearchFilter && renderSearchFilter()}
-      {state.isExpanded && (
-        <div className='g3-filter-section__options'>
-          {(isTextFilter || isSearchFilter) && renderTextFilter(filterStatus)}
-          {isRangeFilter && renderRangeFilter(filterStatus)}
-          {isTextFilter && state.isSearchInputEmpty && renderShowMoreButton()}
-        </div>
-      )}
+      {state.isExpanded &&
+        (options.length > 0 ? (
+          <div className='g3-filter-section__options'>
+            {(isTextFilter || isSearchFilter) && renderTextFilter(filterStatus)}
+            {isRangeFilter && renderRangeFilter(filterStatus)}
+            {isTextFilter && state.isSearchInputEmpty && renderShowMoreButton()}
+          </div>
+        ) : (
+          <div className='g3-filter-section__no-option'>No data</div>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
Ticket: [PEDS-541](https://pcdc.atlassian.net/browse/PEDS-541)

This PR fixes the UX bug where empty filter sections betray user expectations on expand/collapse toggle by displaying "No data" in them if no option is available.