### PR TITLE
Create & use filter info object PEDS-656

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -134,6 +134,7 @@ ConnectedFilter.propTypes = {
       PropTypes.shape({
         field: PropTypes.string,
         name: PropTypes.string,
+        tooltip: PropTypes.string,
       })
     ),
     nodeCountTitle: PropTypes.string,

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -77,7 +77,7 @@ function ConnectedFilter({
       adminAppliedPreFilters,
       arrayFields: arrayFields.current,
       fields,
-      fieldMapping: guppyConfig.fieldMapping,
+      filterInfo: filterConfig.info,
       guppyConfig,
       initialTabsOptions,
       searchFields,
@@ -114,6 +114,12 @@ ConnectedFilter.propTypes = {
       options: PropTypes.arrayOf(PropTypes.string),
       tabs: PropTypes.arrayOf(PropTypes.string),
     }),
+    info: PropTypes.objectOf(
+      PropTypes.shape({
+        label: PropTypes.string,
+        tooltip: PropTypes.string,
+      })
+    ),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -73,16 +73,16 @@ function ConnectedFilter({
   }, []);
 
   const filterTabs = filterConfig.tabs.map(({ fields, searchFields }) =>
-    getFilterSections(
-      fields,
-      searchFields,
-      guppyConfig.fieldMapping,
-      processedTabsOptions,
-      initialTabsOptions,
+    getFilterSections({
       adminAppliedPreFilters,
+      arrayFields: arrayFields.current,
+      fields,
+      fieldMapping: guppyConfig.fieldMapping,
       guppyConfig,
-      arrayFields.current
-    )
+      initialTabsOptions,
+      searchFields,
+      tabsOptions: processedTabsOptions,
+    })
   );
 
   return (

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -240,17 +240,6 @@ const getSingleFilterOption = (histogramResult, initHistogramRes) => {
 };
 
 /**
- * @param {string} str
- */
-const capitalizeFirstLetter = (str) => {
-  const res = str.replace(/_|\./gi, ' ');
-  return res.replace(
-    /\w\S*/g,
-    (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-  );
-};
-
-/**
  * createSearchFilterLoadOptionsFn creates a handler function that loads the search filter's
  * autosuggest options as the user types in the search filter.
  * @param {string} field
@@ -319,7 +308,7 @@ export const checkIsArrayField = (field, arrayFields) => {
  * @param {{ [x:string]: OptionFilter }} args.adminAppliedPreFilters
  * @param {string[][]} args.arrayFields
  * @param {string[]} args.fields
- * @param {{ field: string; name?: string; tooltip?: string }[]} args.fieldMapping
+ * @param {FilterConfig['info']} args.filterInfo
  * @param {GuppyConfig} args.guppyConfig
  * @param {SimpleAggsData} args.initialTabsOptions
  * @param {string[]} args.searchFields
@@ -330,7 +319,7 @@ export const getFilterSections = ({
   adminAppliedPreFilters,
   arrayFields,
   fields,
-  fieldMapping = [],
+  filterInfo,
   guppyConfig,
   initialTabsOptions,
   searchFields,
@@ -343,8 +332,7 @@ export const getFilterSections = ({
     // to search over all options, instead of displaying all options in a list. This allows
     // guppy/portal to support filters that have too many options to be displayed in a list.
     searchFieldSections = searchFields.map((field) => {
-      const fieldConfig = fieldMapping.find((entry) => entry.field === field);
-      const label = fieldConfig?.name ?? capitalizeFirstLetter(field);
+      const { label, tooltip } = filterInfo[field];
 
       const tabsOptionsFiltered = { ...tabsOptions[field] };
       if (Object.keys(adminAppliedPreFilters).includes(field)) {
@@ -373,14 +361,13 @@ export const getFilterSections = ({
           field,
           guppyConfig
         ),
-        tooltip: fieldConfig?.tooltip,
+        tooltip,
       };
     });
   }
 
   const sections = fields.map((field) => {
-    const fieldConfig = fieldMapping.find((entry) => entry.field === field);
-    const label = fieldConfig?.name ?? capitalizeFirstLetter(field);
+    const { label, tooltip } = filterInfo[field];
 
     const tabsOptionsFiltered = { ...tabsOptions[field] };
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
@@ -402,7 +389,7 @@ export const getFilterSections = ({
       title: label,
       options: defaultOptions,
       isArrayField: fieldIsArrayField,
-      tooltip: fieldConfig?.tooltip,
+      tooltip,
     };
   });
   return searchFieldSections.concat(sections);

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -4,6 +4,7 @@ import { queryGuppyForRawData } from './queries';
 /** @typedef {import('../types').AggsCount} AggsCount */
 /** @typedef {import('../types').AggsData} AggsData */
 /** @typedef {import('../types').FilterState} FilterState */
+/** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
@@ -190,9 +191,8 @@ export const mergeTabOptions = (firstTabsOptions, secondTabsOptions) => {
       secondTabsOptions[`${optKey}`] && secondTabsOptions[`${optKey}`].histogram
         ? secondTabsOptions[`${optKey}`].histogram
         : [];
-    mergedTabOptions[`${optKey}`].histogram = firstHistogram.concat(
-      secondHistogram
-    );
+    mergedTabOptions[`${optKey}`].histogram =
+      firstHistogram.concat(secondHistogram);
   });
   return mergedTabOptions;
 };
@@ -257,49 +257,47 @@ const capitalizeFirstLetter = (str) => {
  * @param {GuppyConfig} guppyConfig
  * @returns {(searchString: string, offset: number) => Promise}
  */
-const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (
-  searchString,
-  offset
-) =>
-  new Promise((resolve, reject) => {
-    // If searchString is empty return just the first NUM_SEARCH_OPTIONS options.
-    // This allows the client to show default options in the search filter before
-    // the user has started searching.
-    /** @type {GqlFilter | undefined} */
-    const gqlFilter = searchString
-      ? { search: { keyword: searchString, fields: [field] } }
-      : undefined;
+const createSearchFilterLoadOptionsFn =
+  (field, guppyConfig) => (searchString, offset) =>
+    new Promise((resolve, reject) => {
+      // If searchString is empty return just the first NUM_SEARCH_OPTIONS options.
+      // This allows the client to show default options in the search filter before
+      // the user has started searching.
+      /** @type {GqlFilter | undefined} */
+      const gqlFilter = searchString
+        ? { search: { keyword: searchString, fields: [field] } }
+        : undefined;
 
-    queryGuppyForRawData({
-      type: guppyConfig.dataType,
-      fields: [field],
-      gqlFilter,
-      offset,
-      withTotalCount: true,
-    })
-      .then((res) => {
-        if (!res.data || !res.data[guppyConfig.dataType]) {
-          resolve({
-            options: [],
-            hasMore: false,
-          });
-        } else {
-          const results = res.data[guppyConfig.dataType];
-          const totalCount =
-            res.data._aggregation[guppyConfig.dataType]._totalCount;
-          resolve({
-            options: results.map((result) => ({
-              value: result[field],
-              label: result[field],
-            })),
-            hasMore: totalCount > offset + results.length,
-          });
-        }
+      queryGuppyForRawData({
+        type: guppyConfig.dataType,
+        fields: [field],
+        gqlFilter,
+        offset,
+        withTotalCount: true,
       })
-      .catch((err) => {
-        reject(err);
-      });
-  });
+        .then((res) => {
+          if (!res.data || !res.data[guppyConfig.dataType]) {
+            resolve({
+              options: [],
+              hasMore: false,
+            });
+          } else {
+            const results = res.data[guppyConfig.dataType];
+            const totalCount =
+              res.data._aggregation[guppyConfig.dataType]._totalCount;
+            resolve({
+              options: results.map((result) => ({
+                value: result[field],
+                label: result[field],
+              })),
+              hasMore: totalCount > offset + results.length,
+            });
+          }
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
 
 /**
  * @param {string} field
@@ -317,25 +315,27 @@ export const checkIsArrayField = (field, arrayFields) => {
 };
 
 /**
- * @param {string[]} fields
- * @param {string[]} searchFields
- * @param {{ field: string; name?: string; tooltip?: string }[]} fieldMapping
- * @param {SimpleAggsData} tabsOptions
- * @param {SimpleAggsData} initialTabsOptions
- * @param {{ [x:string]: OptionFilter }} adminAppliedPreFilters
- * @param {GuppyConfig} guppyConfig
- * @param {string[][]} arrayFields
+ * @param {Object} args
+ * @param {{ [x:string]: OptionFilter }} args.adminAppliedPreFilters
+ * @param {string[][]} args.arrayFields
+ * @param {string[]} args.fields
+ * @param {{ field: string; name?: string; tooltip?: string }[]} args.fieldMapping
+ * @param {GuppyConfig} args.guppyConfig
+ * @param {SimpleAggsData} args.initialTabsOptions
+ * @param {string[]} args.searchFields
+ * @param {SimpleAggsData} args.tabsOptions
+ * @returns {import('../../gen3-ui-component/components/filters/types').FilterSectionConfig[]}
  */
-export const getFilterSections = (
-  fields,
-  searchFields,
-  fieldMapping = [],
-  tabsOptions,
-  initialTabsOptions,
+export const getFilterSections = ({
   adminAppliedPreFilters,
+  arrayFields,
+  fields,
+  fieldMapping = [],
   guppyConfig,
-  arrayFields
-) => {
+  initialTabsOptions,
+  searchFields,
+  tabsOptions,
+}) => {
   let searchFieldSections = [];
 
   if (searchFields) {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -82,6 +82,12 @@ export type FilterTabsOption = {
 
 export type FilterConfig = {
   anchor?: AnchorConfig;
+  info?: /* runtime only */ {
+    [field: string]: {
+      label: string;
+      tooltip?: string;
+    };
+  };
   tabs: FilterTabsOption[];
 };
 
@@ -90,7 +96,8 @@ export type GuppyConfig = {
   nodeCountTitle: string;
   fieldMapping?: {
     field: string;
-    name: string;
+    name?: string;
+    tooltip?: string;
   }[];
   manifestMapping?: {
     resourceIndexType: string;

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
+import { createFilterInfo } from './utils';
 
 /** @typedef {import('./types').AlteredExplorerConfig} AlteredExplorerConfig */
 
@@ -85,7 +86,13 @@ export function ExplorerConfigProvider({ children }) {
             terraTemplate: config.terraTemplate,
           },
           chartConfig: config.charts,
-          filterConfig: config.filters,
+          filterConfig: {
+            ...config.filters,
+            info: createFilterInfo(
+              config.filters,
+              config.guppyConfig.fieldMapping
+            ),
+          },
           getAccessButtonLink: config.getAccessButtonLink,
           guppyConfig: config.guppyConfig,
           hideGetAccessButton: config.hideGetAccessButton,

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -13,7 +13,15 @@ import dictIcons from '../../img/icons/index';
 
 /** @typedef {import('react-table').Column} ReactTableColumn */
 /** @typedef {import('../types').GqlSort} GqlSort */
+/** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
+/**
+ * @typedef {Object} TableConfig
+ * @property {string[]} fields
+ * @property {FilterConfig['info']} filterInfo
+ * @property {string[]} linkFields
+ * @property {boolean} ordered
+ */
 
 /**
  * @param {Object} args
@@ -152,7 +160,7 @@ function parseDataForTable(rawData) {
  * @property {GuppyConfig} guppyConfig
  * @property {boolean} isLocked
  * @property {Object[]} [rawData]
- * @property {{ fields: string[]; linkFields: string[]; ordered: boolean }} tableConfig
+ * @property {TableConfig} tableConfig
  * @property {number} totalCount
  */
 
@@ -168,8 +176,8 @@ function ExplorerTable({
   tableConfig,
   totalCount,
 }) {
-  const { dataType, downloadAccessor, fieldMapping } = guppyConfig;
-  const { fields, linkFields, ordered } = tableConfig;
+  const { dataType, downloadAccessor } = guppyConfig;
+  const { fields, filterInfo, linkFields, ordered } = tableConfig;
   if ((fields ?? []).length === 0) return null;
 
   const [pageSize, setPageSize] = useState(defaultPageSize);
@@ -182,8 +190,7 @@ function ExplorerTable({
    * @returns {ReactTableColumn}
    */
   function buildColumnConfig(field) {
-    const overrideName = fieldMapping?.find((i) => i.field === field)?.name;
-    const columnName = overrideName ?? capitalizeFirstLetter(field);
+    const columnName = filterInfo[field]?.label ?? capitalizeFirstLetter(field);
 
     return {
       Header: columnName,

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -171,6 +171,7 @@ function ExplorerVisualization({
   const {
     buttonConfig,
     chartConfig,
+    filterConfig,
     getAccessButtonLink,
     guppyConfig,
     hideGetAccessButton = false,
@@ -218,6 +219,7 @@ function ExplorerVisualization({
     className: 'explorer-visualization__table',
     tableConfig: {
       fields: tableColumnsOrdered ? tableConfig.fields : allFields,
+      filterInfo: filterConfig.info,
       ordered: tableColumnsOrdered,
       linkFields: tableConfig.linkFields || [],
     },

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -6,6 +6,7 @@ export const GuppyConfigType = PropTypes.shape({
     PropTypes.shape({
       field: PropTypes.string,
       name: PropTypes.string,
+      tooltip: PropTypes.string,
     })
   ),
   manifestMapping: PropTypes.shape({

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -1,8 +1,11 @@
 /** @typedef {import('./types').ButtonConfig} ButtonConfig */
 /** @typedef {import('./types').ExplorerFilters} ExplorerFilters */
 /** @typedef {import('./types').FilterConfig} FilterConfig */
+/** @typedef {import('./types').GuppyConfig} GuppyConfig */
 /** @typedef {import('./types').PatientIdsConfig} PatientIdsConfig */
 /** @typedef {import('./types').SingleButtonConfig} SingleButtonConfig */
+
+import { capitalizeFirstLetter } from '../utils';
 
 /**
  * Buttons are grouped by their dropdownId value.
@@ -162,4 +165,22 @@ export function extractExplorerStateFromURL(
     : undefined;
 
   return { initialAppliedFilters, patientIds };
+}
+/**
+ * @param {FilterConfig} filterConfig
+ * @param {GuppyConfig['fieldMapping']} fieldMapping
+ */
+export function createFilterInfo(filterConfig, fieldMapping) {
+  const map = /** @type {FilterConfig['info']} */ ({});
+
+  for (const { field, name, tooltip } of fieldMapping)
+    map[field] = { label: name ?? capitalizeFirstLetter(field), tooltip };
+
+  const allFields = filterConfig.tabs.flatMap(({ fields }) => fields);
+  if ('anchor' in filterConfig) allFields.push(filterConfig.anchor.field);
+
+  for (const field of allFields)
+    if (!(field in map)) map[field] = { label: capitalizeFirstLetter(field) };
+
+  return map;
 }

--- a/src/GuppyDataExplorer/utils.test.js
+++ b/src/GuppyDataExplorer/utils.test.js
@@ -1,4 +1,8 @@
-import { calculateDropdownButtonConfigs, humanizeNumber } from './utils';
+import {
+  calculateDropdownButtonConfigs,
+  createFilterInfo,
+  humanizeNumber,
+} from './utils';
 
 describe('utils for data visualization explorer', () => {
   it('calculate dropdown button configurations correctly', () => {
@@ -58,6 +62,27 @@ describe('utils for data visualization explorer', () => {
       },
     };
     expect(calculateDropdownButtonConfigs(input)).toEqual(expectOutput);
+  });
+
+  it('creates filter info object', () => {
+    const filterConfig = {
+      anchor: { field: 'anchor_field', options: [], tabs: [] },
+      tabs: [
+        { title: 'a', fields: ['foo_foo', 'foo_bar'] },
+        { title: 'b', fields: ['bar.baz'] },
+      ],
+    };
+    const fieldMapping = [
+      { field: 'foo_bar', name: 'Customized Name' },
+      { field: 'bar.baz', tooltip: 'lorem ipsum' },
+    ];
+    const expected = {
+      anchor_field: { label: 'Anchor Field' },
+      foo_foo: { label: 'Foo Foo' },
+      foo_bar: { label: 'Customized Name' },
+      'bar.baz': { label: 'Bar Baz', tooltip: 'lorem ipsum' },
+    };
+    expect(createFilterInfo(filterConfig, fieldMapping)).toEqual(expected);
   });
 
   it('humanize number', () => {


### PR DESCRIPTION
Ticket: [PEDS-656](https://pcdc.atlassian.net/browse/PEDS-656)

This PR creates and uses `filterConfig.info` object that maps each filter's field name to its relevant info, which either comes from `guppyConfig.fieldMapping` array if available (label and/or tooltip) or generated (label only). By doing this work once, we can avoid having to iterate over `guppyConfig.fieldMapping` whenever we need to extract the config-provided info on each filter.

This PR also includes minor refactoring & fixing types.

Note: While `<ExplorerHeatMap>` could also be refactored to take advantage of `filterConfig.info`, I skipped the work because the component is currently not in use.