### PR TITLE
Use survival visualization max time based on data PEDS-573

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -59,6 +59,20 @@ export const defaultFilterSet = {
 };
 
 /**
+ * @param {React.FocusEvent<HTMLInputElement>} e
+ * @param {React.Dispatch<React.SetStateAction<number>>} setStateAction
+ */
+function validateNumberInput(e, setStateAction) {
+  if (e.target.value !== '') {
+    const value = Number.parseInt(e.target.value, 10);
+    const min = Number.parseInt(e.target.min, 10);
+    const max = Number.parseInt(e.target.max, 10);
+    if (min && min > value) setStateAction(min);
+    else if (max && max < value) setStateAction(max);
+  }
+}
+
+/**
  * @param {Object} prop
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
@@ -85,18 +99,6 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
   useEffect(() => {
     if (!isInputChanged && isError) setIsInputChanged(true);
   }, [isInputChanged, isError]);
-
-  const validateNumberInput = (
-    /** @type {{ target: { value: string, min: string, max: string }}} */ e
-  ) => {
-    if (e.target.value !== '') {
-      const value = Number.parseInt(e.target.value, 10);
-      const min = Number.parseInt(e.target.min, 10);
-      const max = Number.parseInt(e.target.max, 10);
-      if (min && min > value) setLocalTimeInterval(min);
-      else if (max && max < value) setLocalTimeInterval(max);
-    }
-  };
 
   const [shouldSubmit, setShouldSubmit] = useState(false);
   useEffect(() => {
@@ -151,7 +153,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         min={0}
         max={endTime - 1}
         step={1}
-        onBlur={validateNumberInput}
+        onBlur={(e) => validateNumberInput(e, setStartTime)}
         onChange={(e) => {
           setStartTime(Number.parseInt(e.target.value, 10));
           setIsInputChanged(true);
@@ -166,7 +168,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         min={startTime + 1}
         max={99}
         step={1}
-        onBlur={validateNumberInput}
+        onBlur={(e) => validateNumberInput(e, setEndTime)}
         onChange={(e) => {
           setEndTime(
             e.target.value === ''
@@ -184,7 +186,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         min={1}
         max={5}
         step={1}
-        onBlur={validateNumberInput}
+        onBlur={(e) => validateNumberInput(e, setLocalTimeInterval)}
         onChange={(e) => {
           setLocalTimeInterval(Number.parseInt(e.target.value, 10));
           setIsInputChanged(true);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -162,6 +162,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         id='survival-end-time'
         label='End time (year)'
         type='number'
+        placeholder='Optional; max value if left blank'
         min={startTime + 1}
         max={99}
         step={1}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -67,7 +67,7 @@ export const defaultFilterSet = {
 const ControlForm = ({ onSubmit, timeInterval, isError }) => {
   const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
   const [startTime, setStartTime] = useState(0);
-  const [endTime, setEndTime] = useState(20);
+  const [endTime, setEndTime] = useState(undefined);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
   const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
@@ -89,11 +89,13 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
   const validateNumberInput = (
     /** @type {{ target: { value: string, min: string, max: string }}} */ e
   ) => {
-    const value = Number.parseInt(e.target.value, 10);
-    const min = Number.parseInt(e.target.min, 10);
-    const max = Number.parseInt(e.target.max, 10);
-    if (min && min > value) setLocalTimeInterval(min);
-    else if (max && max < value) setLocalTimeInterval(max);
+    if (e.target.value !== '') {
+      const value = Number.parseInt(e.target.value, 10);
+      const min = Number.parseInt(e.target.min, 10);
+      const max = Number.parseInt(e.target.max, 10);
+      if (min && min > value) setLocalTimeInterval(min);
+      else if (max && max < value) setLocalTimeInterval(max);
+    }
   };
 
   const [shouldSubmit, setShouldSubmit] = useState(false);
@@ -116,16 +118,9 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
   };
 
   const resetUserInput = () => {
-    setIsInputChanged(
-      localTimeInterval !== 2 ||
-        startTime !== 0 ||
-        endTime !== 20 ||
-        survivalType !== survivalTypeOptions[0]
-    );
-
     setLocalTimeInterval(2);
     setStartTime(0);
-    setEndTime(20);
+    setEndTime(undefined);
     setSurvivalType(survivalTypeOptions[0]);
     setUsedFilterSets(emptyFilterSets);
     setIsInputChanged(false);
@@ -172,7 +167,11 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         step={1}
         onBlur={validateNumberInput}
         onChange={(e) => {
-          setEndTime(Number.parseInt(e.target.value, 10));
+          setEndTime(
+            e.target.value === ''
+              ? undefined
+              : Number.parseInt(e.target.value, 10)
+          );
           setIsInputChanged(true);
         }}
         value={endTime}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -106,7 +106,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
       onSubmit({
         timeInterval: localTimeInterval,
         startTime,
-        endTime,
+        endTime: endTime || undefined,
         efsFlag: survivalType.value === 'efs',
         usedFilterSets,
       });
@@ -170,11 +170,7 @@ const ControlForm = ({ onSubmit, timeInterval, isError }) => {
         step={1}
         onBlur={(e) => validateNumberInput(e, setEndTime)}
         onChange={(e) => {
-          setEndTime(
-            e.target.value === ''
-              ? undefined
-              : Number.parseInt(e.target.value, 10)
-          );
+          setEndTime(Number.parseInt(e.target.value, 10));
           setIsInputChanged(true);
         }}
         value={endTime}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -45,7 +45,7 @@ CustomYAxisTick.propTypes = {
 /**
  * @typedef {Object} RiskTableProps
  * @property {RisktableData[]} data
- * @property {number} endTime
+ * @property {number} [endTime]
  * @property {number} startTime
  * @property {number} timeInterval
  */
@@ -105,7 +105,7 @@ Table.propTypes = {
       name: PropTypes.string,
     })
   ).isRequired,
-  endTime: PropTypes.number.isRequired,
+  endTime: PropTypes.number,
   startTime: PropTypes.number.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -17,7 +17,7 @@ import './typedef';
 /**
  * @typedef {Object} SurvivalPlotProps
  * @property {SurvivalData[]} data
- * @property {number} endTime
+ * @property {number} [endTime]
  * @property {number} startTime
  * @property {number} timeInterval
  */
@@ -115,7 +115,7 @@ Plot.propTypes = {
       name: PropTypes.string,
     })
   ).isRequired,
-  endTime: PropTypes.number.isRequired,
+  endTime: PropTypes.number,
   startTime: PropTypes.number.isRequired,
   timeInterval: PropTypes.number.isRequired,
 };

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -13,7 +13,7 @@ function ExplorerSurvivalAnalysis() {
   const [[risktable, survival], refershResult] = useSurvivalAnalysisResult();
   const [timeInterval, setTimeInterval] = useState(2);
   const [startTime, setStartTime] = useState(0);
-  const [endTime, setEndTime] = useState(20);
+  const [endTime, setEndTime] = useState(undefined);
 
   const [isUpdating, setIsUpdating] = useState(false);
   const [isError, setIsError] = useState(false);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -11,7 +11,7 @@ import './typedef';
 
 function ExplorerSurvivalAnalysis() {
   const [[risktable, survival], refershResult] = useSurvivalAnalysisResult();
-  const [timeInterval, setTimeInterval] = useState(2);
+  const [timeInterval, setTimeInterval] = useState(4);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(undefined);
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -22,10 +22,10 @@ export const getXAxisTicks = (data, step = 2, endtime = undefined) => {
  * Filter survival by start/end time
  * @param {SurvivalData[]} data
  * @param {number} startTime
- * @param {number} endTime
+ * @param {number} [endTime]
  * @returns {SurvivalData[]}
  */
-export const filterSurvivalByTime = (data, startTime, endTime) =>
+export const filterSurvivalByTime = (data, startTime, endTime = Infinity) =>
   data.map(({ data, name }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
     name,
@@ -35,10 +35,10 @@ export const filterSurvivalByTime = (data, startTime, endTime) =>
  * Filter risktable by start/end time
  * @param {RisktableData[]} data
  * @param {number} startTime
- * @param {number} endTime
+ * @param {number} [endTime]
  * @returns {RisktableData[]}
  */
-export const filterRisktableByTime = (data, startTime, endTime) =>
+export const filterRisktableByTime = (data, startTime, endTime = Infinity) =>
   data.map(({ data, name }) => ({
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
     name,


### PR DESCRIPTION
Ticket: [PEDS-573](https://pcdc.atlassian.net/browse/PEDS-573)

This PR enables survival analysis visualizations to use the max time value of the data when "end time" input is left blank (i.e. `undefined`). In addition, the default "time interval" value is changed to `4` to account for the likely greater "end time" value by default.

See image below:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/22449454/146837172-e85a74c4-1486-4f80-bc85-b3bc84785979.png">


The PR also includes minor refactoring to fix small bugs and improve code quality.