### PR TITLE
Add nested fields to survival analysis variables PEDS-574

### DIFF
--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -1,3 +1,4 @@
+const pluralize = require('pluralize');
 const { params } = require('./parameters');
 const { paramByApp, getGraphQL } = require('./dictionaryHelper');
 
@@ -157,10 +158,15 @@ function getEnumFilterList(config, dict) {
       for (const field of fields) filterSet.add(field);
 
   const enumPropSet = new Set();
-  for (const value of Object.values(dict))
-    if (value.properties !== undefined)
+  for (const [name, value] of Object.entries(dict))
+    if (name !== 'survival_characteristic' && value.properties !== undefined)
       for (const [propName, propValue] of Object.entries(value.properties))
-        if (propValue.enum !== undefined) enumPropSet.add(propName);
+        if (propValue.enum !== undefined)
+          enumPropSet.add(
+            ['subject', 'person'].includes(name)
+              ? propName
+              : `${name.endsWith('s') ? name : pluralize(name)}.${propName}`
+          );
 
   const filterList = Array.from(filterSet);
   const enumFilterSet = new Set();


### PR DESCRIPTION
Ticket: [PEDS-574](https://pcdc.atlassian.net/browse/PEDS-574)

This PR updates `getEnumFilterList()` to include nested fields.

Here, "nested fields" exclude properties under `"subject"` (since this is the main data type we use) or `"person"` (since `"subject"` has many-to-one relationship with this) types in the dictionary. We are also excluding properties under `"survival_characteristic"` since the purpose of `enumFilterList` is to identify fields that can be used as survival analysis
 variables (factor/stratification used to group data).

Please note that this PR uses a heuristic to pluralize prop name for nested fields (see line 168) based on observation. While this heuristic works for the filters currently in use, it may not in other unknown cases.

For the nested field variables to work with survival analysis, we will need the `PcdcAnalysisTools` after https://github.com/chicagopcdc/PcdcAnalysisTools/pull/37 to handle them for /survival requests.