### PR TITLE
Display filters in use PEDS-651

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
@@ -44,6 +44,13 @@
   line-height: 2rem;
 }
 
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
+  .explorer-filter-info .pill {
+    font-size: 12px;
+  }
+}
+
 .explorer-filter-info .pill.anchor {
   padding: 8px 4px;
   line-height: 2.2rem;

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
@@ -1,0 +1,64 @@
+.explorer-filter-info {
+  background-color: var(--g3-color__white);
+  padding: 0.5rem 1rem;
+  margin: 0.5rem 0;
+}
+
+.explorer-filter-info__collapsed {
+  max-height: 5.5rem;
+  overflow-y: scroll;
+}
+
+.explorer-filter-info > button {
+  background-color: inherit;
+  border: none;
+  height: 1rem;
+  width: 1rem;
+  margin-right: 0.25rem;
+}
+
+.explorer-filter-info > button:disabled {
+  cursor: not-allowed;
+}
+
+.explorer-filter-info > button > i {
+  background-color: var(--g3-color__bg-coal);
+}
+
+.explorer-filter-info__collapse {
+  max-height: 90px;
+  overflow-x: scroll;
+}
+
+.explorer-filter-info > h4 {
+  display: inline-block;
+  margin-right: 0.25rem;
+}
+
+.explorer-filter-info .pill {
+  background-color: var(--g3-color__bg-cloud);
+  border: 1px solid var(--g3-color__lightgray);
+  border-radius: 4px;
+  padding: 4px;
+  margin: 2px;
+  line-height: 2rem;
+}
+
+.explorer-filter-info .pill.anchor {
+  padding: 8px 4px;
+  line-height: 2.2rem;
+}
+
+.explorer-filter-info .pill > * {
+  border-right: 1px solid var(--g3-color__lightgray);
+  padding: 2px 4px;
+  margin: 0 2px;
+}
+
+.explorer-filter-info .pill > *:last-child {
+  border-right: none;
+}
+
+.explorer-filter-info .pill code {
+  background-color: inherit;
+}

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import { useEffect, useRef, useState } from 'react';
+import Tooltip from 'rc-tooltip';
+import 'rc-tooltip/assets/bootstrap_white.css';
+import './ExplorerFilterDisplay.css';
+
+/**
+ * @typedef {Object} FilterDisplayProps
+ * @property {import('../types').ExplorerFilters} filter
+ * @property {import('../types').FilterConfig['info']} filterInfo
+ */
+
+/** @param {FilterDisplayProps} props */
+function FilterDisplay({ filter, filterInfo }) {
+  const filterElements = /** @type {JSX.Element[]} */ ([]);
+  for (const [key, value] of Object.entries(filter))
+    if ('filter' in value) {
+      const [anchorKey, anchorValue] = key.split(':');
+      filterElements.push(
+        <span key={key} className='pill anchor'>
+          <span className='token field'>
+            With <code>{filterInfo[anchorKey].label}</code> of{' '}
+            <code>{`"${anchorValue}"`}</code>
+          </span>
+          <span className='token'>
+            ( <FilterDisplay filter={value.filter} filterInfo={filterInfo} /> )
+          </span>
+        </span>
+      );
+    } else if ('selectedValues' in value) {
+      filterElements.push(
+        <span key={key} className='pill'>
+          <span className='token'>
+            <code>{filterInfo[key].label}</code>{' '}
+            {value.selectedValues.length > 1 ? 'is any of ' : 'is '}
+          </span>
+          <span className='token'>
+            {value.selectedValues.length > 1 ? (
+              <Tooltip
+                arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                overlay={value.selectedValues.map((v) => `"${v}"`).join(', ')}
+                placement='bottom'
+                trigger={['hover', 'focus']}
+              >
+                <span>
+                  <code>{`"${value.selectedValues[0]}"`}</code>, ...
+                </span>
+              </Tooltip>
+            ) : (
+              <code>{`"${value.selectedValues[0]}"`}</code>
+            )}
+          </span>
+        </span>
+      );
+    } else {
+      filterElements.push(
+        <span key={key} className='pill'>
+          <span className='token'>
+            <code>{filterInfo[key].label}</code> is between
+          </span>
+          <span className='token'>
+            <code>
+              ({value.lowerBound}, {value.upperBound})
+            </code>
+          </span>
+        </span>
+      );
+    }
+
+  return (
+    <>
+      {filterElements.map((filterElement, i) => (
+        <>
+          {filterElement}
+          {i < filterElements.length - 1 && <span className='pill'>AND</span>}
+        </>
+      ))}
+    </>
+  );
+}
+
+FilterDisplay.propTypes = {
+  filter: PropTypes.any,
+  filterInfo: PropTypes.any,
+};
+
+/** @param {FilterDisplayProps} props */
+function ExplorerFilterDisplay({ filter, filterInfo }) {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current?.offsetHeight < ref.current?.scrollHeight) {
+      if (!isOverflowing) setIsOverflowing(true);
+    } else if (isOverflowing) {
+      setIsOverflowing(false);
+    }
+  });
+  return (
+    <div
+      ref={ref}
+      className={`explorer-filter-info ${
+        isCollapsed ? 'explorer-filter-info__collapsed' : ''
+      }`.trim()}
+    >
+      {Object.keys(filter).length > 0 ? (
+        <>
+          <button
+            type='button'
+            onClick={() => setIsCollapsed((s) => !s)}
+            disabled={isCollapsed && !isOverflowing}
+          >
+            <i
+              className={`g3-icon g3-icon--sm g3-icon--chevron-${
+                isCollapsed ? 'right' : 'down'
+              }`}
+            />
+          </button>
+          <h4>Filters in Use:</h4>
+          <FilterDisplay filter={filter} filterInfo={filterInfo} />
+        </>
+      ) : (
+        <h4>← Try Filters to explore data</h4>
+      )}
+    </div>
+  );
+}
+
+ExplorerFilterDisplay.propTypes = FilterDisplay.propTypes;
+
+export default ExplorerFilterDisplay;

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -10,6 +10,7 @@ import DataSummaryCardGroup from '../../components/cards/DataSummaryCardGroup';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import ExplorerRequestAccessButton from '../ExplorerRequestAccessButton';
 import ExplorerExploreExternalButton from '../ExplorerExploreExternalButton';
