### PR TITLE
Update survival UI PEDS-619

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
+import { defaultFilterSet as survivalDefaultFilterSet } from '../ExplorerSurvivalAnalysis/ControlForm';
 import { stringifyFilters } from './utils';
 import './ExplorerFilterSet.css';
 import './typedef';
@@ -169,6 +170,8 @@ function FilterSetCreateForm({
   function validate() {
     if (filterSet.name === '')
       setError({ isError: true, message: 'Name is required!' });
+    else if (filterSet.name === survivalDefaultFilterSet.name)
+      setError({ isError: true, message: 'Name is reserved!' });
     else if (filterSets.filter((c) => c.name === filterSet.name).length > 0)
       setError({ isError: true, message: 'Name is already in use!' });
     else setError({ isError: false, message: '' });

--- a/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
@@ -5,26 +5,6 @@ import './typedef';
 const FILTER_SET_URL = '/amanuensis/filter-set';
 
 /**
- * @returns {Promise<ExplorerFilterSet[]>}
- */
-export function fetchFilterSets() {
-  return fetchWithCreds({
-    path: FILTER_SET_URL,
-    method: 'GET',
-  }).then(({ response, data, status }) => {
-    if (status !== 200) throw response.statusText;
-    if (
-      data === null ||
-      typeof data !== 'object' ||
-      data.searches === undefined ||
-      !Array.isArray(data.searches)
-    )
-      throw new Error('Error: Incorrect Response Data');
-    return data.searches;
-  });
-}
-
-/**
  * @param {ExplorerFilterSet} filterSet
  * @returns {Promise<ExplorerFilterSet>}
  */

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useState } from 'react';
+import PropTypes from 'prop-types';
+import { fetchWithCreds } from '../actions';
+import './typedef';
+
+const FILTER_SET_URL = '/amanuensis/filter-set';
+
+/** @returns {Promise<ExplorerFilterSet[]>} */
+function fetchFilterSets() {
+  return fetchWithCreds({
+    path: FILTER_SET_URL,
+    method: 'GET',
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    if (
+      data === null ||
+      typeof data !== 'object' ||
+      data.searches === undefined ||
+      !Array.isArray(data.searches)
+    )
+      throw new Error('Error: Incorrect Response Data');
+    return data.searches;
+  });
+}
+
+/**
+ * @typedef {Object} ExplorerFilterSetsContext
+ * @property {ExplorerFilterSet[]} filterSets
+ * @property {() => Promise<void>} refreshFilterSets
+ */
+
+/** @type {React.Context<ExplorerFilterSetsContext>} */
+const ExplorerFilterSetsContext = createContext(null);
+
+/** @type {ExplorerFilterSet[]} */
+const emptyFilterSets = [];
+export function ExplorerFilterSetsProvider({ children }) {
+  const [filterSets, setFilterSets] = useState(emptyFilterSets);
+  return (
+    <ExplorerFilterSetsContext.Provider
+      value={{
+        filterSets,
+        refreshFilterSets: () => fetchFilterSets().then(setFilterSets),
+      }}
+    >
+      {children}
+    </ExplorerFilterSetsContext.Provider>
+  );
+}
+
+ExplorerFilterSetsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useExplorerFilterSets = () =>
+  useContext(ExplorerFilterSetsContext);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -11,7 +11,11 @@ const ControlFormSelect = ({ label, ...selectProps }) => (
   <SimpleInputField
     label={label}
     input={
-      <Select {...selectProps} clearable={false} theme={overrideSelectTheme} />
+      <Select
+        {...selectProps}
+        isClearable={false}
+        theme={overrideSelectTheme}
+      />
     }
   />
 );

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -95,19 +95,20 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
 
   return (
     <form className='explorer-survival-analysis__control-form'>
-      <ControlFormInput
-        id='survival-time-interval'
-        label='Time interval'
-        type='number'
-        min={1}
-        max={5}
-        step={1}
-        onBlur={validateNumberInput}
+      <ControlFormSelect
+        inputId='survival-type'
+        isDisabled
+        label='Survival type'
+        options={[
+          { label: 'Overall Survival', value: 'all' },
+          { label: 'Event-Free Survival (EFS)', value: 'efs' },
+        ]}
         onChange={(e) => {
-          setLocalTimeInterval(Number.parseInt(e.target.value, 10));
+          setSurvivalType(e);
+          setShouldUpdateResults(true);
           setIsInputChanged(true);
         }}
-        value={localTimeInterval}
+        value={survivalType}
       />
       <ControlFormInput
         id='survival-start-time'
@@ -138,20 +139,19 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
         }}
         value={endTime}
       />
-      <ControlFormSelect
-        inputId='survival-type'
-        isDisabled
-        label='Survival type'
-        options={[
-          { label: 'Overall Survival', value: 'all' },
-          { label: 'Event-Free Survival (EFS)', value: 'efs' },
-        ]}
+      <ControlFormInput
+        id='survival-time-interval'
+        label='Time interval'
+        type='number'
+        min={1}
+        max={5}
+        step={1}
+        onBlur={validateNumberInput}
         onChange={(e) => {
-          setSurvivalType(e);
-          setShouldUpdateResults(true);
+          setLocalTimeInterval(Number.parseInt(e.target.value, 10));
           setIsInputChanged(true);
         }}
-        value={survivalType}
+        value={localTimeInterval}
       />
       <div className='explorer-survival-analysis__button-group'>
         <Button label='Reset' buttonType='default' onClick={resetUserInput} />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -206,6 +206,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
       ) : (
         usedFilterSets.map((filterSet, i) => (
           <FilterSetCard
+            key={filterSet.id}
             filterSet={filterSet}
             label={`${i + 1}. ${filterSet.name}`}
             onClose={() => {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -4,6 +4,7 @@ import Select from 'react-select';
 import Button from '../../gen3-ui-component/components/Button';
 import SimpleInputField from '../../components/SimpleInputField';
 import { overrideSelectTheme } from '../../utils';
+import FilterSetCard from './FilterSetCard';
 import './typedef';
 
 /** @param {{ label: string; [x: string]: any }} props */
@@ -38,6 +39,35 @@ const survivalTypeOptions = [
   { label: 'Event-Free Survival (EFS)', value: 'efs' },
 ];
 
+/** @type {ExplorerFilterSet[]} */
+const mockFilterSets = [
+  {
+    id: 0,
+    name: 'Foo Bar Baz',
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    filters: { sex: { selectedValues: ['Female'] } },
+  },
+  {
+    id: 1,
+    name: 'Bar Baz Foo',
+    description:
+      'Mauris luctus nisi quis urna pretium, id faucibus libero imperdiet.',
+    filters: { race: { selectedValues: ['Asian'] } },
+  },
+  {
+    id: 2,
+    name: 'Baz Foo Bar',
+    description:
+      'Etiam fringilla odio ornare, vehicula sapien molestie, tempor elit.',
+    filters: { ethnicity: { selectedValues: ['Not+Hispanic+or+Latino'] } },
+  },
+];
+
+const mockFilterSetOptions = mockFilterSets.map((filterSet) => ({
+  label: filterSet.name,
+  value: filterSet,
+}));
+
 /**
  * @param {Object} prop
  * @param {UserInputSubmitHandler} prop.onSubmit
@@ -50,6 +80,8 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
+  const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
+  const [usedFilterSets, setUsedFilterSets] = useState([]);
 
   const [isInputChanged, setIsInputChanged] = useState(true);
   useEffect(() => {
@@ -157,6 +189,48 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
         }}
         value={localTimeInterval}
       />
+      <div className='explorer-survival-analysis__filter-set-select'>
+        <Select
+          inputId='survival-filter-sets'
+          placeholder='Select Filter Set to analyze'
+          options={mockFilterSetOptions}
+          onChange={setSelectFilterSetOption}
+          value={selectFilterSetOption}
+          theme={overrideSelectTheme}
+        />
+        <Button
+          label='Add'
+          buttonType='default'
+          enabled={selectFilterSetOption !== null}
+          onClick={() => {
+            setUsedFilterSets((prevFilterSets) => [
+              ...prevFilterSets,
+              selectFilterSetOption.value,
+            ]);
+            setSelectFilterSetOption(null);
+            setShouldUpdateResults(true);
+            setIsInputChanged(true);
+          }}
+        />
+      </div>
+      {usedFilterSets.length === 0 ? (
+        <span style={{ fontStyle: 'italic' }}>
+          Nothing to show here. Try select and use Filter Sets for survival
+          analysis.
+        </span>
+      ) : (
+        usedFilterSets.map((filterSet, i) => (
+          <FilterSetCard
+            filterSet={filterSet}
+            label={`${i + 1}. ${filterSet.name}`}
+            onClose={() =>
+              setUsedFilterSets((prevFilterSets) =>
+                prevFilterSets.filter(({ id }) => id !== filterSet.id)
+              )
+            }
+          />
+        ))
+      )}
       <div className='explorer-survival-analysis__button-group'>
         <Button label='Reset' buttonType='default' onClick={resetUserInput} />
         <Button

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -53,13 +53,14 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [endTime, setEndTime] = useState(20);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
+  const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
+  const [usedFilterSets, setUsedFilterSets] = useState([]);
   const { filterSets } = useExplorerFilterSets();
   const filterSetOptions = filterSets.map((filterSet) => ({
     label: filterSet.name,
     value: filterSet,
+    isDisabled: usedFilterSets.some(({ id }) => id === filterSet.id),
   }));
-  const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
-  const [usedFilterSets, setUsedFilterSets] = useState([]);
 
   const [isInputChanged, setIsInputChanged] = useState(true);
   useEffect(() => {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -224,7 +224,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
           label='Apply'
           buttonType='primary'
           onClick={submitUserInput}
-          enabled={isInputChanged}
+          enabled={isInputChanged && usedFilterSets.length > 0}
         />
       </div>
     </form>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -40,6 +40,9 @@ const survivalTypeOptions = [
   { label: 'Event-Free Survival (EFS)', value: 'efs' },
 ];
 
+/** @type {ExplorerFilterSet[]} */
+const emptyFilterSets = [];
+
 /**
  * @param {Object} prop
  * @param {UserInputSubmitHandler} prop.onSubmit
@@ -54,7 +57,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
   const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
-  const [usedFilterSets, setUsedFilterSets] = useState([]);
+  const [usedFilterSets, setUsedFilterSets] = useState(emptyFilterSets);
   const { filterSets } = useExplorerFilterSets();
   const filterSetOptions = filterSets.map((filterSet) => ({
     label: filterSet.name,
@@ -89,6 +92,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
       endTime,
       efsFlag: survivalType.value === 'efs',
       shouldUpdateResults,
+      usedFilterSets,
     });
     setIsInputChanged(false);
     setShouldUpdateResults(false);
@@ -106,6 +110,8 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
     setStartTime(0);
     setEndTime(20);
     setSurvivalType(survivalTypeOptions[0]);
+    setUsedFilterSets(emptyFilterSets);
+    setIsInputChanged(true);
   };
 
   return (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -43,14 +43,21 @@ const survivalTypeOptions = [
 /** @type {ExplorerFilterSet[]} */
 const emptyFilterSets = [];
 
+/** @type {ExplorerFilterSet} */
+const defaultFilterSet = {
+  name: '*** All Subjects ***',
+  description: '',
+  filters: {},
+  id: -1,
+};
+
 /**
  * @param {Object} prop
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
  * @param {boolean} prop.isError
- * @param {boolean} prop.isFilterChanged
  */
-const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
+const ControlForm = ({ onSubmit, timeInterval, isError }) => {
   const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
@@ -59,21 +66,18 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
   const [usedFilterSets, setUsedFilterSets] = useState(emptyFilterSets);
   const { filterSets } = useExplorerFilterSets();
-  const filterSetOptions = filterSets.map((filterSet) => ({
-    label: filterSet.name,
-    value: filterSet,
-    isDisabled: usedFilterSets.some(({ id }) => id === filterSet.id),
-  }));
+  const filterSetOptions = [defaultFilterSet, ...filterSets].map(
+    (filterSet) => ({
+      label: filterSet.name,
+      value: filterSet,
+      isDisabled: usedFilterSets.some(({ id }) => id === filterSet.id),
+    })
+  );
 
-  const [isInputChanged, setIsInputChanged] = useState(true);
+  const [isInputChanged, setIsInputChanged] = useState(false);
   useEffect(() => {
     if (!isInputChanged && isError) setIsInputChanged(true);
   }, [isInputChanged, isError]);
-
-  const [shouldUpdateResults, setShouldUpdateResults] = useState(true);
-  useEffect(() => {
-    if (isFilterChanged && !shouldUpdateResults) setShouldUpdateResults(true);
-  }, [isFilterChanged]);
 
   const validateNumberInput = (
     /** @type {{ target: { value: string, min: string, max: string }}} */ e
@@ -91,11 +95,9 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
       startTime,
       endTime,
       efsFlag: survivalType.value === 'efs',
-      shouldUpdateResults,
       usedFilterSets,
     });
     setIsInputChanged(false);
-    setShouldUpdateResults(false);
   };
 
   const resetUserInput = () => {
@@ -111,7 +113,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
     setEndTime(20);
     setSurvivalType(survivalTypeOptions[0]);
     setUsedFilterSets(emptyFilterSets);
-    setIsInputChanged(true);
+    setIsInputChanged(false);
   };
 
   return (
@@ -126,7 +128,6 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
         ]}
         onChange={(e) => {
           setSurvivalType(e);
-          setShouldUpdateResults(true);
           setIsInputChanged(true);
         }}
         value={survivalType}
@@ -193,7 +194,6 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
               selectFilterSetOption.value,
             ]);
             setSelectFilterSetOption(null);
-            setShouldUpdateResults(true);
             setIsInputChanged(true);
           }}
         />
