### PR TITLE
Fix failing explorer config update on browser navigation PEDS-583

### DIFF
--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -47,6 +47,17 @@ export function ExplorerConfigProvider({ children }) {
     setExporerId(id);
     history.push({ search: `id=${id}` });
   }
+  useEffect(() => {
+    function handleBrowserNavigationForConfig() {
+      const newSearchParam = new URLSearchParams(history.location.search);
+      const newSearchParamId = Number(newSearchParam.get('id'));
+      setExporerId(newSearchParamId);
+    }
+    window.addEventListener('popstate', handleBrowserNavigationForConfig);
+    return () => {
+      window.removeEventListener('popstate', handleBrowserNavigationForConfig);
+    };
+  }, []);
 
   const config = explorerConfig.find(({ id }) => id === explorerId);
 

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -16,6 +16,7 @@ import './typedef';
  * @property {AlteredExplorerConfig} current
  * @property {number} explorerId
  * @property {{ label: string; value: string }[]} explorerOptions
+ * @property {() => void} handleBrowserNavigationForConfig
  * @property {(id: number) => void} updateExplorerId
  */
 
@@ -57,17 +58,12 @@ export function ExplorerConfigProvider({ children }) {
     setExporerId(id);
     history.push({ search: `id=${id}` });
   }
-  useEffect(() => {
-    function handleBrowserNavigationForConfig() {
-      const searchParams = new URLSearchParams(history.location.search);
-      const searchParamId = Number(searchParams.get('id'));
-      setExporerId(searchParamId);
-    }
-    window.addEventListener('popstate', handleBrowserNavigationForConfig);
-    return () => {
-      window.removeEventListener('popstate', handleBrowserNavigationForConfig);
-    };
-  }, []);
+
+  function handleBrowserNavigationForConfig() {
+    const searchParams = new URLSearchParams(history.location.search);
+    const searchParamId = Number(searchParams.get('id'));
+    setExporerId(searchParamId);
+  }
 
   const config = explorerConfig.find(({ id }) => id === explorerId);
 
@@ -95,6 +91,7 @@ export function ExplorerConfigProvider({ children }) {
         },
         explorerId,
         explorerOptions,
+        handleBrowserNavigationForConfig,
         updateExplorerId,
       }}
     >

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -1,7 +1,6 @@
 import React, {
   createContext,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -16,6 +15,7 @@ import './typedef';
  * @typedef {Object} ExplorerStateContext
  * @property {FilterState} initialAppliedFilters
  * @property {string[]} patientIds
+ * @property {() => void} handleBrowserNavigationForState
  * @property {(filter: FilterState) => void} handleFilterChange
  * @property {(patientIds: string[]) => void} handlePatientIdsChange
  * @property {() => void} clearFilters
@@ -42,24 +42,17 @@ export function ExplorerStateProvider({ children }) {
   const [patientIds, setPatientIds] = useState(initialState.patientIds);
 
   const isBrowserNavigation = useRef(false);
-
-  useEffect(() => {
-    function handleBrowserNavigationForState() {
-      isBrowserNavigation.current = true;
-      const newState = extractExplorerStateFromURL(
-        new URLSearchParams(history.location.search),
-        filterConfig,
-        patientIdsConfig
-      );
-      setFilters(newState.initialAppliedFilters);
-      setPatientIds(newState.patientIds);
-      isBrowserNavigation.current = false;
-    }
-    window.addEventListener('popstate', handleBrowserNavigationForState);
-    return () => {
-      window.removeEventListener('popstate', handleBrowserNavigationForState);
-    };
-  }, []);
+  function handleBrowserNavigationForState() {
+    isBrowserNavigation.current = true;
+    const newState = extractExplorerStateFromURL(
+      new URLSearchParams(history.location.search),
+      filterConfig,
+      patientIdsConfig
+    );
+    setFilters(newState.initialAppliedFilters);
+    setPatientIds(newState.patientIds);
+    isBrowserNavigation.current = false;
+  }
 
   /** @param {FilterState} filter */
   function handleFilterChange(filter) {
@@ -116,6 +109,7 @@ export function ExplorerStateProvider({ children }) {
       value={{
         initialAppliedFilters: filters,
         patientIds,
+        handleBrowserNavigationForState,
         handleFilterChange,
         handlePatientIdsChange,
         clearFilters,

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -28,10 +29,14 @@ export function ExplorerStateProvider({ children }) {
   const history = useHistory();
   const { filterConfig, patientIdsConfig } = useExplorerConfig().current;
 
-  const initialState = extractExplorerStateFromURL(
-    new URLSearchParams(history.location.search),
-    filterConfig,
-    patientIdsConfig
+  const initialState = useMemo(
+    () =>
+      extractExplorerStateFromURL(
+        new URLSearchParams(history.location.search),
+        filterConfig,
+        patientIdsConfig
+      ),
+    []
   );
   const [filters, setFilters] = useState(initialState.initialAppliedFilters);
   const [patientIds, setPatientIds] = useState(initialState.patientIds);

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -39,7 +39,7 @@ export function ExplorerStateProvider({ children }) {
   const isBrowserNavigation = useRef(false);
 
   useEffect(() => {
-    window.onpopstate = () => {
+    function handleBrowserNavigationForState() {
       isBrowserNavigation.current = true;
       const newState = extractExplorerStateFromURL(
         new URLSearchParams(history.location.search),
@@ -49,9 +49,10 @@ export function ExplorerStateProvider({ children }) {
       setFilters(newState.initialAppliedFilters);
       setPatientIds(newState.patientIds);
       isBrowserNavigation.current = false;
-    };
+    }
+    window.addEventListener('popstate', handleBrowserNavigationForState);
     return () => {
-      window.onpopstate = () => {};
+      window.removeEventListener('popstate', handleBrowserNavigationForState);
     };
   }, []);
 

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { explorerConfig } from '../localconf';
@@ -26,7 +26,6 @@ const emptyAdminAppliedPreFilters = {};
 /** @param {{ dataVersion: string }} props */
 function ExplorerDashboard({ dataVersion }) {
   const {
-    explorerId,
     current: {
       adminAppliedPreFilters = emptyAdminAppliedPreFilters,
       chartConfig,
@@ -34,12 +33,23 @@ function ExplorerDashboard({ dataVersion }) {
       guppyConfig,
       tableConfig,
     },
+    explorerId,
+    handleBrowserNavigationForConfig,
   } = useExplorerConfig();
   const {
     initialAppliedFilters,
     patientIds,
+    handleBrowserNavigationForState,
     handleFilterChange,
   } = useExplorerState();
+  useEffect(() => {
+    window.addEventListener('popstate', handleBrowserNavigationForConfig);
+    window.addEventListener('popstate', handleBrowserNavigationForState);
+    return () => {
+      window.removeEventListener('popstate', handleBrowserNavigationForConfig);
+      window.removeEventListener('popstate', handleBrowserNavigationForState);
+    };
+  }, []);
 
   return (
     <GuppyWrapper


### PR DESCRIPTION
Ticket: [PEDS-583](https://pcdc.atlassian.net/browse/PEDS-583)

This PR fixes failing explorer config update on browser navigation (go back/go forward) that involves switching between different `?id` values.

The bug originated from missing `popstate` event listener in `ExplorerConfigContext`, which wraps the `explorerId` state. Due to this, using browser navigation does not produce intended effect for switching explorers, such as updating the explorer config as well as resetting explorer states (`initialAppliedFilters` & `patientIds`).

This PR also optimizes both explorer config and state contexts by `useMemo()`-ing respective initial state.