+import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
 import ReduxExplorerButtonGroup from '../ExplorerButtonGroup/ReduxExplorerButtonGroup';
@@ -263,6 +264,9 @@ function ExplorerVisualization({
           <ReduxExplorerButtonGroup {...buttonGroupProps} />
         </div>
       </div>
+      {explorerView !== 'survival analysis' && (
+        <ExplorerFilterDisplay filter={filter} filterInfo={filterConfig.info} />
+      )}
       <ViewContainer
         showIf={explorerView === 'summary view'}
         isLoading={isLoadingAggsData}


### PR DESCRIPTION
Ticket: [PEDS-651](https://pcdc.atlassian.net/browse/PEDS-651)

This PR implements a new UI component to display filters in use for the explorer. While the current filter state is already available in various forms (e.g. `?filter` search param in URL, filters UI, filter set UI), they all fall short in user-friendliness. The new UI aims to address this gap and makes it easy for users to see all filters in use in a more accessible format.

See an example screenshot:
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/22449454/151260494-2e618a0b-9b3c-4907-a31b-1bc316c11495.png">

Some key points:
* The "survival analysis" view does not include the new UI since the tool doesn't directly interact with explorer filters.
* The new UI is currently for display only--i.e. no handling user input
* The new UI has a set maximum height, but can be expanded/collapsed
* For option type filters, if more than one option is selected, the values are truncated; users can still view all selected values via tooltip