@@ -212,7 +212,6 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
               setUsedFilterSets((prevFilterSets) =>
                 prevFilterSets.filter(({ id }) => id !== filterSet.id)
               );
-              setShouldUpdateResults(true);
               setIsInputChanged(true);
             }}
           />
@@ -224,7 +223,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
           label='Apply'
           buttonType='primary'
           onClick={submitUserInput}
-          enabled={isInputChanged || isFilterChanged}
+          enabled={isInputChanged}
         />
       </div>
     </form>
@@ -235,7 +234,6 @@ ControlForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   timeInterval: PropTypes.number.isRequired,
   isError: PropTypes.bool,
-  isFilterChanged: PropTypes.bool,
 };
 
 export default ControlForm;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -202,11 +202,13 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
           <FilterSetCard
             filterSet={filterSet}
             label={`${i + 1}. ${filterSet.name}`}
-            onClose={() =>
+            onClose={() => {
               setUsedFilterSets((prevFilterSets) =>
                 prevFilterSets.filter(({ id }) => id !== filterSet.id)
-              )
-            }
+              );
+              setShouldUpdateResults(true);
+              setIsInputChanged(true);
+            }}
           />
         ))
       )}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -29,7 +29,6 @@ ControlFormInput.propTypes = {
   label: PropTypes.string,
 };
 
