### PR TITLE
Fix filter section options visibility getting reset on select PEDS-540

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -109,17 +109,18 @@ function FilterSection({
     // used for rerendering child components when reset button is clicked
     resetClickCounter: 0,
   });
+
+  /** @type {React.MutableRefObject<HTMLInputElement>} */
+  const inputElem = useRef();
   useEffect(() => {
     setState((prevState) => ({
       ...prevState,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        prevState.isShowingMoreOptions
+        prevState.isShowingMoreOptions,
+        inputElem.current?.value
       ),
     }));
   }, [options]);
-
-  /** @type {React.MutableRefObject<HTMLInputElement>} */
-  const inputElem = useRef();
 
   function clearSearchInput() {
     inputElem.current.value = '';


### PR DESCRIPTION
Ticket: [PEDS-540](https://pcdc.atlassian.net/browse/PEDS-540)

This PR fixes a bug where the filter section options visibility is reset to default (first 5) when user selects one of the search results. This is caused by updating options visibility on options update (from selecting filter option) without using the current search input text.