### PR TITLE
Scale watermark on survival plots PEDS-591

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -66,7 +66,7 @@
   background-image: url(../../img/logo.png);
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 100%;
+  background-size: contain;
 }
 
 .explorer-survival-analysis__risk-table {


### PR DESCRIPTION
Ticket: [PEDS-591](https://pcdc.atlassian.net/browse/PEDS-591)

This PR modifies the watermark size for each survival plot to address feedback on chopped logo image.

Before:
<image src="https://user-images.githubusercontent.com/22449454/140424046-e2afe8aa-8aba-46fe-b3cd-1f78f1628d0a.png" width="480" />

After: 
<image src="https://user-images.githubusercontent.com/22449454/140424076-0f66adca-95d0-4754-acc8-875bf93c11b8.png" width="480" />
