### PR TITLE
Use standard NODE_ENV values only PEDS-529

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,39 +20,19 @@ The portal's `/dev.html` path loads javascript and most css
 from `localhost`. Test code under local development with this procedure:
 
 - `npm install`
-- launch the webpack dev server, and configure local code with the same configuration as the server to test against. For example - if we intend to test against qa.planx-pla.net, then:
+- launch the webpack dev server, and configure local code with the same configuration as the server to test against. For example - if we intend to test against the local Docker Compose stack running on localhost, then:
 
 ```
-HOSTNAME=qa.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
+HOSTNAME=localhost APP=pcdc ./runWebpack.sh
 ```
 
-, or for qa-brain:
-
-```
-HOSTNAME=qa-brain.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
-```
-
-> **NOTE:** To locally test Tiered Access features, you must include the additional environment variables `TIER_ACCESS_LEVEL` and `TIER_ACCESS_LIMIT`, with should have the same values as the server's "global.tier_access_level" and "global.tier_access_limit" properties in its [`manifest.json`](https://github.com/uc-cdis/cdis-manifest).
+> **NOTE:** To locally test Tiered Access features, you must include the additional environment variable `TIER_ACCESS_LIMIT`, which should have the same values as the server's "global.tier_access_limit" properties in its [`manifest.json`](https://github.com/uc-cdis/cdis-manifest).
 >
-> **Example**:`HOSTNAME=qa-brain.planx-pla.net TIER_ACCESS_LEVEL=regular TIER_ACCESS_LIMIT=50 NODE_ENV=auto bash ./runWebpack.sh`
+> **Example**:`HOSTNAME=localhost TIER_ACCESS_LIMIT=50 bash ./runWebpack.sh`
 
 - Accept the self-signed certificate at https://localhost:9443/bundle.js
 
-- Load the test environment's `/dev.html` - ex: https://qa-brian.planx-pla.net/dev.html
-
-### Local development and gitops
-
-Most production commons currently load custom configuration via gitops. The configuration for a production commons is available in that commons' gitops repository (mostly https://github.com/uc-cdis/cdis-manifest), and can be copied for local development. The `runWebpack.sh` script automates this process when `NODE_ENV` is set to `auto` - ex:
-
-```
-HOSTNAME=qa-brain.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
-```
-
-Note: the legacy `dev` NODE_ENV is still available, but the `APP` environment must also be manually set to load the configuration that matches the dictionary from HOSTNAME - ex:
-
-```
-HOSTNAME=qa.planx-pla.net NODE_ENV=dev APP=dev bash ./runWebpack.sh
-```
+- Load the test environment's `/dev.html` - ex: https://localhost/dev.html
 
 ### Component story books
 

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Runtime deployment helper.  Keys on environment variables:
-#  NODE_ENV = dev|production
+#  NODE_ENV = development|production
 #  APP = commons specific
 #  HOSTNAME = where to download graphql schema from
 #  LOGOUT_INACTIVE_USERS = bool, should inactive users be logged out before session lifetime ends
@@ -15,7 +15,7 @@
 set -e
 
 export APP="${APP:-dev}"
-export NODE_ENV="${NODE_ENV:-dev}"
+export NODE_ENV="${NODE_ENV:-development}"
 export HOSTNAME="${HOSTNAME:-"revproxy-service"}"
 export TIER_ACCESS_LEVEL="${TIER_ACCESS_LEVEL:-"private"}"
 export TIER_ACCESS_LIMIT="${TIER_ACCESS_LIMIT:-"1000"}"

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -127,11 +127,10 @@ export REACT_APP_DISABLE_SOCKET=true
 # finally either launch the webpack-dev-server or
 # run webpack to generate a static bundle.js
 #
-if [[ "$NODE_ENV" == "dev" || "$NODE_ENV" == "auto" ]]; then
-  echo npx webpack serve
-  npx webpack serve
-else
-  export NODE_ENV="production"
+if [[ "$NODE_ENV" == "production" ]]; then
   echo npx webpack
   npx webpack
+else
+  echo npx webpack serve
+  npx webpack serve
 fi

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Runtime deployment helper.  Keys on environment variables:
-#  NODE_ENV = auto|dev|production
+#  NODE_ENV = dev|production
 #  APP = commons specific
 #  HOSTNAME = where to download graphql schema from
 #  LOGOUT_INACTIVE_USERS = bool, should inactive users be logged out before session lifetime ends
