### PR TITLE
Refactor <ExplorerTable>

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -57,6 +57,74 @@ function getColumnWidth({ field, columnName, linkFields, rawData }) {
 }
 
 /**
+ * @param {Object} args
+ * @param {string} args.downloadAccessor
+ * @param {string} args.field
+ * @param {string[]} args.linkFields
+ * @param {Array} args.rowValue
+ * @param {string} args.valueStr
+ */
+function getCellElement({
+  downloadAccessor,
+  field,
+  linkFields,
+  rowValue,
+  valueStr,
+}) {
+  if (downloadAccessor)
+    return (
+      <div>
+        <span title={valueStr}>
+          <a href={`/files/${valueStr}`}>{valueStr}</a>
+        </span>
+      </div>
+    );
+
+  if (linkFields.includes(field))
+    return field && valueStr ? (
+      <IconicLink
+        link={valueStr}
+        className='explorer-table-link'
+        buttonClassName='explorer-table-link-button'
+        icon='exit'
+        dictIcons={dictIcons}
+        iconColor='#606060'
+        target='_blank'
+        isExternal
+      />
+    ) : null;
+
+  if (field === 'filed_size')
+    return (
+      <div>
+        <span title={valueStr}>{humanFileSize(valueStr)}</span>
+      </div>
+    );
+
+  if (field === 'external_references.external_links') {
+    if (!rowValue) return null;
+    const [
+      resourceName,
+      resourceIconPath,
+      subjectUrl,
+    ] = rowValue[0].external_links.split('|');
+    return (
+      <div className='explorer-table-external-links'>
+        <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
+          <img src={resourceIconPath} alt={resourceName} />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <span title={valueStr}>{valueStr}</span>
+    </div>
+  );
+}
+
+/**
  * @typedef {Object} ExplorerTableProps
  * @property {Object[]} rawData
  * @property {(args: { offset: number; size: number; sort: GqlSort }) => Promise} fetchAndUpdateRawData
@@ -160,58 +228,13 @@ class ExplorerTable extends React.Component {
             ? row.value.join(', ')
             : row.value;
 
-        // handling some special field types
-        if (this.props.guppyConfig.downloadAccessor)
-          return (
-            <div>
-              <span title={valueStr}>
-                <a href={`/files/${valueStr}`}>{valueStr}</a>
-              </span>
-            </div>
-          );
-
-        if (this.props.tableConfig.linkFields.includes(field))
-          return field && valueStr ? (
-            <IconicLink
-              link={valueStr}
-              className='explorer-table-link'
-              buttonClassName='explorer-table-link-button'
-              icon='exit'
-              dictIcons={dictIcons}
-              iconColor='#606060'
-              target='_blank'
-              isExternal
-            />
-          ) : null;
-
-        if (field === 'filed_size')
-          return (
-            <div>
-              <span title={valueStr}>{humanFileSize(valueStr)}</span>
-            </div>
-          );
-
-        if (field === 'external_references.external_links') {
-          if (row.value === null) return null;
-          const [
-            resourceName,
-            resourceIconPath,
-            subjectUrl,
-          ] = row.value[0].external_links.split('|');
-          return (
-            <div className='explorer-table-external-links'>
-              <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
-                <img src={resourceIconPath} alt={resourceName} />
-              </a>
-            </div>
-          );
-        }
-
-        return (
-          <div>
-            <span title={valueStr}>{valueStr}</span>
-          </div>
-        );
+        return getCellElement({
+          downloadAccessor: this.props.guppyConfig.downloadAccessor,
+          field,
+          linkFields: this.props.tableConfig.linkFields,
+          rowValue: row.value,
+          valueStr,
+        });
       },
     };
   };

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -238,29 +238,24 @@ class ExplorerTable extends React.Component {
   buildNestedArrayFieldColumnConfigs = (nestedArrayFieldNames) => {
     /** @type {{ [x: string]: ReactTableColumn[][] }} */
     const nestedArrayFieldColumnConfigs = {};
-    Object.keys(nestedArrayFieldNames).forEach((key) => {
-      if (!nestedArrayFieldColumnConfigs[key]) {
+    for (const key of Object.keys(nestedArrayFieldNames)) {
+      if (!nestedArrayFieldColumnConfigs[key])
         nestedArrayFieldColumnConfigs[key] = [];
+
+      const firstLevelColumns = [];
+      const secondLevelColumns = [];
+      for (const nestedFieldName of nestedArrayFieldNames[key]) {
+        const field = `${key}.${nestedFieldName}`;
+        firstLevelColumns.push(this.buildColumnConfig(field, true, false));
+        secondLevelColumns.push(this.buildColumnConfig(field, true, true));
       }
-      const firstLevelColumns = nestedArrayFieldNames[key].map((field) =>
-        this.buildColumnConfig(`${key}.${field}`, true, false)
+
+      nestedArrayFieldColumnConfigs[key].push(
+        [{ Header: key, columns: firstLevelColumns }],
+        [{ Header: key, columns: secondLevelColumns }]
       );
-      const firstLevelColumnsConfig = [];
-      firstLevelColumnsConfig.push({
-        Header: key,
-        columns: firstLevelColumns,
-      });
-      const secondLevelColumns = nestedArrayFieldNames[key].map((field) =>
-        this.buildColumnConfig(`${key}.${field}`, true, true)
-      );
-      const secondLevelColumnsConfig = [];
-      secondLevelColumnsConfig.push({
-        Header: key,
-        columns: secondLevelColumns,
-      });
-      nestedArrayFieldColumnConfigs[key].push(firstLevelColumnsConfig);
-      nestedArrayFieldColumnConfigs[key].push(secondLevelColumnsConfig);
-    });
+    }
+
     return nestedArrayFieldColumnConfigs;
   };
 

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -161,56 +161,57 @@ class ExplorerTable extends React.Component {
             : row.value;
 
         // handling some special field types
-        switch (field) {
-          case this.props.guppyConfig.downloadAccessor:
-            return (
-              <div>
-                <span title={valueStr}>
-                  <a href={`/files/${valueStr}`}>{valueStr}</a>
-                </span>
-              </div>
-            );
-          case this.props.tableConfig.linkFields.includes(field) && field:
-            return valueStr ? (
-              <IconicLink
-                link={valueStr}
-                className='explorer-table-link'
-                buttonClassName='explorer-table-link-button'
-                icon='exit'
-                dictIcons={dictIcons}
-                iconColor='#606060'
-                target='_blank'
-                isExternal
-              />
-            ) : null;
-          case 'file_size':
-            return (
-              <div>
-                <span title={valueStr}>{humanFileSize(valueStr)}</span>
-              </div>
-            );
-          case 'external_references.external_links': {
-            if (row.value === null) return null;
-            const [
-              resourceName,
-              resourceIconPath,
-              subjectUrl,
-            ] = row.value[0].external_links.split('|');
-            return (
-              <div className='explorer-table-external-links'>
-                <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
-                  <img src={resourceIconPath} alt={resourceName} />
-                </a>
-              </div>
-            );
-          }
-          default:
-            return (
-              <div>
-                <span title={valueStr}>{valueStr}</span>
-              </div>
-            );
+        if (this.props.guppyConfig.downloadAccessor)
+          return (
+            <div>
+              <span title={valueStr}>
+                <a href={`/files/${valueStr}`}>{valueStr}</a>
+              </span>
+            </div>
+          );
+
+        if (this.props.tableConfig.linkFields.includes(field))
+          return field && valueStr ? (
+            <IconicLink
+              link={valueStr}
+              className='explorer-table-link'
+              buttonClassName='explorer-table-link-button'
+              icon='exit'
+              dictIcons={dictIcons}
+              iconColor='#606060'
+              target='_blank'
+              isExternal
+            />
+          ) : null;
+
+        if (field === 'filed_size')
+          return (
+            <div>
+              <span title={valueStr}>{humanFileSize(valueStr)}</span>
+            </div>
+          );
+
+        if (field === 'external_references.external_links') {
+          if (row.value === null) return null;
+          const [
+            resourceName,
+            resourceIconPath,
+            subjectUrl,
+          ] = row.value[0].external_links.split('|');
+          return (
+            <div className='explorer-table-external-links'>
+              <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
+                <img src={resourceIconPath} alt={resourceName} />
+              </a>
+            </div>
+          );
         }
+
+        return (
+          <div>
+            <span title={valueStr}>{valueStr}</span>
+          </div>
+        );
       },
     };
   };

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -158,7 +158,7 @@ function ExplorerTable({
   /**
    * Build column config for each table according to their locations and fields
    * @param {string} field: the full field name
-   * @returns {ReactTableColumn} a column config for the input field which can be used by react-table
+   * @returns {ReactTableColumn}
    */
   function buildColumnConfig(field) {
     const { downloadAccessor, fieldMapping } = guppyConfig;
@@ -190,9 +190,8 @@ function ExplorerTable({
   /**
    * Build nested column config for each table according to their locations and fields
    * @param {string} field the full field name, contains at least 1 '.'
-   * @param {boolean} [isDetailedColumn] control flag to determine if it is building column config for inner
-   * most nested table
-   * @returns {ReactTableColumn} a column config for the input field which can be used by react-table
+   * @param {boolean} [isDetailedColumn] control flag to determine if it is building column config for innermost nested table
+   * @returns {ReactTableColumn}
    */
   function buildNestedColumnConfig(field, isDetailedColumn = false) {
     const { downloadAccessor, fieldMapping } = guppyConfig;
@@ -247,29 +246,22 @@ function ExplorerTable({
 
   /**
    * Build column configs nested array fields
-   * We only need nested table if the nested field is an array
-   * Otherwise the nested field will have 1-1 relationship to its parent
-   * so can be displayed in one row
-   * @param {{ [x: string]: string[] }} nestedArrayFieldNames: an object containing all the nested array fields,
-   * separated by their parent names
-   * e.g.:
+   * We only need nested table if the nested field is an array.
+   * Otherwise, the nested field can be displayed in one row.
+   * @param {{ [x: string]: string[] }} nestedArrayFieldNames an object containing
+   * all the nested array fields, separated by their parent names.
+   * @example
    * {
-   *    ActionableMutations: [ Lab ],
-   *    Oncology_Primary: [ Multiplicitycounter, ICDOSite ]
+   *    ActionableMutations: [ 'Lab' ],
+   *    Oncology_Primary: [ 'Multiplicitycounter', 'ICDOSite' ]
    * }
    * @returns a collection of column configs for each nested table,
    * separated by their parent names. Each set of column configs contains two configs,
-   * one for the 1st level nested table and one for the 2nd level table
-   * e.g.:
+   * one for the 1st level nested table and one for the 2nd level table.
+   * @example
    * {
-   *    ActionableMutations: [
-   *      <columnConfig for 1st level nested table>,
-   *      <columnConfig for 2nd level nested table (the details table)>
-   *    ],
-   *    Oncology_Primary: [
-   *      <columnConfig for 1st level nested table>,
-   *      <columnConfig for 2nd level nested table (the details table)>
-   *    ]
+   *    ActionableMutations: [ firstLevelColumnConfig, secondLevelColumnConfig ],
+   *    Oncology_Primary: [ firstLevelColumnConfig, secondLevelColumnConfig ]
    * }
    */
   function buildNestedArrayFieldColumnConfigs(nestedArrayFieldNames) {

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -149,6 +149,8 @@ function ExplorerTable({
   tableConfig,
   totalCount,
 }) {
+  if ((tableConfig.fields ?? []).length === 0) return null;
+
   const [pageSize, setPageSize] = useState(defaultPageSize);
   const [currentPage, setCurrentPage] = useState(0);
   const [isInitialFetchData, setIsInitialFetchData] = useState(true);
@@ -294,9 +296,6 @@ function ExplorerTable({
     return nestedArrayFieldColumnConfigs;
   }
 
-  if (!tableConfig.fields || tableConfig.fields.length === 0) {
-    return null;
-  }
   // build column configs for root table first
   const rootColumnsConfig = tableConfig.fields.map(buildColumnConfig);
   if (!tableConfig.ordered) {

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -420,14 +420,14 @@ function ExplorerTable({
 }
 
 ExplorerTable.propTypes = {
-  rawData: PropTypes.array, // from GuppyWrapper
-  fetchAndUpdateRawData: PropTypes.func.isRequired, // from GuppyWrapper
   accessibleCount: PropTypes.number.isRequired, // from GuppyWrapper
-  isLocked: PropTypes.bool.isRequired,
   className: PropTypes.string,
   defaultPageSize: PropTypes.number,
-  tableConfig: TableConfigType.isRequired,
+  fetchAndUpdateRawData: PropTypes.func.isRequired, // from GuppyWrapper
   guppyConfig: GuppyConfigType.isRequired,
+  isLocked: PropTypes.bool.isRequired,
+  rawData: PropTypes.array, // from GuppyWrapper
+  tableConfig: TableConfigType.isRequired,
   totalCount: PropTypes.number,
 };
 

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -61,14 +61,14 @@ function getColumnWidth({ field, columnName, linkFields, rawData }) {
  * @param {string} args.downloadAccessor
  * @param {string} args.field
  * @param {string[]} args.linkFields
- * @param {Array} args.rowValue
+ * @param {Array} args.value
  * @param {string} args.valueStr
  */
 function getCellElement({
   downloadAccessor,
   field,
   linkFields,
-  rowValue,
+  value,
   valueStr,
 }) {
   if (downloadAccessor)
@@ -102,12 +102,12 @@ function getCellElement({
     );
 
   if (field === 'external_references.external_links') {
-    if (!rowValue) return null;
+    if (!value) return null;
     const [
       resourceName,
       resourceIconPath,
       subjectUrl,
-    ] = rowValue[0].external_links.split('|');
+    ] = value[0].external_links.split('|');
     return (
       <div className='explorer-table-external-links'>
         <a href={subjectUrl} target='_blank' rel='noopenner noreferrer'>
@@ -183,7 +183,7 @@ class ExplorerTable extends React.Component {
           downloadAccessor,
           field,
           linkFields: this.props.tableConfig.linkFields,
-          rowValue: value,
+          value,
           valueStr: Array.isArray(value) ? value.join(', ') : value,
         }),
     };
@@ -238,7 +238,7 @@ class ExplorerTable extends React.Component {
             downloadAccessor,
             field,
             linkFields: this.props.tableConfig.linkFields,
-            rowValue: value,
+            value,
             valueStr: Array.isArray(value)
               ? value.map((v) => get(v, nestedFieldName)).join(', ')
               : get(value, nestedFieldName),

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -205,37 +205,37 @@ function ExplorerTable({
       // @ts-ignore
       width: '70vw',
       accessor: (d) => d[fieldStringsArray[0]],
-      Cell: ({ value }) =>
-        // for inner most detailed table, 1 value per row
-        isDetailedColumn ? (
-          <div className='rt-tbody'>
-            <div className='rt-tr-group'>
-              {value.map((v, i) => (
-                <div
-                  className={`rt-tr ${i % 2 === 0 ? '-even' : '-odd'}`}
-                  key={i}
-                >
-                  <div className='rt-td'>
-                    <span>
-                      {get(v, nestedFieldName)}
-                      <br />
-                    </span>
+      Cell: isDetailedColumn
+        ? ({ value }) => (
+            // for inner most detailed table, 1 value per row
+            <div className='rt-tbody'>
+              <div className='rt-tr-group'>
+                {value.map((v, i) => (
+                  <div
+                    className={`rt-tr ${i % 2 === 0 ? '-even' : '-odd'}`}
+                    key={i}
+                  >
+                    <div className='rt-td'>
+                      <span>
+                        {get(v, nestedFieldName)}
+                        <br />
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </div>
-        ) : (
-          getCellElement({
-            downloadAccessor,
-            field,
-            linkFields,
-            value,
-            valueStr: Array.isArray(value)
-              ? value.map((v) => get(v, nestedFieldName)).join(', ')
-              : get(value, nestedFieldName),
-          })
-        ),
+          )
+        : ({ value }) =>
+            getCellElement({
+              downloadAccessor,
+              field,
+              linkFields,
+              value,
+              valueStr: Array.isArray(value)
+                ? value.map((v) => get(v, nestedFieldName)).join(', ')
+                : get(value, nestedFieldName),
+            }),
     };
   }
 

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -311,38 +311,34 @@ function ExplorerTable({
     }
 
   /** @type {import('react-table').SubComponentFunction} */
-  let subComponent = null;
+  let SubComponent = null;
   if (Object.keys(nestedArrayFieldNames).length > 0) {
     // eslint-disable-next-line max-len
     const nestedArrayFieldColumnConfigs = buildNestedArrayFieldColumnConfigs(
       nestedArrayFieldNames
     );
     // this is the subComponent of the two-level nested tables
-    subComponent = (row) =>
-      Object.keys(nestedArrayFieldColumnConfigs).map((key) => {
-        const rowData =
-          isLocked || !rawData ? [] : rawData.slice(row.index, row.index + 1);
-        return (
-          <div className='explorer-nested-table' key={key}>
-            <ReactTable
-              data={isLocked || !rowData ? [] : rowData}
-              columns={nestedArrayFieldColumnConfigs[key][0]}
-              defaultPageSize={1}
-              showPagination={false}
-              SubComponent={() => (
-                <div className='explorer-nested-table'>
-                  <ReactTable
-                    data={isLocked || !rowData ? [] : rowData}
-                    columns={nestedArrayFieldColumnConfigs[key][1]}
-                    defaultPageSize={1}
-                    showPagination={false}
-                  />
-                </div>
-              )}
-            />
-          </div>
-        );
-      });
+    SubComponent = (row) =>
+      Object.keys(nestedArrayFieldColumnConfigs).map((key) => (
+        <div className='explorer-nested-table' key={key}>
+          <ReactTable
+            data={(rawData ?? []).slice(row.index, row.index + 1)}
+            columns={nestedArrayFieldColumnConfigs[key][0]}
+            defaultPageSize={1}
+            showPagination={false}
+            SubComponent={() => (
+              <div className='explorer-nested-table'>
+                <ReactTable
+                  data={(rawData ?? []).slice(row.index, row.index + 1)}
+                  columns={nestedArrayFieldColumnConfigs[key][1]}
+                  defaultPageSize={1}
+                  showPagination={false}
+                />
+              </div>
+            )}
+          />
+        </div>
+      ));
   }
 
   const totalPages =
@@ -422,7 +418,7 @@ function ExplorerTable({
             <div className='rt-noData'>No data to display</div>
           )
         }
-        SubComponent={isLocked ? null : subComponent}
+        SubComponent={isLocked ? null : SubComponent}
       />
     </div>
   );

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -266,27 +266,6 @@ class ExplorerTable extends React.Component {
     return nestedArrayFieldColumnConfigs;
   };
 
-  /**
-   * @param {Object} state
-   * @param {number} state.page
-   * @param {number} state.pageSize
-   * @param {{ id: string; desc: boolean }[]} state.sorted
-   */
-  fetchData = ({ page, pageSize, sorted }) => {
-    this.props
-      .fetchAndUpdateRawData({
-        offset: page * pageSize,
-        size: pageSize,
-        sort: sorted.map((i) => ({ [i.id]: i.desc ? 'desc' : 'asc' })),
-      })
-      .then(() => {
-        this.setState({
-          pageSize,
-          currentPage: page,
-        });
-      });
-  };
-
   render() {
     if (
       !this.props.tableConfig.fields ||
@@ -417,7 +396,21 @@ class ExplorerTable extends React.Component {
           onFetchData={
             this.state.isInitialFetchData
               ? () => this.setState({ isInitialFetchData: false })
-              : this.fetchData
+              : (state) =>
+                  this.props
+                    .fetchAndUpdateRawData({
+                      offset: state.page * state.pageSize,
+                      size: state.pageSize,
+                      sort: state.sorted.map((i) => ({
+                        [i.id]: i.desc ? 'desc' : 'asc',
+                      })),
+                    })
+                    .then(() =>
+                      this.setState({
+                        pageSize: state.pageSize,
+                        currentPage: state.page,
+                      })
+                    )
           }
           defaultPageSize={this.props.defaultPageSize}
           className={'-striped -highlight '}

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -63,39 +63,28 @@ class ExplorerTable extends React.Component {
    * @param {string} columnName
    */
   getWidthForColumn = (field, columnName) => {
+    // special cases
     if (field === 'external_links') return 200;
-
-    if (this.props.tableConfig.linkFields.includes(field)) {
-      return 80;
-    }
+    if (this.props.tableConfig.linkFields.includes(field)) return 80;
+    if ((this.props.rawData ?? []).length === 0) return 100;
 
     // some magic numbers that work fine for table columns width
-    const minWidth = 100;
     const maxWidth = 400;
     const letterWidth = 8;
     const spacing = 20;
-    if (!this.props.rawData || this.props.rawData.length === 0) {
-      return minWidth;
-    }
+
+    const [fieldName] = field.split('.');
     let maxLetterLen = columnName.length;
-    const fieldStringsArray = field.split('.');
-    this.props.rawData.forEach((d) => {
-      if (
-        d[fieldStringsArray[0]] === null ||
-        typeof d[fieldStringsArray[0]] === 'undefined'
-      ) {
-        return;
-      }
+
+    for (const d of this.props.rawData) {
       // the calculation logic here is a bit wild if it is a nested array field
       // it would convert the whole array to string and calculate
       // which in most cases would exceed the maxWidth so just use maxWidth
-      const str =
-        d[fieldStringsArray[0]].toString && d[fieldStringsArray[0]].toString();
-      const len = str ? str.length : 0;
-      maxLetterLen = len > maxLetterLen ? len : maxLetterLen;
-    });
-    const resWidth = Math.min(maxLetterLen * letterWidth + spacing, maxWidth);
-    return resWidth;
+      const len = d?.[fieldName]?.toString().length ?? 0;
+      maxLetterLen = Math.max(len, maxLetterLen);
+    }
+
+    return Math.min(maxLetterLen * letterWidth + spacing, maxWidth);
   };
 
   /**

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -255,8 +255,8 @@ function ExplorerTable({
    * one for the 1st level nested table and one for the 2nd level table.
    * @example
    * {
-   *    ActionableMutations: [ firstLevelColumnConfig, secondLevelColumnConfig ],
-   *    Oncology_Primary: [ firstLevelColumnConfig, secondLevelColumnConfig ]
+   *    ActionableMutations: [ firstLevelColumnsConfig, secondLevelColumnsConfig ],
+   *    Oncology_Primary: [ firstLevelColumnsConfig, secondLevelColumnsConfig ]
    * }
    */
   function buildNestedArrayFieldColumnConfigs(nestedArrayFieldNames) {
@@ -314,26 +314,28 @@ function ExplorerTable({
     );
     // this is the subComponent of the two-level nested tables
     SubComponent = (row) =>
-      Object.keys(nestedArrayFieldColumnConfigs).map((key) => (
-        <div className='explorer-nested-table' key={key}>
-          <ReactTable
-            data={(rawData ?? []).slice(row.index, row.index + 1)}
-            columns={nestedArrayFieldColumnConfigs[key][0]}
-            defaultPageSize={1}
-            showPagination={false}
-            SubComponent={() => (
-              <div className='explorer-nested-table'>
-                <ReactTable
-                  data={(rawData ?? []).slice(row.index, row.index + 1)}
-                  columns={nestedArrayFieldColumnConfigs[key][1]}
-                  defaultPageSize={1}
-                  showPagination={false}
-                />
-              </div>
-            )}
-          />
-        </div>
-      ));
+      Object.entries(nestedArrayFieldColumnConfigs).map(
+        ([key, [firstLevelColumnsConfig, secondLevelColumnsConfig]]) => (
+          <div className='explorer-nested-table' key={key}>
+            <ReactTable
+              data={(rawData ?? []).slice(row.index, row.index + 1)}
+              columns={firstLevelColumnsConfig}
+              defaultPageSize={1}
+              showPagination={false}
+              SubComponent={() => (
+                <div className='explorer-nested-table'>
+                  <ReactTable
+                    data={(rawData ?? []).slice(row.index, row.index + 1)}
+                    columns={secondLevelColumnsConfig}
+                    defaultPageSize={1}
+                    showPagination={false}
+                  />
+                </div>
+              )}
+            />
+          </div>
+        )
+      );
   }
 
   const totalPages =

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -270,24 +270,17 @@ class ExplorerTable extends React.Component {
    * @param {number} state.pageSize
    * @param {{ id: string; desc: boolean }[]} state.sorted
    */
-  fetchData = (state) => {
-    const offset = state.page * state.pageSize;
-    /** @type {GqlSort} */
-    const sort = state.sorted.map((i) => ({
-      [i.id]: i.desc ? 'desc' : 'asc',
-    }));
-    const size = state.pageSize;
+  fetchData = ({ page, pageSize, sorted }) => {
     this.props
       .fetchAndUpdateRawData({
-        offset,
-        size,
-        sort,
+        offset: page * pageSize,
+        size: pageSize,
+        sort: sorted.map((i) => ({ [i.id]: i.desc ? 'desc' : 'asc' })),
       })
       .then(() => {
-        // Guppy fetched and loaded raw data into "this.props.rawData" already
         this.setState({
-          pageSize: size,
-          currentPage: state.page,
+          pageSize,
+          currentPage: page,
         });
       });
   };

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -19,11 +19,11 @@ import '../typedef';
  * A simplified alternative to lodash/get using string path of property names only.
  * @param {object} object The object to query.
  * @param {string} path Path to the property to get, e.g. 'a.b.c'
- * @param {any} defaultValue The value returned if the resolved value is undefined.
  * @return Returns the resolved value.
  */
-const get = (object, path, defaultValue) =>
-  path.split('.').reduce((obj, key) => obj && obj[key], object) || defaultValue;
+function get(object, path) {
+  return path.split('.').reduce((obj, key) => obj && obj[key], object);
+}
 
 /**
  * @param {Object} args


### PR DESCRIPTION
This PR refactors `<ExplorerTable>` component in preparation for the upcoming migration to [React Table](https://react-table.tanstack.com/) 7.

The focus of this refactoring effort includes:

* Use function component
* Extract simple methods as function outside the component
* Simply and reduce boilerplate