### PR TITLE
Add filter finder to explorer page PEDS-652

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.css
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.css
@@ -3,6 +3,10 @@
   flex-flow: column;
 }
 
+.g3-filter-group__filter-finder {
+  margin-bottom: 1rem;
+}
+
 .g3-filter-group__tabs {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Ticket: [PEDS-652](https://pcdc.atlassian.net/browse/PEDS-652)

This PR adds a simple filter finder feature to explorer page, which allows users to quickly search and select filter to use across all filter tabs. Selecting the filter to user will move browser focus to the relevant filter section.

Here's a quick demo video:

https://user-images.githubusercontent.com/22449454/150853876-d023f77c-47b5-4523-a04b-0028537eb331.mov

