### PR TITLE
Migrate react router to 6 PEDS-584

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25897,25 +25897,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -29675,91 +29656,38 @@
       }
     },
     "react-router": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
-      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
+      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "history": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+          "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
           "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
+            "@babel/runtime": "^7.7.6"
           }
         }
       }
     },
     "react-router-dom": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
-      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
+      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.2.0",
+        "react-router": "6.2.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "history": {
-          "version": "4.10.1",
-          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
+          "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
           "requires": {
-            "@babel/runtime": "^7.1.2",
-            "loose-envify": "^1.2.0",
-            "resolve-pathname": "^3.0.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0",
-            "value-equal": "^1.0.1"
+            "@babel/runtime": "^7.7.6"
           }
         }
       }
@@ -30856,11 +30784,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -32917,16 +32840,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -33718,11 +33631,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "value-or-promise": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-redux": "^7.2.6",
     "react-relay": "^11.0.2",
     "react-responsive": "^8.2.0",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^6.2.1",
     "react-select": "^5.2.1",
     "react-select-async-paginate": "^0.6.0",
     "react-table": "^7.7.0",

--- a/src/Analysis/Analysis.jsx
+++ b/src/Analysis/Analysis.jsx
@@ -7,7 +7,7 @@ import './Analysis.css';
 
 class Analysis extends Component {
   openApp = (app) => {
-    this.props.history.push(`/analysis/${app}`);
+    this.props.navigate(`/analysis/${app}`);
   };
 
   render() {
@@ -49,7 +49,7 @@ class Analysis extends Component {
 }
 
 Analysis.propTypes = {
-  history: PropTypes.object.isRequired,
+  navigate: PropTypes.func.isRequired,
 };
 
 export default Analysis;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { lazy, Suspense, useEffect } from 'react';
 import {
+  Outlet,
   Route,
   Routes,
   useNavigate,
@@ -53,93 +54,113 @@ function App({ store }) {
   const [searchParams] = useSearchParams();
 
   return (
-    <Layout>
-      <Suspense
-        fallback={
-          <div style={{ height: '100vh' }}>
-            <Spinner />
-          </div>
+    <Routes>
+      <Route
+        path='/'
+        element={
+          <Layout>
+            <Suspense
+              fallback={
+                <div style={{ height: '100vh' }}>
+                  <Spinner />
+                </div>
+              }
+            >
+              <Outlet />
+            </Suspense>
+          </Layout>
         }
       >
-        <Routes>
+        <Route
+          index
+          element={
+            <ProtectedContent>
+              <IndexPage />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='login'
+          element={
+            <ProtectedContent
+              isPublic
+              filter={() => store.dispatch(fetchLogin())}
+            >
+              <ReduxLogin />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='submission'
+          element={
+            <ProtectedContent isAdminOnly>
+              <Outlet />
+            </ProtectedContent>
+          }
+        >
+          <Route index element={<SubmissionPage />} />
+          <Route path='files' element={<ReduxMapFiles navigate={navigate} />} />
           <Route
-            path='/login'
-            element={
-              <ProtectedContent
-                isPublic
-                filter={() => store.dispatch(fetchLogin())}
-              >
-                <ReduxLogin />
-              </ProtectedContent>
-            }
+            path='map'
+            element={<ReduxMapDataModel navigate={navigate} />}
           />
+        </Route>
+        <Route
+          path='query'
+          element={
+            <ProtectedContent>
+              <GraphQLQuery />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='identity'
+          element={
+            <ProtectedContent filter={() => store.dispatch(fetchAccess())}>
+              <UserProfile />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='dd'
+          element={
+            <ProtectedContent>
+              <Outlet />
+            </ProtectedContent>
+          }
+        >
+          <Route index element={<DataDictionary />} />
+          <Route path=':node' element={<DataDictionary />} />
+        </Route>
+        <Route
+          path='explorer'
+          element={
+            <ProtectedContent>
+              <Explorer />
+            </ProtectedContent>
+          }
+        />
+        {enableResourceBrowser && (
           <Route
-            path='/'
+            path='resource-browser'
             element={
               <ProtectedContent>
-                <IndexPage />
+                <ResourceBrowser />
               </ProtectedContent>
             }
           />
+        )}
+        <Route path=':project' element={<Outlet />}>
           <Route
-            path='/submission'
-            element={
-              <ProtectedContent isAdminOnly>
-                <SubmissionPage />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/submission/files'
-            element={
-              <ProtectedContent isAdminOnly>
-                <ReduxMapFiles navigate={navigate} />
-              </ProtectedContent>
-            }
-          />
-
-          <Route
-            path='/submission/map'
-            element={
-              <ProtectedContent isAdminOnly>
-                <ReduxMapDataModel navigate={navigate} />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/query'
+            index
             element={
               <ProtectedContent>
-                <GraphQLQuery />
+                <ProjectSubmission />
               </ProtectedContent>
             }
           />
           <Route
-            path='/identity'
-            element={
-              <ProtectedContent filter={() => store.dispatch(fetchAccess())}>
-                <UserProfile />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/dd/:node'
-            element={
-              <ProtectedContent>
-                <DataDictionary />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/dd'
-            element={
-              <ProtectedContent>
-                <DataDictionary />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/:project/search'
+            path='search'
             element={
               <ProtectedContent
                 filter={() =>
@@ -159,68 +180,42 @@ function App({ store }) {
               </ProtectedContent>
             }
           />
-          <Route
-            path='/explorer'
-            element={
-              <ProtectedContent>
-                <Explorer />
-              </ProtectedContent>
-            }
-          />
-          {enableResourceBrowser && (
-            <Route
-              path='/resource-browser'
-              element={
-                <ProtectedContent>
-                  <ResourceBrowser />
-                </ProtectedContent>
+        </Route>
+        {/* <Route
+          path='/indexing'
+          element={
+            <ProtectedContent>
+              <Indexing />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='/files/*'
+          element={
+            <ProtectedContent
+              filter={() =>
+                store.dispatch(fetchCoreMetadata(props.match.params[0]))
               }
-            />
-          )}
-          <Route
-            path='/:project'
-            element={
-              <ProtectedContent>
-                <ProjectSubmission />
-              </ProtectedContent>
-            }
-          />
-          {/* <Route
-            path='/indexing'
-            element={
-              <ProtectedContent>
-                <Indexing />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/files/*'
-            element={
-              <ProtectedContent
-                filter={() =>
-                  store.dispatch(fetchCoreMetadata(props.match.params[0]))
-                }
-              >
-                <CoreMetadataPage />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='/workspace'
-            element={
-              <ProtectedContent>
-                <Workspace />
-              </ProtectedContent>
-            }
-          />
-          <Route path={workspaceUrl} element={<ErrorWorkspacePlaceholder />} />
-          <Route
-            path={workspaceErrorUrl}
-            element={<ErrorWorkspacePlaceholder />}
-          /> */}
-        </Routes>
-      </Suspense>
-    </Layout>
+            >
+              <CoreMetadataPage />
+            </ProtectedContent>
+          }
+        />
+        <Route
+          path='/workspace'
+          element={
+            <ProtectedContent>
+              <Workspace />
+            </ProtectedContent>
+          }
+        />
+        <Route path={workspaceUrl} element={<ErrorWorkspacePlaceholder />} />
+        <Route
+          path={workspaceErrorUrl}
+          element={<ErrorWorkspacePlaceholder />}
+        /> */}
+      </Route>
+    </Routes>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,16 +122,13 @@ function App({ store }) {
           }
         />
         <Route
-          path='dd'
+          path='dd/*'
           element={
             <ProtectedContent>
-              <Outlet />
+              <DataDictionary />
             </ProtectedContent>
           }
-        >
-          <Route index element={<DataDictionary />} />
-          <Route path=':node' element={<DataDictionary />} />
-        </Route>
+        />
         <Route
           path='explorer'
           element={

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -30,7 +30,7 @@ import '../typedef';
  * @property {boolean} isPending: PropTypes.bool,
  * @property {ButtonConfig} buttonConfig: ButtonConfigType.isRequired,
  * @property {GuppyConfig} guppyConfig: GuppyConfigType.isRequired,
- * @property {import('history').History} history: PropTypes.object.isRequired,
+ * @property {import('react-router-dom').NavigateFunction} navigate: PropTypes.func.isRequired,
  * @property {(body: any) => void} submitJob: PropTypes.func.isRequired,
  * @property {() => void} resetJobState: PropTypes.func.isRequired,
  * @property {() => void} checkJobStatus: PropTypes.func.isRequired,
@@ -365,7 +365,7 @@ class ExplorerButtonGroup extends Component {
 
   isPFBRunning = () => this.props.job && this.props.job.status === 'Running';
 
-  gotoWorkspace = () => this.props.history.push('/workspace');
+  gotoWorkspace = () => this.props.navigate('/workspace');
 
   closeToaster = () => {
     this.setState({
@@ -866,7 +866,7 @@ ExplorerButtonGroup.propTypes = {
   isPending: PropTypes.bool,
   buttonConfig: ButtonConfigType.isRequired,
   guppyConfig: GuppyConfigType.isRequired,
-  history: PropTypes.object.isRequired,
+  navigate: PropTypes.func.isRequired,
   submitJob: PropTypes.func.isRequired,
   resetJobState: PropTypes.func.isRequired,
   checkJobStatus: PropTypes.func.isRequired,

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { tierAccessLimit, explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import './typedef';
@@ -20,7 +20,7 @@ import './typedef';
 const ExplorerConfigContext = createContext(null);
 
 export function ExplorerConfigProvider({ children }) {
-  const history = useHistory();
+  const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
 
   const explorerOptions = [];
@@ -34,7 +34,6 @@ export function ExplorerConfigProvider({ children }) {
   }
 
   const [initialExplorerId, hasValidInitialSearchParamId] = useMemo(() => {
-    const searchParams = new URLSearchParams(location.search);
     const hasSearchParamId = searchParams.has('id');
     const searchParamId = hasSearchParamId
       ? Number(searchParams.get('id'))
@@ -48,13 +47,13 @@ export function ExplorerConfigProvider({ children }) {
   const [shouldUpdateState, setShouldUpdateState] = useState(false);
   useEffect(() => {
     if (!hasValidInitialSearchParamId) {
-      history.replace({
-        search:
-          // @ts-ignore
-          location.state?.keepSearch === true
-            ? `id=${initialExplorerId}&${location.search.slice(1)}`
-            : `id=${initialExplorerId}`,
-      });
+      setSearchParams(
+        // @ts-ignore
+        location.state?.keepSearch === true
+          ? `id=${initialExplorerId}&${location.search.slice(1)}`
+          : `id=${initialExplorerId}`,
+        { replace: true }
+      );
       setShouldUpdateState(true);
     }
   }, []);
@@ -62,11 +61,10 @@ export function ExplorerConfigProvider({ children }) {
   const [explorerId, setExporerId] = useState(initialExplorerId);
   function updateExplorerId(id) {
     setExporerId(id);
-    history.push({ search: `id=${id}` });
+    setSearchParams(`id=${id}`);
   }
 
   function handleBrowserNavigationForConfig() {
-    const searchParams = new URLSearchParams(location.search);
     const searchParamId = Number(searchParams.get('id'));
     setExporerId(searchParamId);
   }

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import SummaryChartGroup from '../../gen3-ui-component/components/charts/SummaryChartGroup';
 import PercentageStackedBarChart from '../../gen3-ui-component/components/charts/PercentageStackedBarChart';
 import Spinner from '../../components/Spinner';
@@ -195,7 +195,6 @@ function ExplorerVisualization({
     guppyConfig.nodeCountTitle.toLowerCase() || guppyConfig.dataType
   }.`;
 
-  const history = useHistory();
   const buttonGroupProps = {
     buttonConfig,
     guppyConfig,
@@ -206,7 +205,7 @@ function ExplorerVisualization({
     downloadRawDataByTypeAndFilter,
     getTotalCountsByTypeAndFilter,
     filter,
-    history,
+    navigate: useNavigate(),
     isLocked: isComponentLocked,
     isPending: isLoadingAggsData,
   };

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import MediaQuery from 'react-responsive';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -29,7 +29,7 @@ function IndexOverview({ overviewCounts }) {
     })),
   ];
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const explorerLocation =
     consortium.value === 'total'
       ? { pathname: '/explorer' }
@@ -87,7 +87,7 @@ function IndexOverview({ overviewCounts }) {
             <Button
               label='Explore more'
               buttonType='primary'
-              onClick={() => history.push(explorerLocation)}
+              onClick={() => navigate(explorerLocation)}
             />
           </MediaQuery>
         </div>
@@ -112,7 +112,7 @@ function IndexOverview({ overviewCounts }) {
           <Button
             label='Explore more'
             buttonType='primary'
-            onClick={() => history.push(explorerLocation)}
+            onClick={() => navigate(explorerLocation)}
           />
         </div>
       </MediaQuery>

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Redirect, useLocation, useRouteMatch } from 'react-router-dom';
+import { matchPath, Navigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
   fetchDictionary,
@@ -57,7 +57,6 @@ function ProtectedContent({
   };
   const [state, setState] = useState(initialState);
   const location = useLocation();
-  const match = useRouteMatch();
 
   /**
    * Start filter the 'newState' for the checkLoginStatus component.
@@ -133,13 +132,15 @@ function ProtectedContent({
    */
   function fetchResources({ dispatch, getState }) {
     const { graphiql, project, submission } = getState();
-    const { path } = match;
+    function matchPathOneOf(patterns) {
+      return patterns.some((pattern) => matchPath(pattern, location.pathname));
+    }
 
-    if (LOCATIONS_DICTIONARY.includes(path) && !submission.dictionary) {
+    if (matchPathOneOf(LOCATIONS_DICTIONARY) && !submission.dictionary) {
       dispatch(fetchDictionary());
-    } else if (LOCATIONS_PROJECTS.includes(path) && !project.projects) {
+    } else if (matchPathOneOf(LOCATIONS_PROJECTS) && !project.projects) {
       dispatch(fetchProjects());
-    } else if (LOCATIONS_SCHEMA.includes(path)) {
+    } else if (matchPathOneOf(LOCATIONS_SCHEMA)) {
       if (!graphiql.schema) dispatch(fetchSchema());
       if (!graphiql.guppySchema) dispatch(fetchGuppySchema());
     }
@@ -182,7 +183,7 @@ function ProtectedContent({
     );
   }, [location]);
 
-  if (state.redirectTo) return <Redirect to={state.redirectTo} />;
+  if (state.redirectTo) return <Navigate to={state.redirectTo} replace />;
   if (isPublic && (state.dataLoaded || typeof filter !== 'function'))
     return children;
   if (state.authenticated)

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -29,12 +29,7 @@ import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
  * @property {() => Promise} [filter] optional filter to apply before rendering the child component
  */
 
-const LOCATIONS_DICTIONARY = [
-  '/dd',
-  '/dd/:node',
-  '/submission/map',
-  '/:project',
-];
+const LOCATIONS_DICTIONARY = ['/dd/*', '/submission/map', '/:project'];
 const LOCATIONS_PROJECTS = ['/files/*'];
 const LOCATIONS_SCHEMA = ['/query'];
 

--- a/src/Popup/ReduxAuthTimeoutPopup.jsx
+++ b/src/Popup/ReduxAuthTimeoutPopup.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Popup from '../components/Popup';
 
 /** @param {{ authPopup: boolean; }} props  */
 function AuthPopup({ authPopup }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   return authPopup ? (
     <Popup
       message='Your session has expired or you are logged out. Please log in to continue.'
@@ -13,7 +13,7 @@ function AuthPopup({ authPopup }) {
         {
           caption: 'Go to Login',
           fn: () => {
-            history.push('/login');
+            navigate('/login');
             // Refresh the page.jsx.
             window.location.reload();
           },

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -1,4 +1,4 @@
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { jsonToString, getSubmitPath } from '../utils';
 import Popup from '../components/Popup';
@@ -11,7 +11,7 @@ import './QueryNode.css';
  * @param {Object} props.submission
  * @param {Object} props.queryNodes
  * @param {Object} props.popups
- * @param {(value: any, url: string, history: any ) => void} props.onSearchFormSubmit
+ * @param {(value: any, url: string, navigate: import('react-router-dom').NavigateFunction ) => void} props.onSearchFormSubmit
  * @param {(param: { view_popup: string; nodedelete_popup: boolean | string; }) => void} props.onUpdatePopup
  * @param {() => void} props.onClearDeleteSession
  * @param {(param: { project: string; id: string; }) => void} props.onDeleteNode
@@ -27,7 +27,7 @@ function QueryNode({
   onDeleteNode,
   onStoreNodeInfo,
 }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { project } = useParams();
 
   /**
@@ -158,7 +158,7 @@ function QueryNode({
       {renderDeletePopup().popupEl}
       <QueryForm
         onSearchFormSubmit={(data, url) =>
-          onSearchFormSubmit(data, url, history)
+          onSearchFormSubmit(data, url, navigate)
         }
         project={project}
         nodeTypes={submission.nodeTypes}

--- a/src/QueryNode/ReduxQueryNode.js
+++ b/src/QueryNode/ReduxQueryNode.js
@@ -9,7 +9,7 @@ const clearDeleteSession = {
   type: 'CLEAR_DELETE_SESSION',
 };
 
-export const submitSearchForm = (opts, url, history) => (dispatch) => {
+export const submitSearchForm = (opts, url, navigate) => (dispatch) => {
   const nodeType = opts.node_type;
   const submitterId = opts.submitter_id || '';
 
@@ -39,9 +39,7 @@ export const submitSearchForm = (opts, url, history) => (dispatch) => {
     })
     .then((msg) => dispatch(msg))
     .then(() => {
-      if (url && history) {
-        history.push(url);
-      }
+      if (url) navigate(url);
       return null;
     });
 };
@@ -110,8 +108,8 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-  onSearchFormSubmit: (value, url, history) =>
-    dispatch(submitSearchForm(value, url, history)),
+  onSearchFormSubmit: (value, url, navigate) =>
+    dispatch(submitSearchForm(value, url, navigate)),
   onUpdatePopup: (state) => dispatch(updatePopup(state)),
   onClearDeleteSession: () => dispatch(clearDeleteSession),
   onDeleteNode: ({ id, project }) => {

--- a/src/Submission/MapDataModel.jsx
+++ b/src/Submission/MapDataModel.jsx
@@ -59,7 +59,7 @@ class MapDataModel extends Component {
   componentDidMount() {
     if (this.props.filesToMap.length === 0) {
       // redirect if no files
-      this.props.history.push('/submission/files');
+      this.props.navigate('/submission/files');
     }
     getProjectsList();
   }
@@ -238,7 +238,7 @@ class MapDataModel extends Component {
         promises.push(promise);
       });
       Promise.all(promises).then(() => {
-        this.props.history.push(`/submission/files?message=${message}`);
+        this.props.navigate(`/submission/files?message=${message}`);
       });
     });
   };
@@ -416,7 +416,7 @@ MapDataModel.propTypes = {
   projects: PropTypes.object,
   dictionary: PropTypes.object,
   nodeTypes: PropTypes.array,
-  history: PropTypes.object.isRequired,
+  navigate: PropTypes.func.isRequired,
   submitFiles: PropTypes.func.isRequired,
 };
 

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -135,7 +135,7 @@ class MapFiles extends Component {
   onCompletion = () => {
     const flatFiles = flattenFiles(this.state.selectedFilesByGroup);
     this.props.mapSelectedFiles(flatFiles);
-    this.props.history.push('/submission/map');
+    this.props.navigate('/submission/map');
   };
 
   onUpdate = () => {
@@ -402,7 +402,7 @@ MapFiles.propTypes = {
   unmappedFiles: PropTypes.array,
   fetchUnmappedFiles: PropTypes.func.isRequired,
   mapSelectedFiles: PropTypes.func.isRequired,
-  history: PropTypes.object.isRequired,
+  navigate: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
 };
 

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -34,7 +34,7 @@ function ProjectSubmission({
       <ReduxSubmitForm />
       <ReduxSubmitTSV project={project} />
       {dataIsReady ? (
-        <ReduxDataModelGraph project={project} />
+        <ReduxDataModelGraph />
       ) : (
         project !== '_root' && <Spinner />
       )}

--- a/src/Submission/SubmissionHeader.jsx
+++ b/src/Submission/SubmissionHeader.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '../gen3-ui-component/components/Button';
 import Gen3ClientSvg from '../img/gen3client.svg';
 import MapFilesSvg from '../img/mapfiles.svg';
@@ -35,10 +35,10 @@ function SubmissionHeader({
     window.open('https://gen3.org/resources/user/gen3-client/', '_blank');
   }
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   function navigateToMyFiles() {
-    history.push(`${location.pathname}/files`);
+    navigate(`${location.pathname}/files`);
   }
 
   return (

--- a/src/actions.js
+++ b/src/actions.js
@@ -317,7 +317,7 @@ export const fetchProjects = () => (dispatch) =>
  * @returns {import('redux-thunk').ThunkAction<Promise, any, any, any>}
  */
 export const fetchSchema = () => (dispatch) =>
-  fetch('../data/schema.json')
+  fetch('/data/schema.json')
     .then((response) => response.json())
     .then(({ data }) =>
       dispatch({ type: 'RECEIVE_SCHEMA', schema: buildClientSchema(data) })
@@ -341,7 +341,7 @@ export const fetchGuppySchema = () => (dispatch) =>
 
 /** @returns {import('redux-thunk').ThunkAction<Promise, any, any, any>} */
 export const fetchDictionary = () => (dispatch) =>
-  fetch('../data/dictionary.json')
+  fetch('/data/dictionary.json')
     .then((response) => response.json())
     .then((data) => dispatch({ type: 'RECEIVE_DICTIONARY', data }));
 

--- a/src/components/IndexButtonBar.jsx
+++ b/src/components/IndexButtonBar.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Button from '../gen3-ui-component/components/Button';
 import IconComponent from './Icon';
 import './IndexButtonBar.css';
@@ -16,7 +16,7 @@ import './IndexButtonBar.css';
  * @param {IndexButtonBarProps} props
  */
 function IndexButtonBar({ buttons, dictIcons, userAccess }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const canUserSeeComponent = (componentName) => {
     const authResult = userAccess[componentName];
     return authResult === undefined || authResult;
@@ -42,7 +42,7 @@ function IndexButtonBar({ buttons, dictIcons, userAccess }) {
             </div>
             <Button
               className='index-button-bar__item'
-              onClick={() => history.push(item.link)}
+              onClick={() => navigate(item.link)}
               label={item.label}
               buttonType='primary'
             />

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Button from '../../gen3-ui-component/components/Button';
 import Table from './base/Table';
 import './ProjectTable.css';
@@ -12,7 +12,7 @@ import './ProjectTable.css';
 
 /** @param {ProjectTableProps} props */
 function ProjectTable({ projectList, summaryFields }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const tableHeader = ['Project', ...summaryFields, ''];
   const tableData = [...projectList]
     // eslint-disable-next-line no-nested-ternary
@@ -23,7 +23,7 @@ function ProjectTable({ projectList, summaryFields }) {
       <Button
         className='project-table__submit-button'
         key={i}
-        onClick={() => history.push(`/${name}`)}
+        onClick={() => navigate(`/${name}`)}
         label='Submit Data'
         buttonType='primary'
         rightIcon='upload'

--- a/src/stories/buttons.jsx
+++ b/src/stories/buttons.jsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Route, StaticRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import IconicButton from '../components/buttons/IconicButton';
 import IconicLink from '../components/buttons/IconicLink';
@@ -17,29 +17,23 @@ storiesOf('IconicButton', module)
     />
   ));
 
-const context = {};
-
 storiesOf('IconicLink', module)
   .add('with caption', () => (
-    <StaticRouter context={context}>
-      <Route>
-        <IconicLink
-          onClick={action('clicked')}
-          link='test.com'
-          iconColor='var(--gen3-color__highlight-orange)'
-          caption='Hello Link'
-        />
-      </Route>
-    </StaticRouter>
+    <MemoryRouter>
+      <IconicLink
+        onClick={action('clicked')}
+        link='test.com'
+        iconColor='var(--gen3-color__highlight-orange)'
+        caption='Hello Link'
+      />
+    </MemoryRouter>
   ))
   .add('with color', () => (
-    <StaticRouter context={context}>
-      <Route>
-        <IconicLink
-          onClick={action('clicked')}
-          link='test.com'
-          caption="When you click me, I'm orange!"
-        />
-      </Route>
-    </StaticRouter>
+    <MemoryRouter>
+      <IconicLink
+        onClick={action('clicked')}
+        link='test.com'
+        caption="When you click me, I'm orange!"
+      />
+    </MemoryRouter>
   ));


### PR DESCRIPTION
Ticket: [PEDS-584](https://pcdc.atlassian.net/browse/PEDS-584)

This PR migrates React Router to from 5.3 to 6, following [this official migration guide](https://reactrouter.com/docs/en/v6/upgrading/v5). This migration is motivated by the ease of access to the documentation for the new major version as well as the benefit of more robust nested routing & smaller bundle size.

See [this official blog post](https://remix.run/blog/react-router-v6) for more highlights on React Router 6.