@@ -23,93 +23,8 @@ export USE_INDEXD_AUTHZ="${USE_INDEXD_AUTHZ:-"false"}"
 export LOGOUT_INACTIVE_USERS="${LOGOUT_INACTIVE_USERS:-"true"}"
 export WORKSPACE_TIMEOUT_IN_MINUTES="${WORKSPACE_TIMEOUT_IN_MINUTES:-"480"}"
 
-
-# lib -----------------------------
-
-#
-# Given the HOSTNAME of a public environment,
-# set the APP environment variable and copy gitops
-# config files into the local space
-#
-# @param hostname
-#
-gitops_config() {
-  local hostname
-  local gitRepo
-  local manifestFile
-  local portalApp
-
-  gitRepo="cdis-manifest"
-  hostname="$1"
-  shift
-
-  if [[ -z "$hostname" ]]; then
-    echo "ERROR: gitops_config requires hostname arg"
-    return 1
-  fi
-  if [[ "$hostname" =~ ^qa- ]]; then
-    gitRepo="gitops-qa"
-  elif [[ "$hostname" =~ planx-pla.net$ ]]; then
-    gitRepo="gitops-dev"
-  fi
-  if [[ ! -d "../$gitRepo" ]]; then
-    # git clone
-    echo "ERROR: ../$gitRepo does not exist - please clone https://github.com/uc-cdis/${gitRepo}.git"
-    return 1
-  fi
-  manifestFile="../$gitRepo/$hostname/manifest.json"
-  if [[ ! -f "$manifestFile" ]]; then
-    echo "ERROR: gitops_config - manifest does not exist $manifestFile"
-    return 1
-  fi
-  portalApp="$(jq -r .global.portal_app < $manifestFile)"
-  if [[ -z "$portalApp" ]]; then
-    echo "ERROR: unable to determine portal_app from manifest at $manifestFile"
-    return 1
-  fi
-  echo "INFO: gitops_config - setting APP=$portalApp"
-  export HOSTNAME="$hostname"
-  export APP="$portalApp"
-  if [[ "$portalApp" == "gitops" ]]; then
-    local copySource
-    local copyDest
-
-    copySource="../$gitRepo/$hostname/portal/gitops.json"
-    copyDest="./data/config/gitops.json"
-    if [[ -z "$copySource" || -z "$copyDest" ]]; then
-      echo "ERROR: internal gitops processing error"
-      return 1
-    fi
-    if [[ -f "$copySource" ]]; then
-      echo "INFO: gitops_config - cp $copySource $copyDest"
-      cp "$copySource" "$copyDest"
-    else
-      echo "INFO: gitops_config - no $copySource in gitops"
-    fi
-  fi
-}
-
-# main -------------------
-
 # make sure we're in the right directory
 cd "$(dirname "${BASH_SOURCE}")"
-
-if [[ "$NODE_ENV" == "auto" ]]; then
-  if ! which jq > /dev/null; then
-    echo "ERROR: NODE_ENV=auto requires the jq tool"
-    echo "Install jq on ubuntu: sudo apt install jq"
-    echo "   or download from https://stedolan.github.io/jq/"
-    exit 1
-  fi
-  if [[ -z "$HOSTNAME" || "$HOSTNAME" == "revproxy-service" ]]; then
-    echo "ERROR: NODE_ENV=auto requires a valid HOSTNAME environment: $HOSTNAME"
-    exit 1
-  fi
-  if ! gitops_config "$HOSTNAME"; then
-    exit 1
-  fi
-fi
-
 # download the graphql schema for the commons from HOSTNAME
 npm run schema
 # run the relay compiler against the graphql schema
@@ -123,10 +38,6 @@ export STORYBOOK_PROJECT_ID=search
 export REACT_APP_PROJECT_ID=search
 export REACT_APP_DISABLE_SOCKET=true
 
