### PR TITLE
Use top bar menu UI PEDS-613 PEDS-620

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -128,6 +128,18 @@ Below is an example, with inline comments describing what each JSON block config
           "link": "https://gen3.org/resources/user/",
           "name": "Documentation"
         }
+      ],
+      "menuItems": [
+        {
+          "icon": "external-link",
+          "link": "https://path.to.privacy.policy",
+          "name": "Privacy Policy"
+        },
+        {
+          "icon": "external-link",
+          "link": "https://path.to.terms.and.conditions",
+          "name": "Terms & Conditions"
+        }
       ]
     },
     // what to display on the login page (/login)

--- a/src/components/layout/TopBar.css
+++ b/src/components/layout/TopBar.css
@@ -10,24 +10,18 @@
   width: 100%;
 }
 
-.top-bar--flex-center {
-  display: flex;
-  justify-content: center;
-}
-
 @media screen and (max-width: 1090px) {
   .top-bar {
     justify-content: flex-end;
   }
 
-  .top-bar--hidden-lg-and-down {
+  .top-bar .hidden-lg-and-down {
     display: none;
   }
 }
 
 @media screen and (max-width: 820px) {
-  .top-bar {
-    flex-flow: column;
-    align-items: center;
+  .top-bar .hidden-md-and-down {
+    display: none;
   }
 }

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { TopBarButton, TopBarLink } from './TopBarItems';
+import { TopBarLink } from './TopBarItems';
+import TopBarMenu from './TopBarMenu';
 import './TopBar.css';
 
 /**
@@ -14,7 +15,7 @@ import './TopBar.css';
 /**
  * NavBar renders row of nav-items of form { name, icon, link }
  * @typedef {Object} TopBarProps
- * @property {{ items: TopBarItem[] }} config
+ * @property {{ items: TopBarItem[]; menuItems: TopBarItem[] }} config
  * @property {boolean} isAdminUser
  * @property {React.MouseEventHandler<HTMLButtonElement>} onLogoutClick
  * @property {string} [username]
@@ -56,15 +57,11 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
             )
         )}
         {username !== undefined ? (
-          <>
-            <TopBarLink
-              icon='user-circle'
-              name={username}
-              isActive={location.pathname === '/identity'}
-              to='/identity'
-            />
-            <TopBarButton icon='exit' name='Logout' onClick={onLogoutClick} />
-          </>
+          <TopBarMenu
+            items={config.menuItems}
+            onLogoutClick={onLogoutClick}
+            username={username}
+          />
         ) : (
           location.pathname !== '/login' && (
             <TopBarLink icon='exit' name='Login' to='/login' />
@@ -78,6 +75,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
 TopBar.propTypes = {
   config: PropTypes.exact({
     items: PropTypes.array.isRequired,
+    menuItems: PropTypes.array.isRequired,
   }).isRequired,
   isAdminUser: PropTypes.bool.isRequired,
   onLogoutClick: PropTypes.func.isRequired,

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -32,10 +32,11 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
 
   return (
     <nav className='top-bar' aria-label='Top Navigation'>
-      <div className='top-bar--hidden-lg-and-down'>
+      <div>
         {leftItems.map((item) => (
           <TopBarLink
             key={item.link}
+            className='hidden-lg-and-down'
             name={item.name}
             icon={item.icon}
             isActive={location.pathname === item.link}
@@ -43,12 +44,13 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           />
         ))}
       </div>
-      <div className='top-bar--flex-center'>
+      <div>
         {rightItems.map(
           (item) =>
             (item.link !== '/submission' || isAdminUser) && (
               <TopBarLink
                 key={item.link}
+                className='hidden-md-and-down'
                 name={item.name}
                 icon={item.icon}
                 isActive={location.pathname === item.link}

--- a/src/components/layout/TopBarItems.css
+++ b/src/components/layout/TopBarItems.css
@@ -16,21 +16,8 @@ button.top-bar-item {
   border-radius: 0;
 }
 
-@media screen and (max-width: 820px) {
-  .top-bar-item {
-    border-right: none;
-    width: unset;
-  }
-}
-
 .top-bar-item:last-child {
   border-right: 0;
-}
-
-@media screen and (max-width: 820px) {
-  .top-bar-item:nth-child(-n + 2) {
-    display: none;
-  }
 }
 
 .top-bar-item__content {

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -2,8 +2,14 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import './TopBarItems.css';
 
+/** @param {string[]} args */
+function joinClassNames(...args) {
+  return args.filter(Boolean).join(' ');
+}
+
 /**
  * @typedef {Object} TopBarButtonProps
+ * @property {string} [className]
  * @property {string} [icon]
  * @property {boolean} [isActive]
  * @property {string} name
@@ -11,13 +17,23 @@ import './TopBarItems.css';
  */
 
 /** @param {TopBarButtonProps} props */
-export function TopBarButton({ icon, isActive = false, name, onClick }) {
-  const className = isActive
+export function TopBarButton({
+  className,
+  icon,
+  isActive = false,
+  name,
+  onClick,
+}) {
+  const baseClassName = isActive
     ? 'top-bar-item top-bar-item--active'
     : 'top-bar-item';
 
   return (
-    <button className={className} onClick={onClick} type='button'>
+    <button
+      className={joinClassNames(baseClassName, className)}
+      onClick={onClick}
+      type='button'
+    >
       <span className='top-bar-item__content body-typo'>
         {name}
         {icon && <i className={`g3-icon g3-icon--${icon}`} />}
@@ -27,6 +43,7 @@ export function TopBarButton({ icon, isActive = false, name, onClick }) {
 }
 
 TopBarButton.propTypes = {
+  className: PropTypes.string,
   icon: PropTypes.string,
   isActive: PropTypes.bool,
   name: PropTypes.string.isRequired,
@@ -35,6 +52,7 @@ TopBarButton.propTypes = {
 
 /**
  * @typedef {Object} TopBarLinkProps
+ * @property {string} [className]
  * @property {string} [icon]
  * @property {boolean} [isActive]
  * @property {string} name
@@ -42,8 +60,8 @@ TopBarButton.propTypes = {
  */
 
 /** @param {TopBarLinkProps} props */
-export function TopBarLink({ icon, isActive = false, name, to }) {
-  const className = isActive
+export function TopBarLink({ className, icon, isActive = false, name, to }) {
+  const baseClassName = isActive
     ? 'top-bar-item top-icon-buton--active'
     : 'top-bar-item';
   const content = (
@@ -55,7 +73,7 @@ export function TopBarLink({ icon, isActive = false, name, to }) {
 
   return to.startsWith('http') ? (
     <a
-      className={className}
+      className={joinClassNames(baseClassName, className)}
       target='_blank'
       rel='noopener noreferrer'
       href={to}
@@ -63,13 +81,14 @@ export function TopBarLink({ icon, isActive = false, name, to }) {
       {content}
     </a>
   ) : (
-    <Link className={className} to={to}>
+    <Link className={joinClassNames(baseClassName, className)} to={to}>
       {content}
     </Link>
   );
 }
 
 TopBarLink.propTypes = {
+  className: PropTypes.string,
   icon: PropTypes.string,
   isActive: PropTypes.bool,
   name: PropTypes.string.isRequired,

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -1,0 +1,48 @@
+.top-bar-menu__items {
+  background-color: var(--g3-color__white);
+  border: 1px solid var(--g3-color__silver);
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 10%), 0 4px 11px hsl(0deg 0% 0% / 10%);
+  margin-top: 0.25rem;
+  margin-right: 1rem;
+  min-width: 200px;
+  padding: 0.5rem;
+  position: absolute;
+  right: 0;
+  transform-origin: top right;
+  z-index: 1;
+}
+
+.top-bar-menu__items > hr {
+  border-top: 0.5px solid var(--g3-color__silver);
+  margin: 0.25rem;
+}
+
+.top-bar-menu__item > * {
+  background-color: var(--g3-color__white);
+  border: none;
+  border-radius: 4px;
+  color: var(--g3-color__gray);
+  display: block;
+  font-weight: var(--g3-font__semi-bold-weight);
+  height: 100%;
+  line-height: initial;
+  margin-bottom: 2px;
+  padding: 0.5rem 1rem;
+  text-align: initial;
+  width: 100%;
+}
+
+.top-bar-menu__item > *:hover {
+  background-color: var(--g3-color__silver);
+  color: var(--g3-color__gray);
+}
+
+.top-bar-menu__item i.g3-icon {
+  background-color: var(--g3-color__gray);
+  height: 14px;
+  margin-left: 0.25rem;
+  position: relative;
+  top: 2px;
+  width: 14px;
+}

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { TopBarButton } from './TopBarItems';
+import './TopBarMenu.css';
+
+/**
+ * @param {Object} props
+ * @param {{ icon?: string; link: string; name: string; }[]} [props.items]
+ * @param {React.MouseEventHandler<HTMLButtonElement>} props.onLogoutClick
+ * @param {string} props.username
+ */
+function TopBarMenu({ items, onLogoutClick, username }) {
+  const [showMenu, setShowMenu] = useState(false);
+  function handleMenuBlur(e) {
+    if (showMenu && !e.currentTarget.contains(e.relatedTarget))
+      setShowMenu(false);
+  }
+  function toggleMenu() {
+    setShowMenu((s) => !s);
+  }
+  return (
+    <span onBlur={handleMenuBlur}>
+      <TopBarButton
+        isActive={showMenu}
+        icon='user-circle'
+        name={username}
+        onClick={toggleMenu}
+      />
+      {showMenu && (
+        <ul className='top-bar-menu__items'>
+          <li className='top-bar-menu__item'>
+            <Link to='/identity'>View Profile</Link>
+          </li>
+          {items?.map((item) => (
+            <li key={item.link} className='top-bar-menu__item'>
+              <a href={item.link} target='_blank' rel='noopener noreferrer'>
+                {item.name}
+                {item.icon && <i className={`g3-icon g3-icon--${item.icon}`} />}
+              </a>
+            </li>
+          ))}
+          <hr />
+          <li className='top-bar-menu__item'>
+            <button onClick={onLogoutClick} type='button'>
+              Logout <i className='g3-icon g3-icon--exit' />
+            </button>
+          </li>
+        </ul>
+      )}
+    </span>
+  );
+}
+
+TopBarMenu.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.exact({
+      icon: PropTypes.string,
+      link: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+  onLogoutClick: PropTypes.func.isRequired,
+  username: PropTypes.string.isRequired,
+};
+
+export default TopBarMenu;


### PR DESCRIPTION
Tickets: [PEDS-613](https://pcdc.atlassian.net/browse/PEDS-613), [PEDS-620](https://pcdc.atlassian.net/browse/PEDS-620)

This PR implements the dropdown menu UI to place certain items on the top bar. This allows certain top bar items to be always visible & accessible regardless of the screen size while avoiding crowding out the top bar with too many items to display.

Here's a simple demo:

https://user-images.githubusercontent.com/22449454/145304127-d3be249a-8962-497e-9430-3eb754acf68b.mov


The dropdown menu uses the username as the button to toggle menu items, which has "View Profile" and "Logout" items by default. In addition to the default ones, more menu items can be provided via a new config option `components.topBar.menuItems`. Its value looks mostly like that of the existing option, `components.topBar.items` except that a "menu item" does not handle `"leftOrientation"` option. See the updated documentation in `docs/portal_config.md`