### PR TITLE
Fix invalid indexd response data PEDS-602

### DIFF
--- a/src/Submission/ReduxMapFiles.js
+++ b/src/Submission/ReduxMapFiles.js
@@ -4,10 +4,10 @@ import { fetchWithCreds } from '../actions';
 import { STARTING_DID, FETCH_LIMIT } from './utils';
 import { indexdPath, useIndexdAuthz } from '../localconf';
 
-const fetchUnmappedFiles = (user, total, start, fetchLimit) => (dispatch) => {
+const fetchUnmappedFiles = (user, total, start) => (dispatch) => {
   const unmappedFilesCheck = useIndexdAuthz ? 'authz=null' : 'acl=null';
   return fetchWithCreds({
-    path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${user}&start=${start}&limit=${fetchLimit}`,
+    path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${user}&start=${start}&limit=${FETCH_LIMIT}`,
     method: 'GET',
   })
     .then(
@@ -15,13 +15,12 @@ const fetchUnmappedFiles = (user, total, start, fetchLimit) => (dispatch) => {
         switch (status) {
           case 200:
             total = total.concat(data.records ?? []);
-            if (data.records?.length === fetchLimit) {
+            if (data.records?.length === FETCH_LIMIT) {
               return dispatch(
                 fetchUnmappedFiles(
                   user,
                   total,
-                  data.records[fetchLimit - 1].did,
-                  fetchLimit
+                  data.records[FETCH_LIMIT - 1].did
                 )
               );
             }
@@ -39,9 +38,7 @@ const fetchUnmappedFiles = (user, total, start, fetchLimit) => (dispatch) => {
       (err) => ({ type: 'FETCH_ERROR', error: err })
     )
     .then((msg) => {
-      if (msg) {
-        dispatch(msg);
-      }
+      if (msg) dispatch(msg);
     });
 };
 
@@ -58,7 +55,7 @@ const ReduxMapFiles = (() => {
 
   const mapDispatchToProps = (dispatch) => ({
     fetchUnmappedFiles: (user) =>
-      dispatch(fetchUnmappedFiles(user, [], STARTING_DID, FETCH_LIMIT)),
+      dispatch(fetchUnmappedFiles(user, [], STARTING_DID)),
     mapSelectedFiles: (files) => dispatch(mapSelectedFiles(files)),
   });
 

--- a/src/Submission/ReduxMapFiles.js
+++ b/src/Submission/ReduxMapFiles.js
@@ -14,7 +14,7 @@ const fetchUnmappedFiles = (user, total, start, fetchLimit) => (dispatch) => {
       ({ status, data }) => {
         switch (status) {
           case 200:
-            total = total.concat(data.records);
+            total = total.concat(data.records ?? []);
             if (data.records?.length === fetchLimit) {
               return dispatch(
                 fetchUnmappedFiles(

--- a/src/Submission/ReduxSubmissionHeader.js
+++ b/src/Submission/ReduxSubmissionHeader.js
@@ -4,35 +4,32 @@ import { fetchWithCreds } from '../actions';
 import { FETCH_LIMIT, STARTING_DID } from './utils';
 import { indexdPath, useIndexdAuthz } from '../localconf';
 
-const fetchUnmappedFileStats = (username, totalSize, start, fetchLimit) => (
-  dispatch
-) => {
+const fetchUnmappedFileStats = (username, total, start) => (dispatch) => {
   const unmappedFilesCheck = useIndexdAuthz ? 'authz=null' : 'acl=null';
   return fetchWithCreds({
-    path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${username}&start=${start}&limit=${fetchLimit}`,
+    path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${username}&start=${start}&limit=${FETCH_LIMIT}`,
     method: 'GET',
   })
     .then(
       ({ status, data }) => {
         switch (status) {
           case 200:
-            totalSize = totalSize.concat(data.records ?? []);
-            if (data.records?.length === fetchLimit) {
+            total = total.concat(data.records ?? []);
+            if (data.records?.length === FETCH_LIMIT) {
               return dispatch(
                 fetchUnmappedFileStats(
                   username,
-                  totalSize,
-                  data.records[fetchLimit - 1].did,
-                  fetchLimit
+                  total,
+                  data.records[FETCH_LIMIT - 1].did
                 )
               );
             }
             return {
               type: 'RECEIVE_UNMAPPED_FILE_STATISTICS',
               data: {
-                count: totalSize.length,
-                totalSize: totalSize.reduce(
-                  (total, current) => total + current.size,
+                count: total.length,
+                totalSize: total.reduce(
+                  (size, current) => size + current.size,
                   0
                 ),
               },
@@ -48,9 +45,7 @@ const fetchUnmappedFileStats = (username, totalSize, start, fetchLimit) => (
       (err) => ({ type: 'FETCH_ERROR', error: err })
     )
     .then((msg) => {
-      if (msg) {
-        dispatch(msg);
-      }
+      if (msg) dispatch(msg);
     });
 };
 
@@ -63,7 +58,7 @@ const ReduxSubmissionHeader = (() => {
 
   const mapDispatchToProps = (dispatch) => ({
     fetchUnmappedFileStats: (username) =>
-      dispatch(fetchUnmappedFileStats(username, [], STARTING_DID, FETCH_LIMIT)),
+      dispatch(fetchUnmappedFileStats(username, [], STARTING_DID)),
   });
 
   return connect(mapStateToProps, mapDispatchToProps)(SubmissionHeader);

--- a/src/Submission/ReduxSubmissionHeader.js
+++ b/src/Submission/ReduxSubmissionHeader.js
@@ -16,7 +16,7 @@ const fetchUnmappedFileStats = (username, totalSize, start, fetchLimit) => (
       ({ status, data }) => {
         switch (status) {
           case 200:
-            totalSize = totalSize.concat(data.records);
+            totalSize = totalSize.concat(data.records ?? []);
             if (data.records?.length === fetchLimit) {
               return dispatch(
                 fetchUnmappedFileStats(


### PR DESCRIPTION
Ticket: [PEDS-602](https://pcdc.atlassian.net/browse/PEDS-602)

This PR fixes an unhandled error caused by invalid response from request to `/index/*` path on local docker compose environment. This is due to the fact that the local docker compose does not include indexd service that would be mapped to `/index/`, therefore leading to the client-side router to serve a page for `/index/*`.