-#
-# finally either launch the webpack-dev-server or
-# run webpack to generate a static bundle.js
-#
 if [[ "$NODE_ENV" == "production" ]]; then
   echo npx webpack
   npx webpack

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,6 @@ import { fetchAccess } from './UserProfile/ReduxUserProfile';
 import { submitSearchForm } from './QueryNode/ReduxQueryNode';
 import {
   basename,
-  dev,
   enableResourceBrowser,
   gaDebug,
   // workspaceUrl,
@@ -54,7 +53,7 @@ function App({ store }) {
   return (
     <Provider store={store}>
       <BrowserRouter basename={basename}>
-        {GA.init(gaTracking, dev, gaDebug) && <RouteTracker />}
+        {GA.init(gaTracking, { debug: gaDebug }) && <RouteTracker />}
         {isEnabled('noIndex') && (
           <Helmet>
             <meta name='robots' content='noindex,nofollow' />

--- a/src/actions.js
+++ b/src/actions.js
@@ -237,7 +237,7 @@ export const fetchUser = () => (dispatch) =>
 export const logoutAPI = (displayAuthPopup = false) => (dispatch) =>
   fetch(
     `${userapiPath}/logout?next=${hostname}${
-      process.env.NODE_ENV === 'dev' ? 'dev.html' : ''
+      process.env.NODE_ENV === 'development' ? 'dev.html' : ''
     }`
   ).then((response) => {
     if (displayAuthPopup)

--- a/src/components/GoogleAnalytics.jsx
+++ b/src/components/GoogleAnalytics.jsx
@@ -53,11 +53,9 @@ GoogleAnalytics.defaultProps = {
 
 export const RouteTracker = () => <Route component={GoogleAnalytics} />;
 
-const init = (trackingId, dev, gaDebug, options = {}) => {
+const init = (trackingId, options) => {
   const isGAEnabled = trackingId !== 'undefined';
-  if (isGAEnabled) {
-    ReactGA.initialize(trackingId, { debug: gaDebug, ...options });
-  }
+  if (isGAEnabled) ReactGA.initialize(trackingId, options);
   return isGAEnabled;
 };
 

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -8,7 +8,6 @@ const { components, requiredCerts, config } = require('./params');
  */
 function buildConfig(opts) {
   const defaults = {
-    dev: process.env.NODE_ENV === 'development',
     mockStore: process.env.MOCK_STORE === 'true',
     app: process.env.APP ?? 'generic',
     basename: process.env.BASENAME ?? '/',
@@ -32,7 +31,6 @@ function buildConfig(opts) {
     defaults.basename += 'dev.html';
 
   const {
-    dev,
     mockStore,
     app,
     basename,
@@ -152,7 +150,6 @@ function buildConfig(opts) {
     basename,
     breakpoints,
     buildConfig,
-    dev,
     hostname,
     gaDebug,
     userapiPath,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -8,7 +8,7 @@ const { components, requiredCerts, config } = require('./params');
  */
 function buildConfig(opts) {
   const defaults = {
-    dev: process.env.NODE_ENV === 'dev',
+    dev: process.env.NODE_ENV === 'development',
     mockStore: process.env.MOCK_STORE === 'true',
     app: process.env.APP ?? 'generic',
     basename: process.env.BASENAME ?? '/',

--- a/src/localconf.test.js
+++ b/src/localconf.test.js
@@ -2,7 +2,6 @@ import conf from './localconf';
 
 describe('The localconf', () => {
   const expectedKeys = [
-    'dev',
     'mockStore',
     'app',
     'basename',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,8 @@ const pathPrefix = basename.endsWith('/')
   ? basename.slice(0, basename.length - 1)
   : basename;
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 const plugins = [
   new CompressionPlugin(),
   new webpack.EnvironmentPlugin({
@@ -31,7 +33,7 @@ const plugins = [
       ),
     },
     // disable React DevTools in production; see https://github.com/facebook/react/pull/11448
-    ...(process.env.NODE_ENV === 'production'
+    ...(isProduction
       ? { __REACT_DEVTOOLS_GLOBAL_HOOK__: '({ isDisabled: true })' }
       : {}),
   }),
@@ -66,8 +68,6 @@ const plugins = [
 let optimization = {};
 let devtool = false;
 
-const isProduction =
-  process.env.NODE_ENV !== 'dev' && process.env.NODE_ENV !== 'auto';
 if (isProduction) {
   // optimization for production mode
   optimization = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,7 @@ const plugins = [
     PORTAL_VERSION: portalVersion || '',
   }),
   new webpack.DefinePlugin({
-    // <-- key to reducing React's size
     'process.env': {
-      NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'dev'),
       LOGOUT_INACTIVE_USERS: !(process.env.LOGOUT_INACTIVE_USERS === 'false'),
       WORKSPACE_TIMEOUT_IN_MINUTES:
         process.env.WORKSPACE_TIMEOUT_IN_MINUTES || 480,


### PR DESCRIPTION
Ticket: [PEDS-529](https://pcdc.atlassian.net/browse/PEDS-529)

This PR removes the use of non-standard `NODE_ENV` values and migrates to using more standard/conventional `"development"` and `"production"` only. This is to avoid unintended conflict with build tools that rely on the standard/conventional `NODE_ENV` values.

In doing so, the PR also stops handling `NODE_ENV="auto"` to automatically copy over configuration files from an external location for the select `APP`, which was introduced as a convenience feature to customize the portal setting for different use cases. This change is justified because the PCDC use case is fixed to a single portal setting and no longer rely on customizing it on build time.