### PR TITLE
Remove the use of tier access limit config value PEDS-654

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -90,9 +90,9 @@ function ConnectedFilter({
   return (
     <FilterGroup
       className={className}
-      disabledTooltipMessage={`This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${tierAccessLimit} ${
-        guppyConfig.nodeCountTitle?.toLowerCase() || guppyConfig.dataType
-      } or more.`}
+      disabledTooltipMessage={
+        'This resource is currently disabled because you are exploring restricted data. You are limited to exploring cohorts of a size greater than or equal to the access limit.'
+      }
       filterConfig={filterConfig}
       lockedTooltipMessage={`You may only view summary information for this project. You do not have ${guppyConfig.dataType}-level access.`}
       onAnchorValueChange={onAnchorValueChange}

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -31,7 +31,6 @@ import {
  * @property {(x: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
  * @property {SimpleAggsData} tabsOptions
- * @property {number} [tierAccessLimit]
  */
 
 /** @param {ConnectedFilterProps} props */
@@ -50,7 +49,6 @@ function ConnectedFilter({
   onPatientIdsChange,
   patientIds,
   tabsOptions,
-  tierAccessLimit,
 }) {
   if (
     hidden ||
@@ -102,7 +100,6 @@ function ConnectedFilter({
       hideZero={hideZero}
       initialAppliedFilters={initialAppliedFilters}
       tabs={filterTabs}
-      tierAccessLimit={tierAccessLimit}
     />
   );
 }
@@ -144,7 +141,6 @@ ConnectedFilter.propTypes = {
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   tabsOptions: PropTypes.object.isRequired,
-  tierAccessLimit: PropTypes.number,
 };
 
 export default ConnectedFilter;

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useSearchParams } from 'react-router-dom';
-import { tierAccessLimit, explorerConfig } from '../localconf';
+import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 
 /** @typedef {import('./types').AlteredExplorerConfig} AlteredExplorerConfig */
@@ -92,7 +92,6 @@ export function ExplorerConfigProvider({ children }) {
           patientIdsConfig: config.patientIds,
           survivalAnalysisConfig: config.survivalAnalysis,
           tableConfig: config.table,
-          tierAccessLimit,
         },
         explorerId,
         explorerOptions,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -18,7 +18,7 @@ import './ExplorerFilter.css';
 
 /** @param {ExplorerFilterProps} props */
 function ExplorerFilter({ className = '', ...filterProps }) {
-  const { adminAppliedPreFilters, filterConfig, guppyConfig, tierAccessLimit } =
+  const { adminAppliedPreFilters, filterConfig, guppyConfig } =
     useExplorerConfig().current;
   const {
     initialAppliedFilters,
@@ -33,7 +33,6 @@ function ExplorerFilter({ className = '', ...filterProps }) {
     guppyConfig,
     initialAppliedFilters,
     patientIds,
-    tierAccessLimit,
     onPatientIdsChange: handlePatientIdsChange,
   };
   const hasAppliedFilters = Object.keys(filterProps.filter).length > 0;

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -177,7 +177,6 @@ function ExplorerVisualization({
     patientIdsConfig,
     survivalAnalysisConfig,
     tableConfig,
-    tierAccessLimit,
   } = useExplorerConfig().current;
   const nodeCountTitle =
     guppyConfig.nodeCountTitle || capitalizeFirstLetter(guppyConfig.dataType);
@@ -196,9 +195,8 @@ function ExplorerVisualization({
     totalCount,
   });
   const isComponentLocked = accessibleCount === 0;
-  const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${tierAccessLimit} ${
-    guppyConfig.nodeCountTitle.toLowerCase() || guppyConfig.dataType
-  }.`;
+  const lockMessage =
+    'The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit.';
 
   const buttonGroupProps = {
     buttonConfig,

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -95,7 +95,6 @@ export type AlteredExplorerConfig = {
   patientIdsConfig?: PatientIdsConfig;
   survivalAnalysisConfig: SurvivalAnalysisConfig;
   tableConfig: TableConfig;
-  tierAccessLimit: number;
 };
 
 export type ExplorerFilterSet = {

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -48,7 +48,6 @@ function findFilterElement(label) {
  * @property {FilterChangeHandler} [onFilterChange]
  * @property {(patientIds: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
- * @property {number} [tierAccessLimit]
  * @property {FilterSectionConfig[][]} tabs
  */
 
@@ -68,7 +67,6 @@ function FilterGroup({
   onPatientIdsChange,
   patientIds,
   tabs,
-  tierAccessLimit,
 }) {
   const filterTabs = filterConfig.tabs.map(
     ({ title, fields, searchFields }) => ({
@@ -370,7 +368,6 @@ function FilterGroup({
               handleToggleCombineMode(index, ...args)
             }
             options={section.options}
-            tierAccessLimit={tierAccessLimit}
             title={section.title}
             tooltip={section.tooltip}
           />
@@ -406,7 +403,6 @@ FilterGroup.propTypes = {
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   tabs: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
-  tierAccessLimit: PropTypes.number,
 };
 
 export default FilterGroup;

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -44,7 +44,6 @@ function getNumValuesSelected(filterStatus) {
  * @property {(isExpanded: boolean) => void} [onToggle]
  * @property {(fieldName: string, value: string) => void} [onToggleCombineMode]
  * @property {(SingleSelectFilterOption[] | RangeFilterOption[])} options
- * @property {number} [tierAccessLimit]
  * @property {string} [title]
  * @property {string} [tooltip]
  */
@@ -81,7 +80,6 @@ function FilterSection({
   onToggle = () => {},
   onToggleCombineMode = () => {},
   options = defaultOptions,
-  tierAccessLimit,
   title = '',
   tooltip,
 }) {
@@ -424,7 +422,6 @@ function FilterSection({
           lockedTooltipMessage={lockedTooltipMessage}
           onSelect={handleSelectSingleSelectFilter}
           selected={filterStatus[option.text]}
-          tierAccessLimit={tierAccessLimit}
         />
       );
     });
@@ -617,7 +614,6 @@ FilterSection.propTypes = {
       rangeStep: PropTypes.number, // by default 1
     })
   ),
-  tierAccessLimit: PropTypes.number,
   title: PropTypes.string,
   tooltip: PropTypes.string,
   lockedTooltipMessage: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/SingleSelectFilter/index.jsx
+++ b/src/gen3-ui-component/components/filters/SingleSelectFilter/index.jsx
@@ -15,7 +15,6 @@ import './SingleSelectFilter.css';
  * @property {string} lockedTooltipMessage
  * @property {(label: string) => void} onSelect
  * @property {boolean} selected
- * @property {number} tierAccessLimit
  */
 
 function SingleSelectFilter({
@@ -29,7 +28,6 @@ function SingleSelectFilter({
   lockedTooltipMessage = '',
   onSelect,
   selected,
-  tierAccessLimit,
 }) {
   if (count === 0 && hideZero) {
     return null;
@@ -49,14 +47,9 @@ function SingleSelectFilter({
   if (count === hideValue) {
     // we don't disable selected filters
     inputDisabled = !isChecked;
-    countIconComponent = tierAccessLimit ? (
-      <span className='g3-badge g3-single-select-filter__count'>
-        {Number(tierAccessLimit).toLocaleString()}
-        <i className='g3-icon--under g3-icon g3-icon--sm g3-icon-color__base-blue' />
-      </span>
-    ) : (
+    countIconComponent = (
       <span className='g3-single-select-filter__icon-background'>
-        <i className='g3-icon--under g3-icon g3-icon--sm g3-icon-color__base-blue' />
+        <i className='g3-icon--lock g3-icon g3-icon--sm g3-icon-color__base-blue' />
       </span>
     );
 
@@ -127,7 +120,6 @@ SingleSelectFilter.propTypes = {
   lockedTooltipMessage: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   selected: PropTypes.bool,
-  tierAccessLimit: PropTypes.number,
 };
 
 export default SingleSelectFilter;

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -22,7 +22,6 @@ function buildConfig(opts) {
     workspaceURL: process.env.WORKSPACE_URL,
     manifestServiceURL: process.env.MANIFEST_SERVICE_URL,
     gaDebug: process.env.GA_DEBUG === 'true',
-    tierAccessLimit: Number.parseInt(process.env.TIER_ACCESS_LIMIT, 10) || 1000,
   };
 
   // Override default basename if loading via /dev.html
@@ -42,7 +41,6 @@ function buildConfig(opts) {
     workspaceURL,
     manifestServiceURL,
     gaDebug,
-    tierAccessLimit,
   } = Object.assign(defaults, opts);
 
   function ensureTrailingSlash(url) {
@@ -188,7 +186,6 @@ function buildConfig(opts) {
     externalLoginOptionsUrl,
     showFenceAuthzOnProfile,
     terraExportWarning,
-    tierAccessLimit,
     useIndexdAuthz,
     authzPath,
     enableResourceBrowser,

--- a/src/stories/gen3-ui-component/filters.jsx
+++ b/src/stories/gen3-ui-component/filters.jsx
@@ -221,7 +221,6 @@ storiesOf('Filters', module)
         onSelect={action('checked')}
         count={-1}
         accessible
-        tierAccessLimit={1000}
       />
       <SingleSelectFilter
         label='Option4'
@@ -234,7 +233,6 @@ storiesOf('Filters', module)
         onSelect={action('checked')}
         count={-1}
         accessible={false}
-        tierAccessLimit={1000}
       />
       <SingleSelectFilter
         label='Option6'
@@ -247,13 +245,11 @@ storiesOf('Filters', module)
         onSelect={action('checked')}
         count={-1}
         accessible
-        tierAccessLimit={123456789}
       />
       <SingleSelectFilter
         label='Option8'
         onSelect={action('checked')}
         count={123456789}
-        accessible={false}
       />
     </div>
   ))
@@ -311,7 +307,6 @@ storiesOf('Filters', module)
       options={ethnicityOptions}
       onSelect={action('checked')}
       onAfterDrag={action('range change')}
-      tierAccessLimit={1000}
     />
   ))
   .add('FilterSection for array-type field', () => (
@@ -321,7 +316,6 @@ storiesOf('Filters', module)
       onSelect={action('checked')}
       onAfterDrag={action('range change')}
       onCombineOptionToggle={action('combine mode change')}
-      tierAccessLimit={1000}
       isArrayField
     />
   ))
@@ -341,7 +335,6 @@ storiesOf('Filters', module)
         title={'File GUIDs'}
         onSelect={handleSelect}
         options={selectedOptions}
-        tierAccessLimit={1000}
         isSearchFilter
         onSearchFilterLoadOptions={(searchString, offset = 0) => {
           const pageSize = 20;


### PR DESCRIPTION
Ticket: [PEDS-654](https://pcdc.atlassian.net/browse/PEDS-654)

This PR removes the use of `tierAccessLimit` config value from the portal app. The value, provided via `TIER_ACCESS_LIMIT` environment variable, is only used for display purposes and has no other behavioral implications. 

While the use of `tierAccessLimit` in the portal app has little gain, it introduces unnecessary risk of going out of sync with `guppy` service, which also takes the same `TIER_ACCESS_LIMIT` environment variable. Removing its use simplifies the codebase and avoids the potential bug of out-of-sync `TIER_ACCESS_LIMIT` values between portal and `guppy`.