### PR TITLE
Fix too narrow sidebar width

### DIFF
--- a/src/Layout/Dashboard.css
+++ b/src/Layout/Dashboard.css
@@ -1,5 +1,5 @@
 :root {
-  --dashboard__sidebar-width: 320px;
+  --dashboard__sidebar-width: 360px;
 }
 
 .dashboard {


### PR DESCRIPTION
This PR increase the sidebar with for dashboard layout used in /dd and /explorer pages.

This change is motivated by the failure of displaying standard/current set of explorer tabs (subject, disease, & molecular) in a single line on certain combinations of OS & browser--as in the following image:

<image src="https://user-images.githubusercontent.com/22449454/141333088-d804e2db-005b-40ab-9899-b15dd2fa99a4.png" width="360" />

While this is _not_ a bug in a strict sense, it is still preferable for these initial set of tabs to appear in a single line. The increased sidebar width from 320px to 360px should give enough room to achieve this for any OS & browser combination.