### PR TITLE
Adopt updated filter sets API PEDS-563

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
@@ -6,6 +6,7 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimplePopup from '../../components/SimplePopup';
 import Button from '../../gen3-ui-component/components/Button';
+import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerState } from '../ExplorerStateContext';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import {
@@ -28,6 +29,7 @@ import './typedef';
  * @param {ExplorerFilters} prop.filter
  */
 function ExplorerFilterSet({ className, filter }) {
+  const { explorerId } = useExplorerConfig();
   const { clearFilters, updateFilters } = useExplorerState();
   const [filterSet, setFilterSet] = useState(createEmptyFilterSet());
 
@@ -59,7 +61,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleCreate(/** @type {ExplorerFilterSet} */ created) {
     try {
-      setFilterSet(await createFilterSet(created));
+      setFilterSet(await createFilterSet(explorerId, created));
       await refreshFilterSets();
     } catch (e) {
       setIsError(true);
@@ -69,7 +71,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleUpdate(/** @type {ExplorerFilterSet} */ updated) {
     try {
-      await updateFilterSet(updated);
+      await updateFilterSet(explorerId, updated);
       setFilterSet(cloneDeep(updated));
       await refreshFilterSets();
     } catch (e) {
@@ -80,7 +82,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleDelete(/** @type {ExplorerFilterSet} */ deleted) {
     try {
-      await deleteFilterSet(deleted);
+      await deleteFilterSet(explorerId, deleted);
       setFilterSet(createEmptyFilterSet());
       await refreshFilterSets();
       clearFilters();

--- a/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
@@ -6,20 +6,13 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimplePopup from '../../components/SimplePopup';
 import Button from '../../gen3-ui-component/components/Button';
-import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerState } from '../ExplorerStateContext';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import {
   FilterSetActionMenu,
   FilterSetActionForm,
 } from './FilterSetActionComponents';
-import {
-  createEmptyFilterSet,
-  truncateWithEllipsis,
-  createFilterSet,
-  updateFilterSet,
-  deleteFilterSet,
-} from './utils';
+import { createEmptyFilterSet, truncateWithEllipsis } from './utils';
 import './ExplorerFilterSet.css';
 import './typedef';
 
@@ -29,11 +22,16 @@ import './typedef';
  * @param {ExplorerFilters} prop.filter
  */
 function ExplorerFilterSet({ className, filter }) {
-  const { explorerId } = useExplorerConfig();
   const { clearFilters, updateFilters } = useExplorerState();
   const [filterSet, setFilterSet] = useState(createEmptyFilterSet());
 
-  const { filterSets, refreshFilterSets } = useExplorerFilterSets();
+  const {
+    filterSets,
+    refreshFilterSets,
+    createFilterSet,
+    deleteFilterSet,
+    updateFilterSet,
+  } = useExplorerFilterSets();
   const [isError, setIsError] = useState(false);
   useEffect(() => {
     if (!isError) refreshFilterSets().catch(() => setIsError(true));
@@ -61,7 +59,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleCreate(/** @type {ExplorerFilterSet} */ created) {
     try {
-      setFilterSet(await createFilterSet(explorerId, created));
+      setFilterSet(await createFilterSet(created));
       await refreshFilterSets();
     } catch (e) {
       setIsError(true);
@@ -71,7 +69,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleUpdate(/** @type {ExplorerFilterSet} */ updated) {
     try {
-      await updateFilterSet(explorerId, updated);
+      await updateFilterSet(updated);
       setFilterSet(cloneDeep(updated));
       await refreshFilterSets();
     } catch (e) {
@@ -82,7 +80,7 @@ function ExplorerFilterSet({ className, filter }) {
   }
   async function handleDelete(/** @type {ExplorerFilterSet} */ deleted) {
     try {
-      await deleteFilterSet(explorerId, deleted);
+      await deleteFilterSet(deleted);
       setFilterSet(createEmptyFilterSet());
       await refreshFilterSets();
       clearFilters();

--- a/src/GuppyDataExplorer/ExplorerFilterSet/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/typedef.js
@@ -1,18 +1,5 @@
 /// <reference path="../../GuppyComponents/typedef.js" />
 
 /**
- * @typedef {FilterState} ExplorerFilters
- */
-
-/**
- * @typedef {object} ExplorerFilterSet
- * @property {string} name
- * @property {string} description
- * @property {ExplorerFilters} filters
- * @property {?number} [explorerId]
- * @property {?number} [id]
- */
-
-/**
  * @typedef {'new' | 'open' | 'save' | 'save as' | 'delete'} ExplorerFilterSetActionType
  */

--- a/src/GuppyDataExplorer/ExplorerFilterSet/typedef.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/typedef.js
@@ -9,6 +9,7 @@
  * @property {string} name
  * @property {string} description
  * @property {ExplorerFilters} filters
+ * @property {?number} [explorerId]
  * @property {?number} [id]
  */
 

--- a/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
@@ -1,52 +1,5 @@
-import { fetchWithCreds } from '../../actions';
 import { capitalizeFirstLetter } from '../../utils';
 import './typedef';
-
-const FILTER_SET_URL = '/amanuensis/filter-sets';
-
-/**
- * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
- * @returns {Promise<ExplorerFilterSet>}
- */
-export function createFilterSet(explorerId, filterSet) {
-  return fetchWithCreds({
-    path: `${FILTER_SET_URL}?explorerId=${explorerId}`,
-    method: 'POST',
-    body: JSON.stringify(filterSet),
-  }).then(({ response, data, status }) => {
-    if (status !== 200) throw response.statusText;
-    return data;
-  });
-}
-
-/**
- * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
- */
-export function updateFilterSet(explorerId, filterSet) {
-  const { id, ...requestBody } = filterSet;
-  return fetchWithCreds({
-    path: `${FILTER_SET_URL}/${id}?explorerId=${explorerId}`,
-    method: 'PUT',
-    body: JSON.stringify(requestBody),
-  }).then(({ response, status }) => {
-    if (status !== 200) throw response.statusText;
-  });
-}
-
-/**
- * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
- */
-export function deleteFilterSet(explorerId, filterSet) {
-  return fetchWithCreds({
-    path: `${FILTER_SET_URL}/${filterSet.id}?explorerId=${explorerId}`,
-    method: 'DELETE',
-  }).then(({ response, status }) => {
-    if (status !== 200) throw response.statusText;
-  });
-}
 
 /**
  * @return {ExplorerFilterSet}

--- a/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/utils.js
@@ -2,15 +2,16 @@ import { fetchWithCreds } from '../../actions';
 import { capitalizeFirstLetter } from '../../utils';
 import './typedef';
 
-const FILTER_SET_URL = '/amanuensis/filter-set';
+const FILTER_SET_URL = '/amanuensis/filter-sets';
 
 /**
+ * @param {number} explorerId
  * @param {ExplorerFilterSet} filterSet
  * @returns {Promise<ExplorerFilterSet>}
  */
-export function createFilterSet(filterSet) {
+export function createFilterSet(explorerId, filterSet) {
   return fetchWithCreds({
-    path: FILTER_SET_URL,
+    path: `${FILTER_SET_URL}?explorerId=${explorerId}`,
     method: 'POST',
     body: JSON.stringify(filterSet),
   }).then(({ response, data, status }) => {
@@ -20,12 +21,13 @@ export function createFilterSet(filterSet) {
 }
 
 /**
+ * @param {number} explorerId
  * @param {ExplorerFilterSet} filterSet
  */
-export function updateFilterSet(filterSet) {
+export function updateFilterSet(explorerId, filterSet) {
   const { id, ...requestBody } = filterSet;
   return fetchWithCreds({
-    path: `${FILTER_SET_URL}/${id}`,
+    path: `${FILTER_SET_URL}/${id}?explorerId=${explorerId}`,
     method: 'PUT',
     body: JSON.stringify(requestBody),
   }).then(({ response, status }) => {
@@ -34,11 +36,12 @@ export function updateFilterSet(filterSet) {
 }
 
 /**
+ * @param {number} explorerId
  * @param {ExplorerFilterSet} filterSet
  */
-export function deleteFilterSet(filterSet) {
+export function deleteFilterSet(explorerId, filterSet) {
   return fetchWithCreds({
-    path: `${FILTER_SET_URL}/${filterSet.id}`,
+    path: `${FILTER_SET_URL}/${filterSet.id}?explorerId=${explorerId}`,
     method: 'DELETE',
   }).then(({ response, status }) => {
     if (status !== 200) throw response.statusText;

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -28,9 +28,56 @@ function fetchFilterSets(explorerId) {
 }
 
 /**
+ * @param {number} explorerId
+ * @param {ExplorerFilterSet} filterSet
+ * @returns {Promise<ExplorerFilterSet>}
+ */
+export function createFilterSet(explorerId, filterSet) {
+  return fetchWithCreds({
+    path: `${FILTER_SET_URL}?explorerId=${explorerId}`,
+    method: 'POST',
+    body: JSON.stringify(filterSet),
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    return data;
+  });
+}
+
+/**
+ * @param {number} explorerId
+ * @param {ExplorerFilterSet} filterSet
+ */
+export function deleteFilterSet(explorerId, filterSet) {
+  return fetchWithCreds({
+    path: `${FILTER_SET_URL}/${filterSet.id}?explorerId=${explorerId}`,
+    method: 'DELETE',
+  }).then(({ response, status }) => {
+    if (status !== 200) throw response.statusText;
+  });
+}
+
+/**
+ * @param {number} explorerId
+ * @param {ExplorerFilterSet} filterSet
+ */
+export function updateFilterSet(explorerId, filterSet) {
+  const { id, ...requestBody } = filterSet;
+  return fetchWithCreds({
+    path: `${FILTER_SET_URL}/${id}?explorerId=${explorerId}`,
+    method: 'PUT',
+    body: JSON.stringify(requestBody),
+  }).then(({ response, status }) => {
+    if (status !== 200) throw response.statusText;
+  });
+}
+
+/**
  * @typedef {Object} ExplorerFilterSetsContext
  * @property {ExplorerFilterSet[]} filterSets
  * @property {() => Promise<void>} refreshFilterSets
+ * @property {(filerSet: ExplorerFilterSet) => Promise<ExplorerFilterSet>} createFilterSet
+ * @property {(filerSet: ExplorerFilterSet) => Promise<void>} deleteFilterSet
+ * @property {(filerSet: ExplorerFilterSet) => Promise<void>} updateFilterSet
  */
 
 /** @type {React.Context<ExplorerFilterSetsContext>} */
@@ -47,6 +94,9 @@ export function ExplorerFilterSetsProvider({ children }) {
         filterSets,
         refreshFilterSets: () =>
           fetchFilterSets(explorerId).then(setFilterSets),
+        createFilterSet: (filterSet) => createFilterSet(explorerId, filterSet),
+        deleteFilterSet: (filterSet) => deleteFilterSet(explorerId, filterSet),
+        updateFilterSet: (filterSet) => updateFilterSet(explorerId, filterSet),
       }}
     >
       {children}

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -2,24 +2,28 @@ import { createContext, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { fetchWithCreds } from '../actions';
 import './typedef';
+import { useExplorerConfig } from './ExplorerConfigContext';
 
-const FILTER_SET_URL = '/amanuensis/filter-set';
+const FILTER_SET_URL = '/amanuensis/filter-sets';
 
-/** @returns {Promise<ExplorerFilterSet[]>} */
-function fetchFilterSets() {
+/**
+ * @param {number} explorerId
+ * @returns {Promise<ExplorerFilterSet[]>}
+ */
+function fetchFilterSets(explorerId) {
   return fetchWithCreds({
-    path: FILTER_SET_URL,
+    path: `${FILTER_SET_URL}?explorerId=${explorerId}`,
     method: 'GET',
   }).then(({ response, data, status }) => {
     if (status !== 200) throw response.statusText;
     if (
       data === null ||
       typeof data !== 'object' ||
-      data.searches === undefined ||
-      !Array.isArray(data.searches)
+      data.filter_sets === undefined ||
+      !Array.isArray(data.filter_sets)
     )
       throw new Error('Error: Incorrect Response Data');
-    return data.searches;
+    return data.filter_sets;
   });
 }
 
@@ -35,12 +39,14 @@ const ExplorerFilterSetsContext = createContext(null);
 /** @type {ExplorerFilterSet[]} */
 const emptyFilterSets = [];
 export function ExplorerFilterSetsProvider({ children }) {
+  const { explorerId } = useExplorerConfig();
   const [filterSets, setFilterSets] = useState(emptyFilterSets);
   return (
     <ExplorerFilterSetsContext.Provider
       value={{
         filterSets,
-        refreshFilterSets: () => fetchFilterSets().then(setFilterSets),
+        refreshFilterSets: () =>
+          fetchFilterSets(explorerId).then(setFilterSets),
       }}
     >
       {children}

--- a/src/GuppyDataExplorer/typedef.js
+++ b/src/GuppyDataExplorer/typedef.js
@@ -90,3 +90,16 @@
  * @property {TableConfig} tableConfig
  * @property {number} tierAccessLimit
  */
+
+/**
+ * @typedef {FilterState} ExplorerFilters
+ */
+
+/**
+ * @typedef {object} ExplorerFilterSet
+ * @property {string} name
+ * @property {string} description
+ * @property {ExplorerFilters} filters
+ * @property {?number} [explorerId]
+ * @property {?number} [id]
+ */


### PR DESCRIPTION
Ticket: [PEDS-563](https://pcdc.atlassian.net/browse/PEDS-563)

This PR modifies the API calls to use the filter sets endpoint that is updated to support multi-explorer setup. See this PR for details on the update to the endpoint: https://github.com/chicagopcdc/amanuensis/pull/15.

This PR also consolidates all API calls under `<ExplorerFilterSetsContext>` for better code organization.