### PR TITLE
Fix potential infinite render loop for <MapFiles>

### DIFF
--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -141,15 +141,18 @@ export function isFileReady(file) {
   return file.hashes && Object.keys(file.hashes).length > 0;
 }
 
+/** @type {SubmissionFile[]} */
+const defaultUnmapedFiles = [];
+
 /**
  * @param {Object} props
- * @param {SubmissionFile[]} props.unmappedFiles
+ * @param {SubmissionFile[]} [props.unmappedFiles]
  * @param {(username: string) => void} props.fetchUnmappedFiles
  * @param {(files: SubmissionFile[]) => void} props.mapSelectedFiles
  * @param {string} props.username
  */
 function MapFiles({
-  unmappedFiles = [],
+  unmappedFiles = defaultUnmapedFiles,
   fetchUnmappedFiles,
   mapSelectedFiles,
   username,


### PR DESCRIPTION
This PR fixes the potential infinite render loop for `<MapFiles>` component caused by the default value for `unmappedFiles` prop (an empty array `[]`) coupled with the `useEffect()` hook that depends on `unmappedFiles` prop. Since `useEffect()`  relies on referential equality check, the `unmappedFiles` prop, a new empty array, may trigger `useEffect()`, leading to infinite loop. This is fixed by using a `const` value for default `unmappedFiles` value.

In practice, the component may not face it since the `fetchUnmappedFiles()` call on mount would likely bring in a new, different prop value for `unmappedFiles`. Still, there's a risk that the new `unmappedFiles` is still an empty array.

The PR also updates the tests for `<MapFiles>` to use updated props and fix type errors.