### PR TITLE
Remove getReduxStore() helper PEDS-642

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30140,11 +30140,6 @@
         "lodash.isplainobject": "^4.0.6"
       }
     },
-    "redux-persist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
-      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
-    },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-virtualized": "^9.22.3",
     "recharts": "^2.1.6",
     "redux": "^4.1.2",
-    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.4.1",
     "relay-compiler": "^11.0.2",
     "relay-runtime": "^11.0.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import { lazy, Suspense, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
@@ -37,10 +38,13 @@ const UserProfile = lazy(() => import('./UserProfile/ReduxUserProfile'));
 // const Indexing = lazy(() => import('./Indexing/Indexing'));
 // const Workspace = lazy(() => import('./Workspace'));
 
-function App({ store }) {
+function App() {
   useSessionMonitor();
+
+  /** @type {import('redux-thunk').ThunkDispatch} */
+  const dispatch = useDispatch();
   useEffect(() => {
-    store.dispatch(fetchVersionInfo());
+    dispatch(fetchVersionInfo());
   }, []);
 
   return (
@@ -72,10 +76,7 @@ function App({ store }) {
         <Route
           path='login'
           element={
-            <ProtectedContent
-              isPublic
-              filter={() => store.dispatch(fetchLogin())}
-            >
+            <ProtectedContent isPublic filter={() => dispatch(fetchLogin())}>
               <ReduxLogin />
             </ProtectedContent>
           }
@@ -107,7 +108,7 @@ function App({ store }) {
         <Route
           path='identity'
           element={
-            <ProtectedContent filter={() => store.dispatch(fetchAccess())}>
+            <ProtectedContent filter={() => dispatch(fetchAccess())}>
               <UserProfile />
             </ProtectedContent>
           }
@@ -152,7 +153,7 @@ function App({ store }) {
           element={
             <ProtectedContent
               filter={() =>
-                store.dispatch(fetchCoreMetadata(props.match.params[0]))
+                dispatch(fetchCoreMetadata(props.match.params[0]))
               }
             >
               <CoreMetadataPage />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import {
   // workspaceErrorUrl,
 } from './localconf';
 import { fetchVersionInfo } from './actions';
+import useSessionMonitor from './hooks/useSessionMonitor';
 
 // lazy-loaded pages
 const DataDictionary = lazy(() => import('./DataDictionary'));
@@ -37,6 +38,7 @@ const UserProfile = lazy(() => import('./UserProfile/ReduxUserProfile'));
 // const Workspace = lazy(() => import('./Workspace'));
 
 function App({ store }) {
+  useSessionMonitor();
   useEffect(() => {
     store.dispatch(fetchVersionInfo());
   }, []);

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import MediaQuery from 'react-responsive';
 import {
   ReduxIndexButtonBar,
@@ -14,8 +15,9 @@ import { breakpoints } from '../localconf';
 import './page.css';
 
 function IndexPage() {
+  const dispatch = useDispatch();
   useEffect(() => {
-    getIndexPageCounts();
+    dispatch(getIndexPageCounts());
   }, []);
 
   return (

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import MediaQuery from 'react-responsive';
 import {
   ReduxIndexButtonBar,

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useStore } from 'react-redux';
 import { matchPath, Navigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
@@ -10,7 +11,6 @@ import {
   fetchUserAccess,
 } from '../actions';
 import Spinner from '../components/Spinner';
-import getReduxStore from '../reduxStore';
 import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
@@ -18,6 +18,13 @@ import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 /** @typedef {import('../types').UserState} UserState */
 /** @typedef {import('../GraphQLEditor/types').GraphiqlState} GraphiqlState */
 /** @typedef {import('../Submission/types').SubmissionState} SubmissionState */
+/**
+ * @typedef {Object} ReduxState
+ * @property {GraphiqlState} graphiql
+ * @property {ProjectState} project
+ * @property {SubmissionState} submission
+ * @property {UserState} user
+ */
 
 /**
  * @typedef {Object} ProtectedContentState
@@ -53,6 +60,9 @@ function ProtectedContent({
   isPublic = false,
   filter,
 }) {
+  /** @type {{  dispatch: ThunkDispatch; getState: () => ReduxState }} */
+  const reduxStore = useStore();
+
   /** @type {ProtectedContentState} */
   const initialState = {
     authenticated: false,
@@ -66,34 +76,30 @@ function ProtectedContent({
   /**
    * Start filter the 'newState' for the checkLoginStatus component.
    * Check if the user is logged in, and update state accordingly.
-   * @param {Object} store
-   * @param {ThunkDispatch} store.dispatch
-   * @param {() => { user: UserState }} store.getState
    * @param {ProtectedContentState} currentState
-   * @returns {Promise<ProtectedContentState>}
    */
-  function checkLoginStatus(store, currentState) {
-    const newState = {
+  function checkLoginStatus(currentState) {
+    const newState = /** @type {ProtectedContentState} */ ({
       ...currentState,
       authenticated: true,
       redirectTo: null,
-      user: store.getState().user,
-    };
+      user: reduxStore.getState().user,
+    });
 
     // assume we're still logged in after 1 minute ...
     if (Date.now() - newState.user.lastAuthMs < 60000)
       return Promise.resolve(newState);
 
-    return store
+    return reduxStore
       .dispatch(fetchUser()) // make an API call to see if we're still logged in ...
       .then(() => {
-        newState.user = store.getState().user;
+        newState.user = reduxStore.getState().user;
         if (!newState.user.username) {
           // not authenticated
           newState.redirectTo = '/login';
           newState.authenticated = false;
         } else {
-          store.dispatch(fetchUserAccess());
+          reduxStore.dispatch(fetchUserAccess());
         }
         return newState;
       });
@@ -102,7 +108,6 @@ function ProtectedContent({
   /**
    * Check if user is registered, and update state accordingly.
    * @param {ProtectedContentState} currentState
-   * @returns {ProtectedContentState}
    */
   function checkIfRegisterd(currentState) {
     const isUserRegistered =
@@ -117,7 +122,6 @@ function ProtectedContent({
   /**
    * Check if user is admin if needed, and update state accordingly.
    * @param {ProtectedContentState} currentState
-   * @returns {ProtectedContentState}
    */
   function checkIfAdmin(currentState) {
     if (!isAdminOnly) return currentState;
@@ -128,26 +132,21 @@ function ProtectedContent({
     return isAdminUser ? currentState : { ...currentState, redirectTo: '/' };
   }
 
-  /**
-   * Fetch resources on demand based on path
-   * @param {Object} store
-   * @param {ThunkDispatch} store.dispatch
-   * @param {() => { graphiql: GraphiqlState; project: ProjectState; submission: SubmissionState }} store.getState
-   */
-  function fetchResources({ dispatch, getState }) {
-    const { graphiql, project, submission } = getState();
+  /** Fetch resources on demand based on path */
+  function fetchResources() {
+    const { graphiql, project, submission } = reduxStore.getState();
     /** @param {string[]} patterns */
     function matchPathOneOf(patterns) {
       return patterns.some((pattern) => matchPath(pattern, location.pathname));
     }
 
     if (matchPathOneOf(LOCATIONS_DICTIONARY) && !submission.dictionary) {
-      dispatch(fetchDictionary());
+      reduxStore.dispatch(fetchDictionary());
     } else if (matchPathOneOf(LOCATIONS_PROJECTS) && !project.projects) {
-      dispatch(fetchProjects());
+      reduxStore.dispatch(fetchProjects());
     } else if (matchPathOneOf(LOCATIONS_SCHEMA)) {
-      if (!graphiql.schema) dispatch(fetchSchema());
-      if (!graphiql.guppySchema) dispatch(fetchGuppySchema());
+      if (!graphiql.schema) reduxStore.dispatch(fetchSchema());
+      if (!graphiql.guppySchema) reduxStore.dispatch(fetchGuppySchema());
     }
   }
 
@@ -163,32 +162,28 @@ function ProtectedContent({
       /** @type {{ scrollY?: number }} */ (location?.state)?.scrollY ?? 0
     );
 
-    getReduxStore().then((store) =>
-      Promise.all([
-        store.dispatch({ type: 'CLEAR_COUNTS' }), // clear some counters
-        store.dispatch({ type: 'CLEAR_QUERY_NODES' }),
-      ]).then(() => {
-        if (isPublic)
-          if (typeof filter === 'function')
-            filter().finally(() => updateState(state));
-          else updateState(state);
-        else
-          checkLoginStatus(store, state)
-            .then(checkIfRegisterd)
-            .then(checkIfAdmin)
-            .then((newState) => {
-              if (newState.authenticated && typeof filter === 'function')
-                filter().finally(() => {
-                  updateState(newState);
-                  fetchResources(store);
-                });
-              else {
-                updateState(newState);
-                fetchResources(store);
-              }
+    reduxStore.dispatch({ type: 'CLEAR_COUNTS' }); // clear some counters
+    reduxStore.dispatch({ type: 'CLEAR_QUERY_NODES' });
+
+    if (isPublic)
+      if (typeof filter === 'function')
+        filter().finally(() => updateState(state));
+      else updateState(state);
+    else
+      checkLoginStatus(state)
+        .then(checkIfRegisterd)
+        .then(checkIfAdmin)
+        .then((newState) => {
+          if (newState.authenticated && typeof filter === 'function')
+            filter().finally(() => {
+              updateState(newState);
+              fetchResources();
             });
-      })
-    );
+          else {
+            updateState(newState);
+            fetchResources();
+          }
+        });
   }, [location]);
 
   if (state.redirectTo) return <Navigate to={state.redirectTo} replace />;

--- a/src/Submission/MapDataModel.jsx
+++ b/src/Submission/MapDataModel.jsx
@@ -8,9 +8,9 @@ import BackLink from '../components/BackLink';
 import { getProjectsList } from './relayer';
 import CheckmarkIcon from '../img/icons/status_confirm.svg';
 import InputWithIcon from '../components/InputWithIcon';
+import useSessionMonitor from '../hooks/useSessionMonitor';
 import GQLHelper from '../gqlHelper';
 import environment from '../environment';
-import sessionMonitor from '../SessionMonitor';
 import { headers, submissionApiPath } from '../localconf';
 import './MapDataModel.css';
 
@@ -210,6 +210,8 @@ function MapDataModel({
     if (filesToMap.length === 0) navigate('/submission/files');
     getProjectsList();
   }, []);
+
+  const sessionMonitor = useSessionMonitor();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [nodeType, setNodeType] = useState(null);

--- a/src/Submission/MapDataModel.jsx
+++ b/src/Submission/MapDataModel.jsx
@@ -5,7 +5,6 @@ import { fetchQuery } from 'relay-runtime';
 import Button from '../gen3-ui-component/components/Button';
 import Toaster from '../gen3-ui-component/components/Toaster';
 import BackLink from '../components/BackLink';
-import { getProjectsList } from './relayer';
 import CheckmarkIcon from '../img/icons/status_confirm.svg';
 import InputWithIcon from '../components/InputWithIcon';
 import useSessionMonitor from '../hooks/useSessionMonitor';
@@ -194,6 +193,7 @@ function submitFilesToMap(program, project, files) {
  * @param {Object} props
  * @param {Object} [props.dictionary]
  * @param {Object[]} [props.filesToMap]
+ * @param {() => void} [props.getProjectsList]
  * @param {string[]} [props.nodeTypes]
  * @param {Object} [props.projects]
  * @param {Function} [props.submitFiles]
@@ -201,6 +201,7 @@ function submitFilesToMap(program, project, files) {
 function MapDataModel({
   dictionary = {},
   filesToMap = [],
+  getProjectsList = () => {},
   nodeTypes = [],
   projects = null,
   submitFiles = submitFilesToMap,
@@ -491,6 +492,7 @@ function MapDataModel({
 MapDataModel.propTypes = {
   dictionary: PropTypes.object,
   filesToMap: PropTypes.array,
+  getProjectsList: PropTypes.func,
   nodeTypes: PropTypes.array,
   projects: PropTypes.object,
   submitFiles: PropTypes.func,

--- a/src/Submission/MapDataModel.test.jsx
+++ b/src/Submission/MapDataModel.test.jsx
@@ -1,17 +1,11 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
 import MapDataModel, {
   getParentNodes,
   isValidSubmission,
 } from './MapDataModel';
 import * as testData from './__test__/data.json';
-import { getProjectsList } from './relayer';
 
-jest.mock('./relayer');
-getProjectsList.mockImplementation(() => jest.fn());
-
-const history = createMemoryHistory('/submission/map');
 const projects = {
   test: { name: 'test', counts: [], charts: [], code: 'test' },
 };
@@ -44,7 +38,7 @@ test('renders', () => {
         projects={projects}
         dictionary={dictionary}
         nodeTypes={['aligned_reads_index']}
-        history={history}
+        getProjectsList={() => {}}
         submitFiles={() => {}}
       />
     </MemoryRouter>

--- a/src/Submission/ReduxMapDataModel.js
+++ b/src/Submission/ReduxMapDataModel.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import MapDataModel from './MapDataModel';
+import { getProjectsList } from './relayer';
 
 const ReduxMapDataModel = (() => {
   /** @param {{ submission: import('./types').SubmissionState }} state */
@@ -10,7 +11,14 @@ const ReduxMapDataModel = (() => {
     dictionary: state.submission.dictionary,
   });
 
-  return connect(mapStateToProps)(MapDataModel);
+  /** @param {import('redux-thunk').ThunkDispatch} dispatch */
+  const mapDispatchToProps = (dispatch) => ({
+    getProjectsList: () => {
+      dispatch(getProjectsList());
+    },
+  });
+
+  return connect(mapStateToProps, mapDispatchToProps)(MapDataModel);
 })();
 
 export default ReduxMapDataModel;

--- a/src/Submission/ReduxSubmitTSV.js
+++ b/src/Submission/ReduxSubmitTSV.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import SubmitTSV from './SubmitTSV';
-import sessionMonitor from '../SessionMonitor';
 import { getCounts } from '../DataModelGraph/ReduxDataModelGraph';
 import { submissionApiPath, lineLimit } from '../localconf';
 import { fetchWithCreds } from '../actions';
@@ -11,11 +10,13 @@ import { uploadTSV, updateFileContent } from './actions';
 /** @typedef {import('./types').SubmissionState} SubmissionState */
 
 /**
- * @param {string} fullProject
- * @param {string} methodIn
+ * @param {Object} args
+ * @param {string} args.fullProject
+ * @param {string} [args.methodIn]
+ * @param {() => void} [args.callback]
  */
 const submitToServer =
-  (fullProject, methodIn = 'PUT') =>
+  ({ fullProject, methodIn = 'PUT', callback }) =>
   /**
    * @param {Dispatch} dispatch
    * @param {() => { submission: SubmissionState }} getState
@@ -98,7 +99,7 @@ const submitToServer =
           total: totalChunk,
         }))
         .then((msg) => dispatch(msg))
-        .then(() => sessionMonitor.updateUserActivity());
+        .then(callback);
     }
 
     return recursiveFetch(fileArray);
@@ -119,10 +120,10 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(uploadTSV(value, type));
   },
   /** @param {string} project */
-  onSubmitClick: (project) => {
-    dispatch(submitToServer(project));
+  onSubmitClick: (project, callback) => {
+    dispatch(submitToServer({ fullProject: project, callback }));
   },
-  /** @param {SubmissionState['file']} */
+  /** @param {SubmissionState['file']} value */
   onFileChange: (value) => {
     dispatch(updateFileContent(value));
   },

--- a/src/Submission/SubmitTSV.jsx
+++ b/src/Submission/SubmitTSV.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/theme-kuroir';
+import useSessionMonitor from '../hooks/useSessionMonitor';
 import { predictFileType } from '../utils';
 import SubmissionResult from './SubmissionResult';
 import { SubmissionStateType } from './propTypeDef';
@@ -30,7 +31,7 @@ import './SubmitTSV.css';
  * @param {(file: string, fileType: string) => void} props.onFileChange triggered when user edits something in tsv/json AceEditor
  * @param {(nodeTypes: string[], project: string, dictionary: Object) => void} props.onFinish
  * @param {(file: string, fileType: string) => void} props.onUploadClick
- * @param {(project: string) => void} props.onSubmitClick
+ * @param {(project: string, callback?: () => void) => void} props.onSubmitClick
  */
 function SubmitTSV({
   project,
@@ -71,8 +72,9 @@ function SubmitTSV({
     e.currentTarget.value = null;
   }
 
+  const sessionMonitor = useSessionMonitor();
   function handleSubmitFile() {
-    onSubmitClick(project);
+    onSubmitClick(project, () => sessionMonitor.updateUserActivity());
   }
 
   /** @param {string} value */

--- a/src/Submission/page.jsx
+++ b/src/Submission/page.jsx
@@ -1,12 +1,14 @@
 import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import ProjectDashboard from './ProjectDashboard';
 import ReduxTransaction from './ReduxTransaction';
 import { getTransactionList, getProjectsList } from './relayer';
 
 function SubmissionPage() {
+  const dispatch = useDispatch();
   useEffect(() => {
-    getProjectsList();
-    getTransactionList();
+    dispatch(getProjectsList());
+    dispatch(getTransactionList());
   }, []);
 
   return (

--- a/src/Submission/relayer.js
+++ b/src/Submission/relayer.js
@@ -1,107 +1,67 @@
 import { fetchQuery, graphql } from 'relay-runtime';
 import environment from '../environment';
-import getReduxStore from '../reduxStore';
 import GQLHelper from '../gqlHelper';
 import { config } from '../params';
 
-const updateReduxTransactionList = async (transactionList) =>
-  getReduxStore().then(
-    (store) => {
-      const submissionState = store.getState().submission || {};
-      if (submissionState) {
-        store.dispatch({
-          type: 'RECEIVE_TRANSACTION_LIST',
-          data: transactionList,
-        });
-        return 'dispatch';
-      }
-      return 'NOOP';
-    },
-    () => {}
-  );
-
-const updateReduxError = async (error) =>
-  getReduxStore().then((store) => {
-    store.dispatch({ type: 'RECEIVE_RELAY_FAIL', data: error });
-  });
-
-export const getTransactionList = () => {
-  const query = graphql`
-    query relayerTransactionLogComponentQuery {
-      transactionList: transaction_log(last: 20) {
-        id
-        submitter
-        project_id
-        created_datetime
-        documents {
-          doc_size
-          doc
+export const getTransactionList =
+  () => (/** @type {import('redux').Dispatch} */ dispatch) => {
+    const query = graphql`
+      query relayerTransactionLogComponentQuery {
+        transactionList: transaction_log(last: 20) {
+          id
+          submitter
+          project_id
+          created_datetime
+          documents {
+            doc_size
+            doc
+          }
+          state
         }
-        state
       }
-    }
-  `;
-  fetchQuery(environment, query, {}).subscribe({
-    next: (data) => {
-      updateReduxTransactionList(data.transactionList);
-    },
-    error: (error) => {
-      updateReduxError(error);
-    },
-  });
-};
+    `;
+    fetchQuery(environment, query, {}).subscribe({
+      next: (data) => {
+        dispatch({
+          type: 'RECEIVE_TRANSACTION_LIST',
+          data: data.transactionList,
+        });
+      },
+      error: (error) => {
+        dispatch({ type: 'RECEIVE_RELAY_FAIL', data: error });
+      },
+    });
+  };
 
 const gqlHelper = GQLHelper.getGQLHelper();
-
-const updateReduxProjectList = async ({ projectList, summaryCounts }) =>
-  getReduxStore().then(
-    (store) => {
-      const submissionState = store.getState().submission || {};
-      if (!submissionState.projectsByName) {
-        store.dispatch({
-          type: 'RECEIVE_PROJECT_LIST',
-          data: { projectList, summaryCounts },
-        });
-        return 'dispatch';
-      }
-      return 'NOOP';
-    },
-    (err) => {
-      console.error('WARNING: failed to load redux store', err);
-      return 'ERR';
-    }
-  );
 
 /**
  * Translate relay properties to {summaryCounts, projectList} structure
  * that is friendly to underlying components.
- *
- * @param data
- * @return {projectList, summaryCounts}
  */
 const transformRelayProps = (data) => {
   const { fileCount } = GQLHelper.extractFileInfo(data);
   const nodeCount = Math.min(config.graphql.boardCounts.length + 1, 4);
-  const projectList = (data.projectList || []).map((proj) =>
-    // fill in missing properties
-    ({
-      name: 'unknown',
-      counts: new Array(nodeCount).fill(0),
-      charts: [0, 0],
-      ...proj,
-    })
+  const projectList = /** @type {Array} */ (data.projectList || []).map(
+    (proj) =>
+      // fill in missing properties
+      ({
+        name: 'unknown',
+        counts: new Array(nodeCount).fill(0),
+        charts: [0, 0],
+        ...proj,
+      })
   );
-  let summaryCounts = Object.keys(data)
+  const summaryCounts = Object.keys(data)
     .filter((key) => key.indexOf('count') === 0)
     .map((key) => key)
     .sort()
     .map((key) => data[key]);
-  if (summaryCounts.length < 4) {
-    summaryCounts = [...summaryCounts, fileCount];
-  }
+
   return {
     projectList,
-    summaryCounts,
+    summaryCounts:
+      summaryCounts.length < 4 ? [...summaryCounts, fileCount] : summaryCounts,
   };
 };
 
@@ -125,74 +85,46 @@ const extractCharts = (data) =>
     .sort()
     .map((key) => data[key]);
 
-const updateProjectDetailToRedux = (projInfo) => {
-  getReduxStore()
-    .then((store) => {
-      store.dispatch({ type: 'RECEIVE_PROJECT_DETAIL', data: projInfo });
-    })
-    .catch((err) => {
-      /* eslint no-console: ["error", { allow: ["error"] }] */
-      console.error('WARNING: failed to load redux store', err);
+const getProjectDetail =
+  (projectList) => (/** @type {import('redux').Dispatch} */ dispatch) => {
+    projectList.forEach((project) => {
+      fetchQuery(environment, gqlHelper.projectDetailQuery, {
+        name: project.name,
+      }).subscribe({
+        next: (data) => {
+          dispatch({
+            type: 'RECEIVE_PROJECT_DETAIL',
+            data: {
+              ...data.project[0],
+              counts: extractCounts(data),
+              charts: extractCharts(data),
+            },
+          });
+        },
+      });
     });
-};
+  };
 
-const getProjectDetail = (projectList) => {
-  projectList.forEach((project) => {
-    fetchQuery(environment, gqlHelper.projectDetailQuery, {
-      name: project.name,
-    }).subscribe({
-      next: (data) => {
-        const projInfo = {
-          ...data.project[0],
-          counts: extractCounts(data),
-          charts: extractCharts(data),
-        };
-        updateProjectDetailToRedux(projInfo);
-      },
-    });
-  });
-};
-
-const checkSubmissionPageState = (stateName) =>
-  getReduxStore().then(
-    (store) => {
-      const submissionState = store.getState().submission || {};
-      const nowMs = Date.now();
-      if (
-        !Object.prototype.hasOwnProperty.call(submissionState, stateName) ||
-        (Object.prototype.hasOwnProperty.call(submissionState, stateName) &&
-          nowMs - submissionState[stateName] > 300000)
-      ) {
-        return 'OLD';
-      }
-      return 'FRESH';
-    },
-    (err) => {
-      /* eslint no-console: ["error", { allow: ["error"] }] */
-      console.error('WARNING: failed to load redux store', err);
-      return 'ERR';
-    }
-  );
-
-export const getProjectsList = () => {
-  checkSubmissionPageState('lastestListUpdating').then(
-    (res) => {
-      if (res === 'OLD') {
-        fetchQuery(environment, gqlHelper.submissionPageQuery, {}).subscribe({
-          next: (data) => {
-            const { projectList, summaryCounts } = transformRelayProps(data);
-            updateReduxProjectList({ projectList, summaryCounts }).then(() =>
-              getProjectDetail(projectList)
-            );
-          },
-          error: (error) => {
-            updateReduxError(error);
-          },
-        });
-      }
-    },
-    (error) => {
-      updateReduxError(error);
-    }
-  );
-};
+export const getProjectsList =
+  () =>
+  /**
+   * @param {import('redux-thunk').ThunkDispatch} dispatch
+   * @param {() => { submission: import('./types').SubmissionState }} getState
+   */
+  (dispatch, getState) => {
+    const { lastestListUpdating } = getState().submission;
+    if (!lastestListUpdating || Date.now() - lastestListUpdating > 300000)
+      fetchQuery(environment, gqlHelper.submissionPageQuery, {}).subscribe({
+        next: (data) => {
+          const { projectList, summaryCounts } = transformRelayProps(data);
+          dispatch({
+            type: 'RECEIVE_PROJECT_LIST',
+            data: { projectList, summaryCounts },
+          });
+          dispatch(getProjectDetail(projectList));
+        },
+        error: (error) => {
+          dispatch({ type: 'RECEIVE_RELAY_FAIL', data: error });
+        },
+      });
+  };

--- a/src/UserRegistration/ReduxUserRegistration.js
+++ b/src/UserRegistration/ReduxUserRegistration.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
     if (user.authz['/portal'] !== undefined) {
       dispatch({ type: 'RECEIVE_USER', user });
       dispatch(fetchUserAccess());
-      getIndexPageCounts();
+      dispatch(getIndexPageCounts());
       return 'success';
     }
     throw new Error('Failed to update authorization information.');

--- a/src/hooks/useSessionMonitor.js
+++ b/src/hooks/useSessionMonitor.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import sessionMonitor from '../SessionMonitor';
+
+export default function useSessionMonitor() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    sessionMonitor.useDispatch(dispatch);
+    sessionMonitor.start();
+  }, []);
+
+  return sessionMonitor;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -48,7 +48,7 @@ library.add(
 render(
   <Provider store={reduxStore}>
     <BrowserRouter basename={basename}>
-      <App store={reduxStore} />
+      <App />
     </BrowserRouter>
   </Provider>,
   document.getElementById('root')

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,13 +21,9 @@ import getReduxStore from './reduxStore';
 import { gaTracking } from './params';
 import { basename } from './localconf';
 import App from './App';
-import sessionMonitor from './SessionMonitor';
 import '@fontsource/raleway';
 import './gen3-ui-component/css/base.css';
 import './gen3-ui-component/css/icon.css';
-
-// monitor user's session
-sessionMonitor.start();
 
 // Google Analytics
 ReactGA.initialize(gaTracking);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,7 +17,7 @@ import {
 import ReactGA from 'react-ga';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import getReduxStore from './reduxStore';
+import reduxStore from './reduxStore';
 import { gaTracking } from './params';
 import { basename } from './localconf';
 import App from './App';
@@ -45,17 +45,11 @@ library.add(
   faTrashAlt
 );
 
-// render the app after the store is configured
-async function init() {
-  const store = await getReduxStore();
-  render(
-    <Provider store={store}>
-      <BrowserRouter basename={basename}>
-        <App store={store} />
-      </BrowserRouter>
-    </Provider>,
-    document.getElementById('root')
-  );
-}
-
-init();
+render(
+  <Provider store={reduxStore}>
+    <BrowserRouter basename={basename}>
+      <App store={reduxStore} />
+    </BrowserRouter>
+  </Provider>,
+  document.getElementById('root')
+);

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -3,22 +3,19 @@ import thunk from 'redux-thunk';
 import { mockStore, requiredCerts } from './localconf';
 import reducers from './reducers';
 
-function getpreloadedState() {
-  const state = {
-    user: {},
-    status: {},
-    versionInfo: { dataVersion: '', portalVersion: process.env.PORTAL_VERSION },
-  };
-
-  if (process.env.NODE_ENV !== 'production' && mockStore) {
-    state.user = { username: 'test', certificates_uploaded: requiredCerts };
-  }
-
-  return state;
-}
-
-const preloadedState = getpreloadedState();
-// @ts-ignore
+const preloadedState = {
+  user:
+    process.env.NODE_ENV !== 'production' && mockStore
+      ? { username: 'test', certificates_uploaded: requiredCerts }
+      : {},
+  status: {},
+  versionInfo: {
+    dataVersion: '',
+    dictionaryVersion: '',
+    portalVersion: process.env.PORTAL_VERSION,
+  },
+};
+// @ts-expect-error
 const composeWithDevTools = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 const composeEnhancers =
   process.env.NODE_ENV !== 'production' && composeWithDevTools !== undefined
@@ -27,22 +24,5 @@ const composeEnhancers =
 const enhancer = composeEnhancers(applyMiddleware(thunk));
 
 /** @type {import('redux').Store} */
-let store;
-
-/* eslint-disable no-underscore-dangle */
-/**
- * Little lazy redux store singleton factory.
- * We want some Relayjs adapters to also update the Redux store,
- * so it's handy to be able to access the store outside of
- * the normal react-redux 'connect' mechanism.
- *
- * @return Promisified Redux store
- */
-const getReduxStore = () => {
-  if (store) return Promise.resolve(store);
-
-  store = createStore(reducers, preloadedState, enhancer);
-  return Promise.resolve(store);
-};
-
-export default getReduxStore;
+const store = createStore(reducers, preloadedState, enhancer);
+export default store;

--- a/src/reduxStore.js
+++ b/src/reduxStore.js
@@ -1,16 +1,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
-import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 import thunk from 'redux-thunk';
 import { mockStore, requiredCerts } from './localconf';
 import reducers from './reducers';
-
-const persistConfig = {
-  key: 'primary',
-  storage,
-  whitelist: ['certificate'],
-};
-const reducer = persistReducer(persistConfig, reducers);
 
 function getpreloadedState() {
   const state = {
@@ -35,12 +26,8 @@ const composeEnhancers =
     : compose;
 const enhancer = composeEnhancers(applyMiddleware(thunk));
 
-/** @typedef {import('redux').Store} ReduxStore */
-
-/** @type {ReduxStore} */
+/** @type {import('redux').Store} */
 let store;
-/** @type {Promise<ReduxStore>} */
-let storePromise;
 
 /* eslint-disable no-underscore-dangle */
 /**
@@ -52,21 +39,10 @@ let storePromise;
  * @return Promisified Redux store
  */
 const getReduxStore = () => {
-  // singleton
   if (store) return Promise.resolve(store);
 
-  // store setup is in process
-  if (storePromise) return storePromise;
-
-  storePromise = new Promise((resolve, reject) => {
-    try {
-      store = createStore(reducer, preloadedState, enhancer);
-      persistStore(store, null, () => resolve(store));
-    } catch (e) {
-      reject(e);
-    }
-  });
-  return storePromise;
+  store = createStore(reducers, preloadedState, enhancer);
+  return Promise.resolve(store);
 };
 
 export default getReduxStore;


### PR DESCRIPTION
Ticket: [PEDS-642](https://pcdc.atlassian.net/browse/PEDS-642)

This PR removes the use of `getReduxStore()` helper that was meant for accessing the Redux store outside of its normal context and replaces it with more idiomatic patterns using Redux thunks and Redux-React hooks (i.e. `useStore()`, `useDispatch()`). Part of this effort involves using the `sessionMonitor` instance via custom hook (`useSessionMonitor()`).

In doing so, the PR also removes the use of `redux-persist`, which was only there to persist state that is no longer in use (e163e49646af7142a88601ae6c51e166388ebc50, also see https://github.com/chicagopcdc/data-portal/pull/210).