### PR TITLE
Fix overriden ?filter search param from explore more + @ PEDS-595

### DIFF
--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -50,7 +50,7 @@ export function ExplorerConfigProvider({ children }) {
   }, []);
   useEffect(() => {
     if (!hasValidInitialSearchParamId)
-      history.push({
+      history.replace({
         search:
           // @ts-ignore
           history.location.state.keepSearch === true

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -53,7 +53,7 @@ export function ExplorerConfigProvider({ children }) {
       history.replace({
         search:
           // @ts-ignore
-          history.location.state.keepSearch === true
+          history.location.state?.keepSearch === true
             ? `id=${initialExplorerId}&${history.location.search.slice(1)}`
             : `id=${initialExplorerId}`,
       });

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -17,6 +17,8 @@ import './typedef';
  * @property {number} explorerId
  * @property {{ label: string; value: string }[]} explorerOptions
  * @property {() => void} handleBrowserNavigationForConfig
+ * @property {boolean} shouldUpdateState
+ * @property {(v: boolean) => void} setShouldUpdateState
  * @property {(id: number) => void} updateExplorerId
  */
 
@@ -48,8 +50,9 @@ export function ExplorerConfigProvider({ children }) {
       hasSearchParamId && isSearchParamIdValid,
     ];
   }, []);
+  const [shouldUpdateState, setShouldUpdateState] = useState(false);
   useEffect(() => {
-    if (!hasValidInitialSearchParamId)
+    if (!hasValidInitialSearchParamId) {
       history.replace({
         search:
           // @ts-ignore
@@ -57,6 +60,8 @@ export function ExplorerConfigProvider({ children }) {
             ? `id=${initialExplorerId}&${history.location.search.slice(1)}`
             : `id=${initialExplorerId}`,
       });
+      setShouldUpdateState(true);
+    }
   }, []);
 
   const [explorerId, setExporerId] = useState(initialExplorerId);
@@ -98,6 +103,8 @@ export function ExplorerConfigProvider({ children }) {
         explorerId,
         explorerOptions,
         handleBrowserNavigationForConfig,
+        shouldUpdateState,
+        setShouldUpdateState,
         updateExplorerId,
       }}
     >

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -50,7 +50,13 @@ export function ExplorerConfigProvider({ children }) {
   }, []);
   useEffect(() => {
     if (!hasValidInitialSearchParamId)
-      history.push({ search: `id=${initialExplorerId}` });
+      history.push({
+        search:
+          // @ts-ignore
+          history.location.state.keepSearch === true
+            ? `id=${initialExplorerId}&${history.location.search.slice(1)}`
+            : `id=${initialExplorerId}`,
+      });
   }, []);
 
   const [explorerId, setExporerId] = useState(initialExplorerId);

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -1,6 +1,7 @@
 import React, {
   createContext,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -27,7 +28,11 @@ const ExplorerStateContext = createContext(null);
 
 export function ExplorerStateProvider({ children }) {
   const history = useHistory();
-  const { filterConfig, patientIdsConfig } = useExplorerConfig().current;
+  const {
+    current: { filterConfig, patientIdsConfig },
+    shouldUpdateState,
+    setShouldUpdateState,
+  } = useExplorerConfig();
 
   const initialState = useMemo(
     () =>
@@ -40,6 +45,18 @@ export function ExplorerStateProvider({ children }) {
   );
   const [filters, setFilters] = useState(initialState.initialAppliedFilters);
   const [patientIds, setPatientIds] = useState(initialState.patientIds);
+  useEffect(() => {
+    if (shouldUpdateState) {
+      const newState = extractExplorerStateFromURL(
+        new URLSearchParams(history.location.search),
+        filterConfig,
+        patientIdsConfig
+      );
+      setFilters(newState.initialAppliedFilters);
+      setPatientIds(newState.patientIds);
+      setShouldUpdateState(false);
+    }
+  }, [shouldUpdateState]);
 
   const isBrowserNavigation = useRef(false);
   function handleBrowserNavigationForState() {

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -40,7 +40,13 @@ function IndexOverview({ overviewCounts }) {
         label='Explore more'
         buttonType='primary'
         enabled={enabled}
-        onClick={() => history.push({ pathname: '/explorer', search })}
+        onClick={() =>
+          history.push({
+            pathname: '/explorer',
+            search,
+            state: { keepSearch: true },
+          })
+        }
       />
     );
   }


### PR DESCRIPTION
Ticket: [PEDS-595](https://pcdc.atlassian.net/browse/PEDS-595)

This PR fixes the issue where `?filter` search param in URL gets removed when navigating to the explorer page via "Explorer more" button on the index page. This is caused by the `history.push()` call in `useEffect()` hook in `<ExplorerConfigProvider>`, which is meant to fix invalid/missing `?id` search param value. The fix involves conditionally preserving search value when navigating to `/explorer` via `location.state.keepSearch`.

This PR also fixes another related issue where explorer state extracted from URL search params persists when used with the invalid `?id` value even after the invalid `?id` value is corrected. This is achieved by force-updating explorer state via `shouldUpdateState`.