-const emptySelectOption = { label: 'Select...', value: '' };
 const survivalTypeOptions = [
   { label: 'Overall Survival', value: 'all' },
   { label: 'Event-Free Survival (EFS)', value: 'efs' },
@@ -37,23 +36,12 @@ const survivalTypeOptions = [
 
 /**
  * @param {Object} prop
- * @param {FactorItem[]} prop.factors
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
  * @param {boolean} prop.isError
  * @param {boolean} prop.isFilterChanged
  */
-const ControlForm = ({
-  factors,
-  onSubmit,
-  timeInterval,
-  isError,
-  isFilterChanged,
-}) => {
-  const [factorVariable, setFactorVariable] = useState(emptySelectOption);
-  const [stratificationVariable, setStratificationVariable] = useState(
-    emptySelectOption
-  );
+const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
@@ -79,14 +67,8 @@ const ControlForm = ({
     else if (max && max < value) setLocalTimeInterval(max);
   };
 
-  const withEmptyOption = (
-    /** @type {{ label: string, value: string }[]} */ options
-  ) => [emptySelectOption, ...options];
-
   const submitUserInput = () => {
     onSubmit({
-      factorVariable: factorVariable.value,
-      stratificationVariable: stratificationVariable.value,
       timeInterval: localTimeInterval,
       startTime,
       endTime,
@@ -99,19 +81,12 @@ const ControlForm = ({
 
   const resetUserInput = () => {
     setIsInputChanged(
-      factorVariable.value !== emptySelectOption.value ||
-        stratificationVariable.value !== emptySelectOption.value ||
-        localTimeInterval !== 2 ||
+      localTimeInterval !== 2 ||
         startTime !== 0 ||
         endTime !== 20 ||
         survivalType !== survivalTypeOptions[0]
     );
 
-    if (factorVariable.value !== '' || stratificationVariable.value !== '')
-      setShouldUpdateResults(true);
-
-    setFactorVariable(emptySelectOption);
-    setStratificationVariable(emptySelectOption);
     setLocalTimeInterval(2);
     setStartTime(0);
     setEndTime(20);
@@ -120,34 +95,6 @@ const ControlForm = ({
 
   return (
     <form className='explorer-survival-analysis__control-form'>
-      <ControlFormSelect
-        inputId='survival-factor-variable'
-        label='Factor variable'
-        options={withEmptyOption(factors)}
-        onChange={(e) => {
-          if (e.value === '' || e.value === stratificationVariable)
-            setStratificationVariable(emptySelectOption);
-
-          setFactorVariable(e);
-          setShouldUpdateResults(true);
-          setIsInputChanged(true);
-        }}
-        value={factorVariable}
-      />
-      <ControlFormSelect
-        inputId='survival-stratification-variable'
-        label='Stratification variable'
-        options={withEmptyOption(
-          factors.filter(({ value }) => value !== factorVariable.value)
-        )}
-        isDisabled={factorVariable.value === ''}
-        onChange={(e) => {
-          setStratificationVariable(e);
-          setShouldUpdateResults(true);
-          setIsInputChanged(true);
-        }}
-        value={stratificationVariable}
-      />
       <ControlFormInput
         id='survival-time-interval'
         label='Time interval'
@@ -220,12 +167,6 @@ const ControlForm = ({
 };
 
 ControlForm.propTypes = {
-  factors: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string,
-      value: PropTypes.string,
-    })
-  ).isRequired,
   onSubmit: PropTypes.func.isRequired,
   timeInterval: PropTypes.number.isRequired,
   isError: PropTypes.bool,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -4,6 +4,7 @@ import Select from 'react-select';
 import Button from '../../gen3-ui-component/components/Button';
 import SimpleInputField from '../../components/SimpleInputField';
 import { overrideSelectTheme } from '../../utils';
+import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import FilterSetCard from './FilterSetCard';
 import './typedef';
 
@@ -39,35 +40,6 @@ const survivalTypeOptions = [
   { label: 'Event-Free Survival (EFS)', value: 'efs' },
 ];
 
-/** @type {ExplorerFilterSet[]} */
-const mockFilterSets = [
-  {
-    id: 0,
-    name: 'Foo Bar Baz',
-    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    filters: { sex: { selectedValues: ['Female'] } },
-  },
-  {
-    id: 1,
-    name: 'Bar Baz Foo',
-    description:
-      'Mauris luctus nisi quis urna pretium, id faucibus libero imperdiet.',
-    filters: { race: { selectedValues: ['Asian'] } },
-  },
-  {
-    id: 2,
-    name: 'Baz Foo Bar',
-    description:
-      'Etiam fringilla odio ornare, vehicula sapien molestie, tempor elit.',
-    filters: { ethnicity: { selectedValues: ['Not+Hispanic+or+Latino'] } },
-  },
-];
-
-const mockFilterSetOptions = mockFilterSets.map((filterSet) => ({
-  label: filterSet.name,
-  value: filterSet,
-}));
-
 /**
  * @param {Object} prop
  * @param {UserInputSubmitHandler} prop.onSubmit
@@ -80,6 +52,12 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
+
+  const { filterSets } = useExplorerFilterSets();
+  const filterSetOptions = filterSets.map((filterSet) => ({
+    label: filterSet.name,
+    value: filterSet,
+  }));
   const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
   const [usedFilterSets, setUsedFilterSets] = useState([]);
 
@@ -193,7 +171,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError, isFilterChanged }) => {
         <Select
           inputId='survival-filter-sets'
           placeholder='Select Filter Set to analyze'
-          options={mockFilterSetOptions}
+          options={filterSetOptions}
           onChange={setSelectFilterSetOption}
           value={selectFilterSetOption}
           theme={overrideSelectTheme}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -44,7 +44,7 @@ const survivalTypeOptions = [
 const emptyFilterSets = [];
 
 /** @type {ExplorerFilterSet} */
-const defaultFilterSet = {
+export const defaultFilterSet = {
   name: '*** All Subjects ***',
   description: '',
   filters: {},

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -89,15 +89,23 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
     else if (max && max < value) setLocalTimeInterval(max);
   };
 
+  const [shouldSubmit, setShouldSubmit] = useState(false);
+  useEffect(() => {
+    if (shouldSubmit) {
+      onSubmit({
+        timeInterval: localTimeInterval,
+        startTime,
+        endTime,
+        efsFlag: survivalType.value === 'efs',
+        usedFilterSets,
+      });
+      setShouldSubmit(false);
+    }
+  }, [shouldSubmit]);
+
   const submitUserInput = () => {
-    onSubmit({
-      timeInterval: localTimeInterval,
-      startTime,
-      endTime,
-      efsFlag: survivalType.value === 'efs',
-      usedFilterSets,
-    });
     setIsInputChanged(false);
+    setShouldSubmit(true);
   };
 
   const resetUserInput = () => {
@@ -114,6 +122,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
     setSurvivalType(survivalTypeOptions[0]);
     setUsedFilterSets(emptyFilterSets);
     setIsInputChanged(false);
+    setShouldSubmit(true);
   };
 
   return (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -4,7 +4,7 @@
   flex-wrap: wrap;
   justify-content: space-around;
   margin-top: 10px;
-  padding: 12px;
+  padding: 12px 12px 3rem;
 }
 
 .explorer-survival-analysis__warning {
@@ -40,12 +40,19 @@
 }
 
 .explorer-survival-analysis__button-group {
-  max-width: 200px;
-  min-height: 100px;
-  margin: 3rem auto 1rem;
+  background-color: var(--g3-color__white);
+  border-top: 1px solid var(--g3-color__smoke);
+  bottom: 0;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  left: var(--dashboard__sidebar-width);
+  padding: 1rem 1rem 2rem;
+  position: fixed;
+  width: inherit;
+  z-index: 1;
+}
+
+.explorer-survival-analysis__button-group > button {
+  margin-left: 1rem;
 }
 
 .explorer-survival-analysis__survival-plot {
@@ -86,6 +93,18 @@
   height: 100%;
   width: 90%;
   margin: auto;
+}
+
+@media screen and (max-width: 1090px) {
+  .explorer-survival-analysis {
+    padding-bottom: 5rem;
+  }
+  .explorer-survival-analysis__button-group {
+    left: 0;
+    padding-left: 0;
+    padding-bottom: 4rem;
+    justify-content: center;
+  }
 }
 
 /* Medium screen and less */

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -39,6 +39,46 @@
   width: 100%;
 }
 
+.explorer-survival-analysis__filter-set-card {
+  background-color: var(--g3-color__white);
+  border: 1px solid var(--g3-color__silver);
+  margin-top: 1rem;
+  padding: 0.75rem;
+}
+
+.explorer-survival-analysis__filter-set-card button {
+  background-color: initial;
+  border: initial;
+  border-radius: initial;
+  height: initial;
+  margin: 0.25rem;
+  padding: initial;
+  width: initial;
+}
+
+.explorer-survival-analysis__filter-set-card i {
+  background-color: var(--g3-color__bg-coal);
+}
+
+.explorer-survival-analysis__filter-set-card > header {
+  align-items: center;
+  color: var(--g3-color__bg-coal);
+  display: flex;
+  font-weight: var(--g3-font__semi-bold-weight);
+  justify-content: space-between;
+}
+
+.explorer-survival-analysis__filter-set-card > header > *:first-child {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  padding: 0.25rem;
+}
+
+.explorer-survival-analysis__filter-set-card > header > *:first-child > i {
+  margin-right: 0.5rem;
+}
+
 .explorer-survival-analysis__button-group {
   background-color: var(--g3-color__white);
   border-top: 1px solid var(--g3-color__smoke);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -79,6 +79,17 @@
   margin-right: 0.5rem;
 }
 
+.explorer-survival-analysis__filter-set-select {
+  margin: 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.explorer-survival-analysis__filter-set-select > *:first-child {
+  flex-grow: 1;
+  margin-right: 1rem;
+}
+
 .explorer-survival-analysis__button-group {
   background-color: var(--g3-color__white);
   border-top: 1px solid var(--g3-color__smoke);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -48,13 +48,6 @@
   justify-content: space-between;
 }
 
-.explorer-survival-analysis__pval {
-  margin-left: 12px;
-  padding: 0.5rem 1rem;
-  height: 1.25rem;
-  font-size: 1rem;
-}
-
 .explorer-survival-analysis__survival-plot {
   margin: 12px;
   min-height: 300px;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import SimpleInputField from '../../components/SimpleInputField';
+import { stringifyFilters } from '../ExplorerFilterSet/utils';
+
+/**
+ * @typedef {Object} FilterSetCardProps
+ * @property {ExplorerFilterSet} filterSet
+ * @property {string} label
+ * @property {React.MouseEventHandler<HTMLButtonElement>} onClose
+ */
+
+/** @param {FilterSetCardProps} props */
+export default function FilterSetCard({ filterSet, label, onClose }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toggleCard = () => setIsExpanded((s) => !s);
+  return (
+    <div className='explorer-survival-analysis__filter-set-card'>
+      <header>
+        <button type='button' onClick={toggleCard}>
+          <i
+            className={`g3-icon g3-icon--sm g3-icon--chevron-${
+              isExpanded ? 'down' : 'right'
+            }`}
+          />
+          {label}
+        </button>
+        <button aria-label='Clear' type='button' onClick={onClose}>
+          <i className='g3-icon g3-icon--sm g3-icon--cross' />
+        </button>
+      </header>
+      {isExpanded ? (
+        <>
+          <SimpleInputField
+            label='Description'
+            input={
+              <textarea
+                disabled
+                placeholder='No description'
+                value={filterSet.description}
+              />
+            }
+          />
+          <SimpleInputField
+            label='Filters'
+            input={
+              <textarea
+                disabled
+                placeholder='No filters'
+                value={stringifyFilters(filterSet.filters)}
+              />
+            }
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+FilterSetCard.propTypes = {
+  filterSet: PropTypes.object,
+  label: PropTypes.string,
+  onClose: PropTypes.func,
+};

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-import { Fragment, memo } from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import {
   ScatterChart,
@@ -118,11 +118,10 @@ Table.propTypes = {
  * @param {Object} prop
  * @param {RisktableData[]} prop.data
  * @param {number} prop.endTime
- * @param {boolean} prop.isStratified
  * @param {number} prop.startTime
  * @param {number} prop.timeInterval
  */
-function RiskTable({ data, endTime, isStratified, timeInterval, startTime }) {
+function RiskTable({ data, endTime, timeInterval, startTime }) {
   const filteredData = filterRisktableByTime(data, startTime, endTime);
   return (
     <div className='explorer-survival-analysis__risk-table'>
@@ -138,33 +137,7 @@ function RiskTable({ data, endTime, isStratified, timeInterval, startTime }) {
           >
             Number at risk
           </div>
-          {isStratified ? (
-            Object.entries(
-              filteredData.reduce((acc, { group, data }) => {
-                const [factor, stratification] = group;
-                const stratificationKey = JSON.stringify(stratification);
-                const stratificationValue =
-                  acc[stratificationKey] !== undefined
-                    ? [...acc[stratificationKey], { group: [factor], data }]
-                    : [{ group: [factor], data }];
-
-                return { ...acc, [stratificationKey]: stratificationValue };
-              }, {})
-            ).map(([key, data], i, arr) => (
-              <Fragment key={key}>
-                <div className='explorer-survival-analysis__figure-title'>
-                  {JSON.parse(key).value}
-                </div>
-                <Table
-                  data={data}
-                  timeInterval={timeInterval}
-                  isLast={i === arr.length - 1}
-                />
-              </Fragment>
-            ))
-          ) : (
-            <Table data={filteredData} timeInterval={timeInterval} isLast />
-          )}
+          <Table data={filteredData} timeInterval={timeInterval} isLast />
         </>
       )}
     </div>
@@ -189,7 +162,6 @@ RiskTable.propTypes = {
     })
   ).isRequired,
   endTime: PropTypes.number.isRequired,
-  isStratified: PropTypes.bool.isRequired,
   startTime: PropTypes.number.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -117,7 +117,7 @@ function RiskTable({ data, endTime, timeInterval, startTime }) {
     <div className='explorer-survival-analysis__risk-table'>
       {filteredData.length === 0 ? (
         <div className='explorer-survival-analysis__figure-placeholder'>
-          Click "Apply" to get the risk table here.
+          The number at risk table will appear here.
         </div>
       ) : (
         <>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -19,12 +19,7 @@ import './typedef';
 const parseRisktable = (data, timeInterval) => {
   const minTime = data[0].data[0].time;
   return data
-    .flatMap(({ group, data }) =>
-      data.map((d) => ({
-        group: group.length === 0 ? 'All' : group[0].value,
-        ...d,
-      }))
-    )
+    .flatMap(({ name, data }) => data.map((d) => ({ name, ...d })))
     .filter(({ time }) => (time - minTime) % timeInterval === 0);
 };
 
@@ -78,7 +73,7 @@ const Table = ({ data, isLast, timeInterval }) => (
         ticks={getXAxisTicks(data, timeInterval)}
       />
       <YAxis
-        dataKey='group'
+        dataKey='name'
         type='category'
         allowDuplicatedCategory={false}
         axisLine={false}
@@ -102,12 +97,7 @@ Table.propTypes = {
           time: PropTypes.number,
         })
       ),
-      group: PropTypes.arrayOf(
-        PropTypes.exact({
-          variable: PropTypes.string,
-          value: PropTypes.string,
-        })
-      ),
+      name: PropTypes.string,
     })
   ).isRequired,
   isLast: PropTypes.bool.isRequired,
@@ -153,12 +143,7 @@ RiskTable.propTypes = {
           time: PropTypes.number,
         })
       ),
-      group: PropTypes.arrayOf(
-        PropTypes.exact({
-          variable: PropTypes.string,
-          value: PropTypes.string,
-        })
-      ),
+      name: PropTypes.string,
     })
   ).isRequired,
   endTime: PropTypes.number.isRequired,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-shadow */
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { schemeCategory10 } from 'd3-scale-chromatic';
 import {
   ResponsiveContainer,
   LineChart,
@@ -15,12 +16,21 @@ import './typedef';
 
 /**
  * @param {Object} prop
- * @param {ColorScheme} prop.colorScheme
  * @param {SurvivalData[]} prop.data
  * @param {number} prop.endTime
  * @param {number} prop.timeInterval
  */
-const Plot = ({ colorScheme, data, endTime, timeInterval }) => {
+const Plot = ({ data, endTime, timeInterval }) => {
+  const colorScheme = useMemo(() => {
+    /** @type {ColorScheme} */
+    const colorScheme = {};
+    for (const [count, { name }] of data.entries())
+      if (colorScheme[name] === undefined)
+        colorScheme[name] = schemeCategory10[count % 9];
+
+    return colorScheme;
+  }, [data]);
+
   const [opacity, setOpacity] = useState({});
   useEffect(() => {
     const initOpacity = {};
@@ -86,7 +96,6 @@ const Plot = ({ colorScheme, data, endTime, timeInterval }) => {
 };
 
 Plot.propTypes = {
-  colorScheme: PropTypes.object.isRequired,
   data: PropTypes.arrayOf(
     PropTypes.exact({
       data: PropTypes.arrayOf(
@@ -104,13 +113,12 @@ Plot.propTypes = {
 
 /**
  * @param {Object} prop
- * @param {ColorScheme} prop.colorScheme
  * @param {SurvivalData[]} prop.data
  * @param {number} prop.endTime
  * @param {number} prop.startTime
  * @param {number} prop.timeInterval
  */
-function SurvivalPlot({ colorScheme, data, endTime, timeInterval, startTime }) {
+function SurvivalPlot({ data, endTime, timeInterval, startTime }) {
   const filteredData = filterSurvivalByTime(data, startTime, endTime);
   return (
     <div className='explorer-survival-analysis__survival-plot'>
@@ -120,14 +128,13 @@ function SurvivalPlot({ colorScheme, data, endTime, timeInterval, startTime }) {
           The survival curves plot will appear here.
         </div>
       ) : (
-        <Plot {...{ colorScheme, data: filteredData, endTime, timeInterval }} />
+        <Plot {...{ data: filteredData, endTime, timeInterval }} />
       )}
     </div>
   );
 }
 
 SurvivalPlot.propTypes = {
-  colorScheme: PropTypes.object.isRequired,
   data: PropTypes.arrayOf(
     PropTypes.exact({
       data: PropTypes.arrayOf(

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -117,7 +117,7 @@ function SurvivalPlot({ colorScheme, data, endTime, timeInterval, startTime }) {
       {/* eslint-disable-next-line no-nested-ternary */}
       {filteredData.length === 0 ? (
         <div className='explorer-survival-analysis__figure-placeholder'>
-          {'Click "Apply" to get the survival plot here.'}
+          The survival curves plot will appear here.
         </div>
       ) : (
         <Plot {...{ colorScheme, data: filteredData, endTime, timeInterval }} />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-import { Fragment, memo, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   ResponsiveContainer,
@@ -116,18 +116,10 @@ Plot.propTypes = {
  * @param {ColorScheme} prop.colorScheme
  * @param {SurvivalData[]} prop.data
  * @param {number} prop.endTime
- * @param {boolean} prop.isStratified
  * @param {number} prop.startTime
  * @param {number} prop.timeInterval
  */
-function SurvivalPlot({
-  colorScheme,
-  data,
-  endTime,
-  isStratified,
-  timeInterval,
-  startTime,
-}) {
+function SurvivalPlot({ colorScheme, data, endTime, timeInterval, startTime }) {
   const filteredData = filterSurvivalByTime(data, startTime, endTime);
   return (
     <div className='explorer-survival-analysis__survival-plot'>
@@ -136,26 +128,6 @@ function SurvivalPlot({
         <div className='explorer-survival-analysis__figure-placeholder'>
           {'Click "Apply" to get the survival plot here.'}
         </div>
-      ) : isStratified ? (
-        Object.entries(
-          filteredData.reduce((acc, { group, data }) => {
-            const [factor, stratification] = group;
-            const stratificationKey = JSON.stringify(stratification);
-            const stratificationValue =
-              acc[stratificationKey] !== undefined
-                ? [...acc[stratificationKey], { group: [factor], data }]
-                : [{ group: [factor], data }];
-
-            return { ...acc, [stratificationKey]: stratificationValue };
-          }, {})
-        ).map(([key, data]) => (
-          <Fragment key={key}>
-            <div className='explorer-survival-analysis__figure-title'>
-              {JSON.parse(key).value}
-            </div>
-            <Plot {...{ colorScheme, data, endTime, timeInterval }} />
-          </Fragment>
-        ))
       ) : (
         <Plot {...{ colorScheme, data: filteredData, endTime, timeInterval }} />
       )}
@@ -182,7 +154,6 @@ SurvivalPlot.propTypes = {
     })
   ).isRequired,
   endTime: PropTypes.number.isRequired,
-  isStratified: PropTypes.bool.isRequired,
   startTime: PropTypes.number.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -24,8 +24,7 @@ const Plot = ({ colorScheme, data, endTime, timeInterval }) => {
   const [opacity, setOpacity] = useState({});
   useEffect(() => {
     const initOpacity = {};
-    for (const { group } of data)
-      initOpacity[group.length === 0 ? 'All' : group[0].value] = 1;
+    for (const { name } of data) initOpacity[name] = 1;
     setOpacity(initOpacity);
   }, [data]);
 
@@ -69,21 +68,18 @@ const Plot = ({ colorScheme, data, endTime, timeInterval }) => {
           onMouseEnter={handleLegendMouseEnter}
           onMouseLeave={handleLegendMouseLeave}
         />
-        {data.map(({ group, data }) => {
-          const factorValue = group.length === 0 ? 'All' : group[0].value;
-          return (
-            <Line
-              key={factorValue}
-              data={data}
-              dataKey='prob'
-              dot={false}
-              name={factorValue}
-              type='stepAfter'
-              stroke={colorScheme[factorValue]}
-              strokeOpacity={opacity[factorValue]}
-            />
-          );
-        })}
+        {data.map(({ data, name }) => (
+          <Line
+            key={name}
+            data={data}
+            dataKey='prob'
+            dot={false}
+            name={name}
+            type='stepAfter'
+            stroke={colorScheme[name]}
+            strokeOpacity={opacity[name]}
+          />
+        ))}
       </LineChart>
     </ResponsiveContainer>
   );
@@ -99,12 +95,7 @@ Plot.propTypes = {
           time: PropTypes.number,
         })
       ),
-      group: PropTypes.arrayOf(
-        PropTypes.exact({
-          variable: PropTypes.string,
-          value: PropTypes.string,
-        })
-      ),
+      name: PropTypes.string,
     })
   ).isRequired,
   endTime: PropTypes.number.isRequired,
@@ -145,12 +136,7 @@ SurvivalPlot.propTypes = {
           time: PropTypes.number,
         })
       ),
-      group: PropTypes.arrayOf(
-        PropTypes.exact({
-          variable: PropTypes.string,
-          value: PropTypes.string,
-        })
-      ),
+      name: PropTypes.string,
     })
   ).isRequired,
   endTime: PropTypes.number.isRequired,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -39,7 +39,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
     });
   }
 
-  const [pval, setPval] = useState(-1); // -1 is a placeholder for no p-value
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
   const [isStratified, setIsStratified] = useState(false);
@@ -109,8 +108,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
         result: config.result,
       })
         .then((result) => {
-          if (config.result?.pval)
-            setPval(result.pval ? +parseFloat(result.pval).toFixed(4) : -1);
           if (config.result?.risktable) setRisktable(result.risktable);
           if (config.result?.survival) {
             setSurvival(result.survival);
@@ -153,11 +150,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
           </div>
         ) : (
           <>
-            {config.result?.pval && (
-              <div className='explorer-survival-analysis__pval'>
-                {pval >= 0 && `Log-rank test p-value: ${pval}`}
-              </div>
-            )}
             {config.result?.survival && (
               <SurvivalPlot
                 colorScheme={colorScheme}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -4,25 +4,21 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash.clonedeep';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
-import { enumFilterList } from '../../params';
 import Spinner from '../../components/Spinner';
 import { SurvivalAnalysisConfigType } from '../configTypeDef';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
 import RiskTable from './RiskTable';
-import { getFactors } from './utils';
 import { fetchWithCreds } from '../../actions';
 import './ExplorerSurvivalAnalysis.css';
 import './typedef';
 
 /**
  * @param {Object} prop
- * @param {SimpleAggsData} prop.aggsData
  * @param {SurvivalAnalysisConfig} prop.config
- * @param {{ field: string; name: string; }[]} prop.fieldMapping
  * @param {FilterState} prop.filter
  */
-function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
+function ExplorerSurvivalAnalysis({ config, filter }) {
   const controller = useRef(new AbortController());
   useEffect(() => () => controller.current.abort(), []);
   function fetchResult(body) {
@@ -41,7 +37,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
 
   const [risktable, setRisktable] = useState([]);
   const [survival, setSurvival] = useState([]);
-  const [isStratified, setIsStratified] = useState(false);
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
@@ -57,13 +52,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
       setIsFilterChanged(true);
     }
   }, [filter]);
-
-  const [factors, setFactors] = useState(
-    getFactors(aggsData, fieldMapping, enumFilterList)
-  );
-  useEffect(() => {
-    setFactors(getFactors(aggsData, fieldMapping, enumFilterList));
-  }, [aggsData, fieldMapping]);
 
   /** @type {ColorScheme} */
   const initColorScheme = { All: schemeCategory10[0] };
@@ -96,7 +84,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
     if (isError) setIsError(false);
     if (isFilterChanged) setIsFilterChanged(false);
     setIsUpdating(true);
-    setIsStratified(requestParameter.stratificationVariable !== '');
     setTimeInterval(timeInterval);
     setStartTime(startTime);
     setEndTime(endTime);
@@ -128,7 +115,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
     <div className='explorer-survival-analysis'>
       <div className='explorer-survival-analysis__column-left'>
         <ControlForm
-          factors={factors}
           onSubmit={handleSubmit}
           timeInterval={timeInterval}
           isError={isError}
@@ -155,7 +141,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
                 colorScheme={colorScheme}
                 data={survival}
                 endTime={endTime}
-                isStratified={isStratified}
                 startTime={startTime}
                 timeInterval={timeInterval}
               />
@@ -164,7 +149,6 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
               <RiskTable
                 data={risktable}
                 endTime={endTime}
-                isStratified={isStratified}
                 startTime={startTime}
                 timeInterval={timeInterval}
               />
@@ -177,14 +161,8 @@ function ExplorerSurvivalAnalysis({ aggsData, config, fieldMapping, filter }) {
 }
 
 ExplorerSurvivalAnalysis.propTypes = {
-  aggsData: PropTypes.object,
   config: SurvivalAnalysisConfigType,
-  fieldMapping: PropTypes.array,
   filter: PropTypes.object,
-};
-
-ExplorerSurvivalAnalysis.defaultProps = {
-  fieldMapping: [],
 };
 
 export default memo(ExplorerSurvivalAnalysis);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-shadow */
-import { memo, useMemo, useState } from 'react';
-import { schemeCategory10 } from 'd3-scale-chromatic';
+import { memo, useState } from 'react';
 import Spinner from '../../components/Spinner';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import useSurvivalAnalysisResult from './useSurvivalAnalysisResult';
@@ -15,19 +14,6 @@ function ExplorerSurvivalAnalysis() {
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(20);
-
-  const colorScheme = useMemo(() => {
-    /** @type {ColorScheme} */
-    const colorScheme = {};
-    let count = 0;
-    for (const { name } of survival)
-      if (colorScheme[name] === undefined) {
-        colorScheme[name] = schemeCategory10[count % 9];
-        count += 1;
-      }
-
-    return colorScheme;
-  }, [survival]);
 
   const [isUpdating, setIsUpdating] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -80,7 +66,6 @@ function ExplorerSurvivalAnalysis() {
           <>
             {config.result?.survival && (
               <SurvivalPlot
-                colorScheme={colorScheme}
                 data={survival}
                 endTime={endTime}
                 startTime={startTime}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -26,8 +26,6 @@
 
 /**
  * @typedef {Object} UserInput
- * @property {string} factorVariable
- * @property {string} stratificationVariable
  * @property {number} timeInterval
  * @property {number} startTime
  * @property {number} endTime

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/typedef.js
@@ -9,7 +9,7 @@
 /**
  * @typedef {Object} RisktableData
  * @property {RisktableDataPoint[]} data
- * @property {{ variable: string; value: string; }[]} group
+ * @property {string} name
  */
 
 /**
@@ -21,8 +21,17 @@
 /**
  * @typedef {Object} SurvivalData
  * @property {SurvivalDataPoint[]} data
- * @property {{ variable: string; value: string; }[]} group
+ * @property {string} name
  */
+
+/**
+ * @typedef {Object} SurvivalResultForFilterSet
+ * @property {string} name
+ * @property {RisktableDataPoint[]} risktable
+ * @property {SurvivalDataPoint[]} survival
+ */
+
+/** @typedef {{ [id: string]: SurvivalResultForFilterSet }} SurvivalAnalysisResult */
 
 /**
  * @typedef {Object} UserInput
@@ -30,7 +39,7 @@
  * @property {number} startTime
  * @property {number} endTime
  * @property {boolean} efsFlag
- * @property {boolean} shouldUpdateResults
+ * @property {ExplorerFilterSet[]} usedFilterSets
  */
 
 /**

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -6,7 +6,6 @@ import '../typedef';
 
 /**
  * @typedef {Object} ExplorerFilterSetDTO
- * @property {string} description
  * @property {GqlFilter} filters
  * @property {number} id
  * @property {string} name
@@ -68,13 +67,12 @@ export default function useSurvivalAnalysisResult() {
     /** @type {SurvivalAnalysisResult} */
     const cache = {};
     for (const [index, usedFilterSet] of usedFilterSets.entries()) {
-      const { description, filters, id, name } = usedFilterSet;
+      const { filters, id, name } = usedFilterSet;
       body.usedFilterSetIds.push(id);
       if (id in result)
         cache[id] = { ...result[id], name: `${index + 1}. ${name}` };
       else
         body.filterSets.push({
-          description,
           filters: getGQLFilter(filters) ?? {},
           id,
           name: `${index + 1}. ${name}`,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -1,0 +1,92 @@
+import { useMemo, useState } from 'react';
+import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
+import { fetchWithCreds } from '../../actions';
+import { useExplorerConfig } from '../ExplorerConfigContext';
+import '../typedef';
+
+/**
+ * @typedef {Object} ExplorerFilterSetDTO
+ * @property {string} description
+ * @property {GqlFilter} filters
+ * @property {number} id
+ * @property {string} name
+ */
+
+/**
+ * @param {{ name: string }} a a.name has a format: [index]. [filterSetName]
+ * @param {{ name: string }} b b.name has a format: [index]. [filterSetName]
+ */
+function sortByIndexCompareFn(a, b) {
+  const [aIndex] = a.name.split('.');
+  const [bIndex] = b.name.split('.');
+  return Number.parseInt(aIndex, 10) - Number.parseInt(bIndex, 10);
+}
+
+/** @type {SurvivalAnalysisResult} */
+const emptyData = {};
+
+/** @returns {[[RisktableData[], SurvivalData[]], (usedFilterSets: ExplorerFilterSet[]) => Promise<void>]} */
+export default function useSurvivalAnalysisResult() {
+  const { current, explorerId } = useExplorerConfig();
+  const config = current.survivalAnalysisConfig;
+
+  const [result, setResult] = useState(emptyData);
+  const parsedResult = useMemo(() => {
+    /** @type {[RisktableData[], SurvivalData[]]} */
+    const parsed = [[], []];
+    const [r, s] = parsed;
+    for (const { name, risktable, survival } of Object.values(result)) {
+      if (config.result?.risktable) r.push({ data: risktable, name });
+      if (config.result?.survival) s.push({ data: survival, name });
+    }
+    r.sort(sortByIndexCompareFn);
+    s.sort(sortByIndexCompareFn);
+    return parsed;
+  }, [result]);
+
+  /**
+   * @param {Object} body
+   * @param {ExplorerFilterSetDTO[]} body.filterSets
+   * @param {number[]} body.usedFilterSetIds
+   * @returns {Promise<SurvivalAnalysisResult>}
+   */
+  function fetchResult(body) {
+    return fetchWithCreds({
+      path: '/analysis/tools/survival',
+      method: 'POST',
+      body: JSON.stringify({ ...body, explorerId, result: config.result }),
+    }).then(({ response, data, status }) => {
+      if (status !== 200) throw response.statusText;
+      return data;
+    });
+  }
+
+  /** @param {ExplorerFilterSet[]} usedFilterSets */
+  function refreshResult(usedFilterSets) {
+    /** @type {{ filterSets: ExplorerFilterSetDTO[]; usedFilterSetIds: number[] }} */
+    const body = { filterSets: [], usedFilterSetIds: [] };
+    /** @type {SurvivalAnalysisResult} */
+    const cache = {};
+    for (const [index, usedFilterSet] of usedFilterSets.entries()) {
+      const { description, filters, id, name } = usedFilterSet;
+      body.usedFilterSetIds.push(id);
+      if (id in result)
+        cache[id] = { ...result[id], name: `${index + 1}. ${name}` };
+      else
+        body.filterSets.push({
+          description,
+          filters: getGQLFilter(filters) ?? {},
+          id,
+          name: `${index + 1}. ${name}`,
+        });
+    }
+
+    if (body.filterSets.length > 0)
+      return fetchResult(body).then((data) => setResult({ ...cache, ...data }));
+
+    setResult(cache);
+    return Promise.resolve();
+  }
+
+  return [parsedResult, refreshResult];
+}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -2,52 +2,6 @@
 import './typedef';
 
 /**
- * Get factor variables to use for survival analysis
- * @param {SimpleAggsData} aggsData
- * @param {{ field: string; name: string }[]} fieldMapping
- * @param {string[]} enumFilterList
- */
-export const getFactors = (aggsData, fieldMapping, enumFilterList) => {
-  const factors = [];
-  const exceptions = ['project_id', 'data_contributor_id'];
-
-  /** @type {{ [key: string]: string }} */
-  const fieldNameMap = {};
-  for (const { field, name } of fieldMapping) fieldNameMap[field] = name;
-
-  const fields = Object.keys(aggsData);
-  for (const field of fields)
-    if (
-      enumFilterList.includes(field) &&
-      !exceptions.includes(field) &&
-      !(
-        aggsData[field].histogram.length === 1 &&
-        aggsData[field].histogram[0].key === 'no data'
-      )
-    )
-      factors.push({
-        label:
-          fieldNameMap[field] !== undefined
-            ? fieldNameMap[field]
-            : field
-                .toLowerCase()
-                .replace(/_|\./gi, ' ')
-                .replace(/\b\w/g, (c) => c.toUpperCase())
-                .trim(),
-        value: field,
-      });
-
-  return factors.sort((a, b) => {
-    const labelA = a.label.toUpperCase();
-    const labalB = b.label.toUpperCase();
-
-    if (labelA < labalB) return -1;
-    if (labelA > labalB) return 1;
-    return 0;
-  });
-};
-
-/**
  * Builds x-axis ticks array to use in plots
  * @param {{ data: { time: number; }[]}[]} data
  * @param {number} step

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -26,9 +26,9 @@ export const getXAxisTicks = (data, step = 2, endtime = undefined) => {
  * @returns {SurvivalData[]}
  */
 export const filterSurvivalByTime = (data, startTime, endTime) =>
-  data.map(({ data, group }) => ({
+  data.map(({ data, name }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    group,
+    name,
   }));
 
 /**
@@ -39,7 +39,7 @@ export const filterSurvivalByTime = (data, startTime, endTime) =>
  * @returns {RisktableData[]}
  */
 export const filterRisktableByTime = (data, startTime, endTime) =>
-  data.map(({ data, group }) => ({
+  data.map(({ data, name }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
-    group,
+    name,
   }));

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -22,10 +22,6 @@
   justify-content: space-between;
 }
 
-.explorer-visualization__view {
-  position: relative;
-}
-
 .explorer-visualization__view--hidden {
   display: none;
 }

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -132,7 +132,6 @@ function getChartData({
  * @typedef {Object} ExplorerVisualizationProps
  * @property {number} accessibleCount
  * @property {number} totalCount
- * @property {AggsData} aggsData
  * @property {SimpleAggsData} aggsChartData
  * @property {Object[]} rawData
  * @property {string[]} allFields
@@ -151,7 +150,6 @@ function getChartData({
 function ExplorerVisualization({
   accessibleCount = 0,
   totalCount = 0,
-  aggsData = {},
   aggsChartData = {},
   rawData = [],
   allFields = [],
@@ -229,9 +227,7 @@ function ExplorerVisualization({
     isLocked: isComponentLocked,
   };
   const survivalProps = {
-    aggsData,
     config: survivalAnalysisConfig,
-    fieldMapping: guppyConfig.fieldMapping,
     filter,
   };
 
@@ -330,7 +326,6 @@ function ExplorerVisualization({
 ExplorerVisualization.propTypes = {
   accessibleCount: PropTypes.number, // inherited from GuppyWrapper
   totalCount: PropTypes.number, // inherited from GuppyWrapper
-  aggsData: PropTypes.object, // inherited from GuppyWrapper
   aggsChartData: PropTypes.object, // inherited from GuppyWrapper
   rawData: PropTypes.array, // inherited from GuppyWrapper
   allFields: PropTypes.array, // inherited from GuppyWrapper

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -226,9 +226,6 @@ function ExplorerVisualization({
     guppyConfig,
     isLocked: isComponentLocked,
   };
-  const survivalProps = {
-    config: survivalAnalysisConfig,
-  };
 
   return (
     <div className={className}>
@@ -315,7 +312,7 @@ function ExplorerVisualization({
       )}
       {isSurvivalAnalysisEnabled(survivalAnalysisConfig) && (
         <ViewContainer showIf={explorerView === 'survival analysis'}>
-          <ExplorerSurvivalAnalysis {...survivalProps} />
+          <ExplorerSurvivalAnalysis />
         </ViewContainer>
       )}
     </div>

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -228,7 +228,6 @@ function ExplorerVisualization({
   };
   const survivalProps = {
     config: survivalAnalysisConfig,
-    filter,
   };
 
   return (

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -47,7 +47,7 @@ ViewContainer.propTypes = {
 /** @param {SurvivalAnalysisConfig} survivalAnalysisConfig */
 function isSurvivalAnalysisEnabled(survivalAnalysisConfig) {
   if (survivalAnalysisConfig.result !== undefined)
-    for (const resultOption of ['pval', 'risktable', 'survival'])
+    for (const resultOption of ['risktable', 'survival'])
       if (survivalAnalysisConfig.result[resultOption]) return true;
 
   return false;

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -59,7 +59,6 @@ export const ChartConfigType = PropTypes.object;
 
 export const SurvivalAnalysisConfigType = PropTypes.shape({
   result: PropTypes.shape({
-    pval: PropTypes.bool,
     risktable: PropTypes.bool,
     survival: PropTypes.bool,
   }),

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -97,7 +97,6 @@ function ExplorerDashboard({ dataVersion, portalVersion }) {
           <Dashboard.Main className='explorer__main'>
             <ExplorerVisualization
               accessibleCount={data.accessibleCount}
-              aggsData={data.aggsData}
               aggsChartData={data.aggsChartData}
               allFields={data.allFields}
               filter={data.filter}

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -12,6 +12,7 @@ import {
   ExplorerStateProvider,
   useExplorerState,
 } from './ExplorerStateContext';
+import { ExplorerFilterSetsProvider } from './ExplorerFilterSetsContext';
 import ExplorerErrorBoundary from './ExplorerErrorBoundary';
 import ExplorerSelect from './ExplorerSelect';
 import ExplorerVisualization from './ExplorerVisualization';
@@ -131,9 +132,11 @@ export default function Explorer() {
   return explorerConfig.length === 0 ? null : (
     <ExplorerConfigProvider>
       <ExplorerStateProvider>
-        <ExplorerErrorBoundary>
-          <ReduxExplorerDashboard />
-        </ExplorerErrorBoundary>
+        <ExplorerFilterSetsProvider>
+          <ExplorerErrorBoundary>
+            <ReduxExplorerDashboard />
+          </ExplorerErrorBoundary>
+        </ExplorerFilterSetsProvider>
       </ExplorerStateProvider>
     </ExplorerConfigProvider>
   );

--- a/src/GuppyDataExplorer/typedef.js
+++ b/src/GuppyDataExplorer/typedef.js
@@ -52,7 +52,6 @@
 /**
  * @typedef {Object} SurvivalAnalysisConfig
  * @property {Object} [result]
- * @property {boolean} [result.pval]
  * @property {boolean} [result.risktable]
  * @property {boolean} [result.survival]
  */


### PR DESCRIPTION
Ticket: [PEDS-619](https://pcdc.atlassian.net/browse/PEDS-619)

This PR implements [the revised spec](https://github.com/chicagopcdc/Documents/blob/a638562a01f49330111a125f5380ed3e48c3af32/GEN3/survival-analysis-tool/requirements.md) for the survival analysis tool UI. This is a breaking change and deploying it must be coupled with a corresponding change to the survival analysis tool Microservice (https://github.com/chicagopcdc/PcdcAnalysisTools/pull/41).

The key changes include:

* Drop p-value reporting
* Stop using factor/stratification variables
* Adopt revised request/response data structure based on filter sets
  * Revise the UI to allow users to select saved filter sets to use
  * Provide a default "All Subjects" option
  * Cache and reuse the survival analysis result for the filter sets in the previous request

In doing so, the PR restructures the relevant components and introduces 1) `useExplorerFilterSets()` hook/context to share filter sets data across the component tree and 2) `useSurvivalAnalysisResult()` hook to manage survival analysis result. The PR also includes a few minor refactoring efforts/optimizations.
