### PR TITLE
Add acron to dependencies explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9146,6 +9146,12 @@
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
+            "acorn": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "dev": true
+            },
             "cacache": {
               "version": "12.0.4",
               "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
@@ -10526,6 +10532,14 @@
             "terser-webpack-plugin": "^1.4.3",
             "watchpack": "^1.7.4",
             "webpack-sources": "^1.4.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "dev": true
+            }
           }
         }
       }
@@ -10703,6 +10717,12 @@
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
+            "acorn": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "dev": true
+            },
             "watchpack": {
               "version": "1.7.5",
               "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
@@ -11210,6 +11230,12 @@
             "webpack-sources": "^1.4.1"
           },
           "dependencies": {
+            "acorn": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "dev": true
+            },
             "cacache": {
               "version": "12.0.4",
               "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
@@ -11884,6 +11910,14 @@
             "terser-webpack-plugin": "^1.4.3",
             "watchpack": "^1.7.4",
             "webpack-sources": "^1.4.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "dev": true
+            }
           }
         }
       }
@@ -13508,10 +13542,9 @@
       "integrity": "sha512-SOLzdaQkY6ecPKYRDDg+MY1WoGgXA34cIvYJNNoBMGGUswHmlauU2Hy0UL96vW0Fs/LgFbMUjD+6vqzWTldIYQ=="
     },
     "acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
     },
     "acorn-globals": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@svgr/webpack": "^6.1.1",
     "ace-builds": "^1.4.13",
+    "acorn": "^8.6.0",
     "antd": "^4.17.3",
     "autoprefixer": "^10.4.0",
     "babel-loader": "^8.2.3",


### PR DESCRIPTION
This PR fixes `Error: Cannot find module 'acorn'` caused by NPM failing to correctly resolve conflicts from multiple versions of the said packaged in the dependency graph where some marked as "dev" only. The fixes involves simply adding `acorn` to the dependencies explicitly.