### PR TITLE
Enable adding tooltip to anchor filter via config PEDS-543

### DIFF
--- a/docs/anchored_filters.md
+++ b/docs/anchored_filters.md
@@ -15,7 +15,8 @@ The use of anchored filters can be specified using a portal configuration option
       "anchor": {
         "field": "",
         "options": [""],
-        "tabs": [""]
+        "tabs": [""],
+        "tooltip": "" // optional
       },
       "tabs": [
         // ...
@@ -28,6 +29,7 @@ The use of anchored filters can be specified using a portal configuration option
 - `"field"` is the name of the field to use as anchor. It must be a common attribute to all nested field filters to be used as anchored filters. Additionally, the anchor must be an _option_ (as opposed to _range_) type filter
 - `"options"` is an array of values for the anchor field to be used for anchored filters.
 - `"tabs"` is an array of tab titles where the tabs will contain nested field filters to be used as anchored filters.
+- `"tooltip"` is the text to display on hover in a tooltip element. This is optional.
 
 ## UI
 

--- a/src/GuppyComponents/typedef.js
+++ b/src/GuppyComponents/typedef.js
@@ -74,6 +74,7 @@
  * @property {string} field
  * @property {string[]} options
  * @property {string[]} tabs
+ * @property {string} [tooltip]
  */
 
 /**

--- a/src/gen3-ui-component/components/filters/AnchorFilter.jsx
+++ b/src/gen3-ui-component/components/filters/AnchorFilter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { capitalizeFirstLetter } from '../../../utils';
 
@@ -12,6 +13,7 @@ import { capitalizeFirstLetter } from '../../../utils';
  * @property {(anchor: string) => void} onChange
  * @property {string[]} options
  * @property {string[]} [optionsInUse]
+ * @property {string} [tooltip]
  */
 
 /** @param {AnchorFilterProps} props */
@@ -23,7 +25,25 @@ function AnchorFilter({
   onChange,
   options,
   optionsInUse,
+  tooltip,
 }) {
+  const sectionTitle = (
+    <div style={{ display: 'flex' }}>
+      <span className='g3-filter-section__toggle-icon-container'>
+        <FontAwesomeIcon icon='anchor' />
+      </span>
+      <span
+        className={`g3-filter-section__title${
+          defaultOptionValue !== anchorValue
+            ? ' g3-filter-section__title--active'
+            : ''
+        }`}
+      >
+        {capitalizeFirstLetter(anchorField)}
+      </span>
+    </div>
+  );
+
   return (
     <div
       className='g3-filter-section'
@@ -42,18 +62,19 @@ function AnchorFilter({
           tabIndex={0}
           aria-label='Filter: patient ids'
         >
-          <span className='g3-filter-section__toggle-icon-container'>
-            <FontAwesomeIcon icon='anchor' />
-          </span>
-          <span
-            className={`g3-filter-section__title${
-              defaultOptionValue !== anchorValue
-                ? ' g3-filter-section__title--active'
-                : ''
-            }`}
-          >
-            {capitalizeFirstLetter(anchorField)}
-          </span>
+          {tooltip ? (
+            <Tooltip
+              arrowContent={<div className='rc-tooltip-arrow-inner' />}
+              mouseLeaveDelay={0}
+              overlay={tooltip}
+              placement='topLeft'
+              trigger={['hover', 'focus']}
+            >
+              {sectionTitle}
+            </Tooltip>
+          ) : (
+            sectionTitle
+          )}
         </div>
       </div>
       {[defaultOptionValue, ...options].map((option) => (
@@ -89,6 +110,7 @@ AnchorFilter.propTypes = {
   onChange: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   optionsInUse: PropTypes.arrayOf(PropTypes.string),
+  tooltip: PropTypes.string,
 };
 
 export default AnchorFilter;

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -267,6 +267,7 @@ function FilterGroup({
             onChange={handleAnchorValueChange}
             options={filterConfig.anchor.options}
             optionsInUse={selectedAnchors[tabIndex]}
+            tooltip={filterConfig.anchor.tooltip}
           />
         )}
         {showPatientIdsFilter && (
@@ -314,6 +315,7 @@ FilterGroup.propTypes = {
       field: PropTypes.string,
       options: PropTypes.arrayOf(PropTypes.string),
       tabs: PropTypes.arrayOf(PropTypes.string),
+      tooltip: PropTypes.string,
     }),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/stories/gen3-ui-component/filters.jsx
+++ b/src/stories/gen3-ui-component/filters.jsx
@@ -317,6 +317,7 @@ storiesOf('Filters', module)
           options={['Initial Diagnosis', 'Relapse']}
           optionsInUse={['Initial Diagnosis']}
           onChange={handleChange}
+          tooltip='Foobar'
         />
       </div>
     );


### PR DESCRIPTION
Ticket: [PEDS-543](https://pcdc.atlassian.net/browse/PEDS-543)

This PR implements displaying tooltip text for the anchor filter. The tooltip text can be provided via config (`dataExplorerConfig.filters.anchor.tooltip`) and if provided, the tooltip element would be displayed on hover over anchor filter title. See image:

<image alt="image" src="https://user-images.githubusercontent.com/22449454/138359046-e2db89ec-4ef2-46f8-85ca-92169533d408.png" width="400" />
