### PR TITLE
Fix graphql crashing due to missing rule PEDS-605

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20059,12 +20059,9 @@
       }
     },
     "graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.7.2.tgz",
+      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
     },
     "graphql-language-service": {
       "version": "3.2.0",
@@ -21748,11 +21745,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "iterate-iterator": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "flat": "^5.0.2",
     "fuse.js": "^3.3.0",
     "graphiql": "^1.5.0",
-    "graphql": "^14.7.0",
+    "graphql": "^15.7.2",
     "html-webpack-plugin": "^5.5.0",
     "ignore-loader": "^0.1.2",
     "isomorphic-fetch": "^3.0.0",


### PR DESCRIPTION
Ticket: [PEDS-605](https://pcdc.atlassian.net/browse/PEDS-605)

This PR fixes the crashing of /query page due to missing rule (`NoDeprecatedCustomRule`). This was achieved by migrating `graphql` to 15. 

The crash was caused by updating dependency `graphiql` from `1.4.7` to `1.5.0` (https://github.com/chicagopcdc/data-portal/pull/266/commits/8264ea446db2b515c21585d49b26f65d32fc9eb4) without accounting for the change to its peerDependency `graphql` that no longer accepts the current `grpahql` version `14.7.0` (https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a#diff-55dd96166f54f148632a71fbe37e0f7a75e287b15cc9cfe35359f4d5824026ea).

No other changes were made since breaking changes introduced in `graphql@15` do not seem to concern the utility functions in use (`buildClientSchema`, `getIntrospectionQuery`, and `printSchema`).