### PR TITLE
Fix submission search double requests PEDS-631

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,6 @@
 /* eslint-disable react/prop-types */
 import { lazy, Suspense, useEffect } from 'react';
-import {
-  Outlet,
-  Route,
-  Routes,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom';
+import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
 import Layout from './Layout';
@@ -15,7 +8,6 @@ import ReduxLogin, { fetchLogin } from './Login/ReduxLogin';
 import ProtectedContent from './Login/ProtectedContent';
 // import { fetchCoreMetadata } from './CoreMetadata/reduxer';
 import { fetchAccess } from './UserProfile/ReduxUserProfile';
-import { submitSearchForm } from './QueryNode/ReduxQueryNode';
 import {
   enableResourceBrowser,
   // workspaceUrl,
@@ -50,8 +42,6 @@ function App({ store }) {
   }, []);
 
   const navigate = useNavigate();
-  const params = useParams();
-  const [searchParams] = useSearchParams();
 
   return (
     <Routes>
@@ -147,36 +137,16 @@ function App({ store }) {
             }
           />
         )}
-        <Route path=':project' element={<Outlet />}>
-          <Route
-            index
-            element={
-              <ProtectedContent>
-                <ProjectSubmission />
-              </ProtectedContent>
-            }
-          />
-          <Route
-            path='search'
-            element={
-              <ProtectedContent
-                filter={() =>
-                  Array.from(searchParams.keys()).length > 0
-                    ? // Linking directly to a search result,
-                      // so kick-off search here (rather than on button click)
-                      store.dispatch(
-                        submitSearchForm({
-                          project: params.project,
-                          ...Object.fromEntries(searchParams.entries()),
-                        })
-                      )
-                    : Promise.resolve('ok')
-                }
-              >
-                <ReduxQueryNode />
-              </ProtectedContent>
-            }
-          />
+        <Route
+          path=':project'
+          element={
+            <ProtectedContent>
+              <Outlet />
+            </ProtectedContent>
+          }
+        >
+          <Route index element={<ProjectSubmission />} />
+          <Route path='search' element={<ReduxQueryNode />} />
         </Route>
         {/* <Route
           path='/indexing'

--- a/src/QueryNode/QueryForm.jsx
+++ b/src/QueryNode/QueryForm.jsx
@@ -44,8 +44,7 @@ class QueryForm extends Component {
         data[input.name] = input.value;
       }
     }
-    const url = `/${this.props.project}/search?${queryParam.join('&')}`;
-    this.props.onSearchFormSubmit(data, url);
+    this.props.onSearchFormSubmit(data, queryParam.join('&'));
   }
 
   updateValue(newValue) {

--- a/src/QueryNode/QueryNode.css
+++ b/src/QueryNode/QueryNode.css
@@ -1,8 +1,16 @@
 .query-node__button {
   cursor: pointer;
   float: right;
-  display: inline-block;
+  line-height: 1.6em;
   margin-left: 2em;
+}
+
+button.query-node__button {
+  background: initial;
+  border: none;
+  margin-left: 2em;
+  width: auto;
+  height: auto;
 }
 
 .query-node__button:hover,

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -178,7 +178,7 @@ function QueryNode({
       <h4>most recent 20:</h4>
       {queryNodesList.map(([key, value]) => (
         <ul key={key}>
-          {value.map(({ id, submitter_id: submitterId }, i) => (
+          {value.map(({ id, submitter_id: submitterId }) => (
             <li key={submitterId}>
               <span>{submitterId}</span>
               <a

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -1,4 +1,10 @@
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { jsonToString, getSubmitPath } from '../utils';
 import Popup from '../components/Popup';
@@ -29,6 +35,18 @@ function QueryNode({
 }) {
   const navigate = useNavigate();
   const { project } = useParams();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (Array.from(searchParams.keys()).length > 0)
+      // Linking directly to a search result,
+      // so kick-off search here (rather than on button click)
+      onSearchFormSubmit(
+        { project, ...Object.fromEntries(searchParams.entries()) },
+        null,
+        navigate
+      );
+  }, []);
 
   /**
    * Internal helper to render the 'view node" popup if necessary

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -1,10 +1,5 @@
 import { useEffect } from 'react';
-import {
-  Link,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { jsonToString, getSubmitPath } from '../utils';
 import Popup from '../components/Popup';
@@ -17,7 +12,7 @@ import './QueryNode.css';
  * @param {Object} props.submission
  * @param {Object} props.queryNodes
  * @param {Object} props.popups
- * @param {(value: any, url: string, navigate: import('react-router-dom').NavigateFunction ) => void} props.onSearchFormSubmit
+ * @param {(value: any, cb?: Function) => void} props.onSearchFormSubmit
  * @param {(param: { view_popup: string; nodedelete_popup: boolean | string; }) => void} props.onUpdatePopup
  * @param {() => void} props.onClearDeleteSession
  * @param {(param: { project: string; id: string; }) => void} props.onDeleteNode
@@ -33,19 +28,17 @@ function QueryNode({
   onDeleteNode,
   onStoreNodeInfo,
 }) {
-  const navigate = useNavigate();
   const { project } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     if (Array.from(searchParams.keys()).length > 0)
       // Linking directly to a search result,
       // so kick-off search here (rather than on button click)
-      onSearchFormSubmit(
-        { project, ...Object.fromEntries(searchParams.entries()) },
-        null,
-        navigate
-      );
+      onSearchFormSubmit({
+        project,
+        ...Object.fromEntries(searchParams.entries()),
+      });
   }, []);
 
   /**
@@ -175,8 +168,8 @@ function QueryNode({
       {renderViewPopup().popupEl}
       {renderDeletePopup().popupEl}
       <QueryForm
-        onSearchFormSubmit={(data, url) =>
-          onSearchFormSubmit(data, url, navigate)
+        onSearchFormSubmit={(data, newSearchParams) =>
+          onSearchFormSubmit(data, () => setSearchParams(newSearchParams))
         }
         project={project}
         nodeTypes={submission.nodeTypes}

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -187,32 +187,28 @@ function QueryNode({
               >
                 Download
               </a>
-              <a
-                role='button'
-                tabIndex={0}
+              <button
                 className='query-node__button query-node__button--view'
                 onClick={() =>
                   onStoreNodeInfo({ project, id }).then(() =>
                     onUpdatePopup({ view_popup: true })
                   )
                 }
-                aria-label='View'
+                type='button'
               >
                 View
-              </a>
-              <a
-                role='button'
-                tabIndex={0}
+              </button>
+              <button
                 className='query-node__button query-node__button--delete'
                 onClick={() =>
                   onStoreNodeInfo({ project, id }).then(() =>
                     onUpdatePopup({ nodedelete_popup: true })
                   )
                 }
-                aria-label='Delete'
+                type='button'
               >
                 Delete
-              </a>
+              </button>
             </li>
           ))}
         </ul>

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -13,10 +13,10 @@ import './QueryNode.css';
  * @param {Object} props.queryNodes
  * @param {Object} props.popups
  * @param {(value: any, cb?: Function) => void} props.onSearchFormSubmit
- * @param {(param: { view_popup: string; nodedelete_popup: boolean | string; }) => void} props.onUpdatePopup
+ * @param {(param: { view_popup?: boolean; nodedelete_popup?: boolean | string; }) => void} props.onUpdatePopup
  * @param {() => void} props.onClearDeleteSession
  * @param {(param: { project: string; id: string; }) => void} props.onDeleteNode
- * @param {(param: { project: string; id: string; }) => void} props.onStoreNodeInfo
+ * @param {(param: { project: string; id: string; }) => Promise<void>} props.onStoreNodeInfo
  */
 function QueryNode({
   submission = null,
@@ -44,7 +44,7 @@ function QueryNode({
   /**
    * Internal helper to render the 'view node" popup if necessary
    * based on the popups and queryNodes properties attached to this component.
-   * @return {{ state: 'vieNode' | 'noPopup'; popupEl: JSX.Element | null; }}
+   * @return {{ state: 'viewNode' | 'noPopup'; popupEl: JSX.Element | null; }}
    * state (just used for testing) is string one of [viewNode, noPopup], and
    * popupEl is either null or a <Popup> properly configured to render
    */

--- a/src/QueryNode/ReduxQueryNode.js
+++ b/src/QueryNode/ReduxQueryNode.js
@@ -9,7 +9,7 @@ const clearDeleteSession = {
   type: 'CLEAR_DELETE_SESSION',
 };
 
-export const submitSearchForm = (opts, url, navigate) => (dispatch) => {
+export const submitSearchForm = (opts, cb) => (dispatch) => {
   const nodeType = opts.node_type;
   const submitterId = opts.submitter_id || '';
 
@@ -38,10 +38,7 @@ export const submitSearchForm = (opts, url, navigate) => (dispatch) => {
       }
     })
     .then((msg) => dispatch(msg))
-    .then(() => {
-      if (url) navigate(url);
-      return null;
-    });
+    .then(() => cb?.());
 };
 
 const deleteNode = ({ id, project }) => (dispatch) =>

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -19,7 +19,7 @@ import './Popup.css';
  * @property {string} [error]
  * @property {string} [iconName]
  * @property {PopupButton[]} [leftButtons]
- * @property {{ code: string; label: string }[]} [lines]
+ * @property {{ code: string; label?: string }[]} [lines]
  * @property {string} [message]
  * @property {() => void} [onClose]
  * @property {PopupButton[]} [rightButtons]


### PR DESCRIPTION
Ticket: [PEDS-631](https://pcdc.atlassian.net/browse/PEDS-631)

This PR fixes the bug where clicking "Search" button for project submission search page leads to making requests twice. The bug is caused by a rerendering of `<ProtectedContent>` that is triggered by calling `navigate()` after clicking submit button. This leads to updating `location` value and thus invoking `useEffect()`.

The PR also includes minor fixes and refactoring to relevant components.