### PR TITLE
Display version info on all pages PEDS-564

### DIFF
--- a/src/DataDictionary/DataDictionary.css
+++ b/src/DataDictionary/DataDictionary.css
@@ -81,6 +81,10 @@
   .data-dictionary__searcher {
     display: hidden;
   }
+
+  .data-dictionary__version-info-area {
+    display: none;
+  }
 }
 
 /* Tablet width and less */

--- a/src/DataDictionary/DataDictionary.css
+++ b/src/DataDictionary/DataDictionary.css
@@ -3,6 +3,12 @@
   --data-dictionary__switch-border-color: var(--g3-color__black);
 }
 
+.data-dictionary__sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 .data-dictionary__graph {
   overflow: hidden;
   height: 100%;
@@ -54,6 +60,16 @@
 .data-dictionary__switch-button--active {
   background-color: var(--pcdc-color__primary);
   color: var(--g3-color__white);
+}
+
+.data-dictionary__version-info-area {
+  margin: 0 auto;
+  padding: 3rem 0 2rem;
+  width: fit-content;
+}
+
+.data-dictionary__version-info > span {
+  font-style: italic;
 }
 
 /* Medium screen and less */

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -85,12 +85,12 @@ class DataDictionary extends React.Component {
             <div className='data-dictionary__version-info-list'>
               {this.props.dataVersion !== '' && (
                 <div className='data-dictionary__version-info'>
-                  <span>Data release version:</span> {this.props.dataVersion}
+                  <span>Data Release Version:</span> {this.props.dataVersion}
                 </div>
               )}
               {this.props.portalVersion !== '' && (
                 <div className='data-dictionary__version-info'>
-                  <span>Portal version:</span> {this.props.portalVersion}
+                  <span>Portal Version:</span> {this.props.portalVersion}
                 </div>
               )}
             </div>

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -29,56 +29,72 @@ class DataDictionary extends React.Component {
   render() {
     return (
       <Dashboard>
-        <Dashboard.Sidebar>
-          <div className='data-dictionary__switch'>
-            <span
-              className={`data-dictionary__switch-button ${
-                !this.props.isGraphView
-                  ? ''
-                  : 'data-dictionary__switch-button--active'
-              }`}
-              onClick={() => {
-                this.setGraphView(true);
-              }}
-              onKeyPress={(e) => {
-                if (e.charCode === 13 || e.charCode === 32) {
-                  e.preventDefault();
+        <Dashboard.Sidebar className='data-dictionary__sidebar'>
+          <div>
+            <div className='data-dictionary__switch'>
+              <span
+                className={`data-dictionary__switch-button ${
+                  !this.props.isGraphView
+                    ? ''
+                    : 'data-dictionary__switch-button--active'
+                }`}
+                onClick={() => {
                   this.setGraphView(true);
-                }
-              }}
-              role='button'
-              tabIndex={0}
-              aria-label='Graph view'
-            >
-              Graph View
-            </span>
-            <span
-              className={`data-dictionary__switch-button ${
-                this.props.isGraphView
-                  ? ''
-                  : 'data-dictionary__switch-button--active'
-              }`}
-              onClick={() => {
-                this.setGraphView(false);
-              }}
-              onKeyPress={(e) => {
-                if (e.charCode === 13 || e.charCode === 32) {
-                  e.preventDefault();
+                }}
+                onKeyPress={(e) => {
+                  if (e.charCode === 13 || e.charCode === 32) {
+                    e.preventDefault();
+                    this.setGraphView(true);
+                  }
+                }}
+                role='button'
+                tabIndex={0}
+                aria-label='Graph view'
+              >
+                Graph View
+              </span>
+              <span
+                className={`data-dictionary__switch-button ${
+                  this.props.isGraphView
+                    ? ''
+                    : 'data-dictionary__switch-button--active'
+                }`}
+                onClick={() => {
                   this.setGraphView(false);
-                }
-              }}
-              role='button'
-              tabIndex={0}
-              aria-label='Dictionary view'
-            >
-              Table View
-            </span>
+                }}
+                onKeyPress={(e) => {
+                  if (e.charCode === 13 || e.charCode === 32) {
+                    e.preventDefault();
+                    this.setGraphView(false);
+                  }
+                }}
+                role='button'
+                tabIndex={0}
+                aria-label='Dictionary view'
+              >
+                Table View
+              </span>
+            </div>
+            <ReduxDictionarySearcher ref={this.dictionarySearcherRef} />
+            <ReduxDataModelStructure />
+            <ReduxDictionarySearchHistory
+              onClickSearchHistoryItem={this.handleClickSearchHistoryItem}
+            />
           </div>
-          <ReduxDictionarySearcher ref={this.dictionarySearcherRef} />
-          <ReduxDataModelStructure />
-          <ReduxDictionarySearchHistory
-            onClickSearchHistoryItem={this.handleClickSearchHistoryItem}
-          />
+          <div className='data-dictionary__version-info-area'>
+            <div className='data-dictionary__version-info-list'>
+              {this.props.dataVersion !== '' && (
+                <div className='data-dictionary__version-info'>
+                  <span>Data release version:</span> {this.props.dataVersion}
+                </div>
+              )}
+              {this.props.portalVersion !== '' && (
+                <div className='data-dictionary__version-info'>
+                  <span>Portal version:</span> {this.props.portalVersion}
+                </div>
+              )}
+            </div>
+          </div>
         </Dashboard.Sidebar>
         <Dashboard.Main className='data-dictionary__main'>
           {this.props.isGraphView ? (
@@ -107,8 +123,10 @@ class DataDictionary extends React.Component {
 }
 
 DataDictionary.propTypes = {
-  onSetGraphView: PropTypes.func,
+  dataVersion: PropTypes.string,
   isGraphView: PropTypes.bool,
+  onSetGraphView: PropTypes.func,
+  portalVersion: PropTypes.string,
 };
 
 DataDictionary.defaultProps = {

--- a/src/DataDictionary/index.jsx
+++ b/src/DataDictionary/index.jsx
@@ -5,6 +5,7 @@ import DataDictionary from './DataDictionary';
 const ReduxDataDictionary = (() => {
   const mapStateToProps = (state) => ({
     isGraphView: state.ddgraph.isGraphView,
+    ...state.versionInfo,
   });
 
   const mapDispatchToProps = (dispatch) => ({

--- a/src/GuppyDataExplorer/Explorer.css
+++ b/src/GuppyDataExplorer/Explorer.css
@@ -11,6 +11,12 @@
   padding: 1rem;
 }
 
+.explorer__sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 .explorer__top-banner {
   width: 100%;
   margin-bottom: 10px;
@@ -25,12 +31,13 @@
   padding: 1rem 1rem 2rem;
 }
 
-.explorer__data-release-version {
-  padding: 3rem 1rem 2rem;
-  text-align: center;
+.explorer__version-info-area {
+  margin: 0 auto;
+  padding: 3rem 0 2rem;
+  width: fit-content;
 }
 
-.explorer__data-release-version > span {
+.explorer__version-info > span {
   font-style: italic;
 }
 

--- a/src/GuppyDataExplorer/Explorer.css
+++ b/src/GuppyDataExplorer/Explorer.css
@@ -49,7 +49,7 @@
 
   .explorer__filter,
   .explorer__filter-set,
-  .explorer__data-release-version {
+  .explorer__version-info-area {
     display: none;
   }
 }

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -84,12 +84,12 @@ function ExplorerDashboard({ dataVersion, portalVersion }) {
             <div className='explorer__version-info-area'>
               {dataVersion !== '' && (
                 <div className='explorer__version-info'>
-                  <span>Data release version:</span> {dataVersion}
+                  <span>Data Release Version:</span> {dataVersion}
                 </div>
               )}
               {portalVersion !== '' && (
                 <div className='explorer__version-info'>
-                  <span>Portal version:</span> {portalVersion}
+                  <span>Portal Version:</span> {portalVersion}
                 </div>
               )}
             </div>

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -23,8 +23,8 @@ import './typedef';
 /** @type {{ [x:string]: OptionFilter }} */
 const emptyAdminAppliedPreFilters = {};
 
-/** @param {{ dataVersion: string }} props */
-function ExplorerDashboard({ dataVersion }) {
+/** @param {{ dataVersion?: string; portalVersion?: string }} props */
+function ExplorerDashboard({ dataVersion, portalVersion }) {
   const {
     current: {
       adminAppliedPreFilters = emptyAdminAppliedPreFilters,
@@ -66,21 +66,32 @@ function ExplorerDashboard({ dataVersion }) {
       {(data) => (
         <Dashboard>
           <Dashboard.Sidebar className='explorer__sidebar'>
-            <ExplorerSelect />
-            <ExplorerFilterSet
-              className='explorer__filter-set'
-              filter={data.filter}
-            />
-            <ExplorerFilter
-              className='explorer__filter'
-              filter={data.filter}
-              initialTabsOptions={data.initialTabsOptions}
-              onAnchorValueChange={data.onAnchorValueChange}
-              onFilterChange={data.onFilterChange}
-              tabsOptions={data.tabsOptions}
-            />
-            <div className='explorer__data-release-version'>
-              <span>Data release version:</span> {dataVersion}
+            <div>
+              <ExplorerSelect />
+              <ExplorerFilterSet
+                className='explorer__filter-set'
+                filter={data.filter}
+              />
+              <ExplorerFilter
+                className='explorer__filter'
+                filter={data.filter}
+                initialTabsOptions={data.initialTabsOptions}
+                onAnchorValueChange={data.onAnchorValueChange}
+                onFilterChange={data.onFilterChange}
+                tabsOptions={data.tabsOptions}
+              />
+            </div>
+            <div className='explorer__version-info-area'>
+              {dataVersion !== '' && (
+                <div className='explorer__version-info'>
+                  <span>Data release version:</span> {dataVersion}
+                </div>
+              )}
+              {portalVersion !== '' && (
+                <div className='explorer__version-info'>
+                  <span>Portal version:</span> {portalVersion}
+                </div>
+              )}
             </div>
           </Dashboard.Sidebar>
           <Dashboard.Main className='explorer__main'>
@@ -111,9 +122,10 @@ function ExplorerDashboard({ dataVersion }) {
 
 ExplorerDashboard.propTypes = {
   dataVersion: PropTypes.string,
+  portalVersion: PropTypes.string,
 };
 
-const mapStateToProps = ({ versionInfo: { dataVersion } }) => ({ dataVersion });
+const mapStateToProps = ({ versionInfo }) => versionInfo;
 const ReduxExplorerDashboard = connect(mapStateToProps)(ExplorerDashboard);
 
 export default function Explorer() {

--- a/src/Layout/ReduxFooter.js
+++ b/src/Layout/ReduxFooter.js
@@ -1,9 +1,6 @@
 import { connect } from 'react-redux';
 import Footer from '../components/layout/Footer';
 
-const mapStateToProps = (state) => ({
-  dataVersion: state.versionInfo.dataVersion,
-});
-
+const mapStateToProps = (state) => state.versionInfo;
 const ReduxFooter = connect(mapStateToProps)(Footer);
 export default ReduxFooter;

--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -125,15 +125,15 @@
   content: '';
 }
 
-.footer__data-release-version-area {
-  display: inline-flex;
-  flex-wrap: wrap;
+.footer__version-info-area {
   align-self: center;
-  justify-content: center;
   margin: 1rem;
 }
 
-.footer__data-release-version-area--title {
+.footer__version-info {
+  text-align: left;
+}
+
+.footer__version-info > span {
   font-style: italic;
-  margin-right: 0.25rem;
 }

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -7,20 +7,25 @@ import './Footer.css';
  * @param {string} [props.dataVersion]
  * @param {{ href: string; text: string; }[]} [props.links]
  * @param {{ alt: string; height: number; href: string; src: string; }[]} props.logos
+ * @param {string} [props.portalVersion]
  * @param {{ file?: string; footerHref: string; routeHref?: string; text: string }} [props.privacyPolicy]
  */
-function Footer({ dataVersion = '', links, logos, privacyPolicy }) {
+function Footer({ dataVersion, links, logos, portalVersion, privacyPolicy }) {
   return (
     <footer>
       <nav className='footer__nav' aria-label='Footer Navigation'>
-        {dataVersion !== '' && (
-          <div className='footer__data-release-version-area'>
-            <span className='footer__data-release-version-area--title'>
-              Data Release Version:
-            </span>
-            {dataVersion}
-          </div>
-        )}
+        <div className='footer__version-info-area'>
+          {dataVersion !== '' && (
+            <div className='footer__version-info'>
+              <span>Data Release Version:</span> {dataVersion}
+            </div>
+          )}
+          {portalVersion !== '' && (
+            <div className='footer__version-info'>
+              <span>Portal Version:</span> {portalVersion}
+            </div>
+          )}
+        </div>
         <div className='footer__spacer-area' />
         {privacyPolicy?.text && (
           <div className='footer__privacy-policy-area'>
@@ -86,6 +91,7 @@ Footer.propTypes = {
       src: PropTypes.string.isRequired,
     })
   ).isRequired,
+  portalVersion: PropTypes.string,
   privacyPolicy: PropTypes.exact({
     file: PropTypes.string,
     footerHref: PropTypes.string.isRequired,

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -13,7 +13,11 @@ const persistConfig = {
 const reducer = persistReducer(persistConfig, reducers);
 
 function getpreloadedState() {
-  const state = { user: {}, status: {} };
+  const state = {
+    user: {},
+    status: {},
+    versionInfo: { dataVersion: '', portalVersion: process.env.PORTAL_VERSION },
+  };
 
   if (process.env.NODE_ENV !== 'production' && mockStore) {
     state.user = { username: 'test', certificates_uploaded: requiredCerts };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const plugins = [
   new webpack.EnvironmentPlugin({
     MOCK_STORE: null,
     BASENAME: '/',
-    PORTAL_VERSION: JSON.stringify(portalVersion || ''),
+    PORTAL_VERSION: portalVersion || '',
   }),
   new webpack.DefinePlugin({
     // <-- key to reducing React's size

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const CompressionPlugin = require('compression-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const portalVersion = require('./package.json').version;
 
 const basename = process.env.BASENAME || '/';
 const pathPrefix = basename.endsWith('/')
@@ -13,6 +14,7 @@ const plugins = [
   new webpack.EnvironmentPlugin({
     MOCK_STORE: null,
     BASENAME: '/',
+    PORTAL_VERSION: JSON.stringify(portalVersion || ''),
   }),
   new webpack.DefinePlugin({
     // <-- key to reducing React's size


### PR DESCRIPTION
Ticket: [PEDS-564](https://pcdc.atlassian.net/browse/PEDS-564)

This PR displays both data release version and portal version on all pages.

On large screen, the version info is displayed on the left end of the footer or on the bottom of the sidebar. On smaller screen, the version info is hidden if using dashboard layout.

The portal version data is drawn from `/package.json`.