### PR TITLE
Fix mistake renaming <MapFiles> prop PEDS-650

### DIFF
--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -144,18 +144,18 @@ export function isFileReady(file) {
 /**
  * @param {Object} props
  * @param {SubmissionFile[]} props.unmappedFiles
- * @param {(username: string) => void} props.fetchSubmissionFiles
+ * @param {(username: string) => void} props.fetchUnmappedFiles
  * @param {(files: SubmissionFile[]) => void} props.mapSelectedFiles
  * @param {string} props.username
  */
 function MapFiles({
   unmappedFiles = [],
-  fetchSubmissionFiles,
+  fetchUnmappedFiles,
   mapSelectedFiles,
   username,
 }) {
   useEffect(() => {
-    fetchSubmissionFiles(username);
+    fetchUnmappedFiles(username);
   }, []);
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -396,7 +396,7 @@ function MapFiles({
 
 MapFiles.propTypes = {
   unmappedFiles: PropTypes.array,
-  fetchSubmissionFiles: PropTypes.func.isRequired,
+  fetchUnmappedFiles: PropTypes.func.isRequired,
   mapSelectedFiles: PropTypes.func.isRequired,
   username: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Ticket: [PEDS-650](https://pcdc.atlassian.net/browse/PEDS-650)

The PR fixes a simple bug caused by https://github.com/chicagopcdc/data-portal/commit/66925d731736da21d501308cf960daa2f3ad172c (part of #306), which mistakenly renamed `fetchUnmappedFiles` prop to `fetchSubmissionFiles`.