### PR TITLE
Patch release 1.2.1 PEDS-658

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.16.12",

--- a/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.jsx
+++ b/src/DataDictionary/search/DictionarySearchHistory/DictionarySearchHistory.jsx
@@ -3,16 +3,16 @@ import './DictionarySearchHistory.css';
 
 /**
  * @param {Object} props
- * @param {() => void} props.onClearSearchHistoryItems
- * @param {(keyword: string) => void} props.onClickSearchHistoryItem
- * @param {import('../../types').SearchHistoryItem[]} props.searchHistoryItems
+ * @param {() => void} [props.onClearSearchHistoryItems]
+ * @param {(keyword: string) => void} [props.onClickSearchHistoryItem]
+ * @param {import('../../types').SearchHistoryItem[]} [props.searchHistoryItems]
  */
 function DictionarySearchHistory({
   onClearSearchHistoryItems,
   onClickSearchHistoryItem,
-  searchHistoryItems = [],
+  searchHistoryItems,
 }) {
-  return searchHistoryItems.length > 0 ? (
+  return searchHistoryItems?.length > 0 ? (
     <div className='dictionary-search-history'>
       <div className='dictionary-search-history__title'>
         <h4 className='dictionary-search-history__title-text'>Last Search</h4>


### PR DESCRIPTION
Ticket: [PEDS-658](https://pcdc.atlassian.net/browse/PEDS-658)

This PR bumps the project version to 1.0.2.

The PR includes the fix for crashing /DD page when no existing search history is available in the local storage. This bug was introduced in https://github.com/chicagopcdc/data-portal/commit/3fc218fb16858db9563a35a58b502766613cd2f5 (part of https://github.com/chicagopcdc/data-portal/pull/306), which replaced the check for whether `searchHistoryItems` prop exists with a default prop value. This change failed to handle the case of `null` value for `searchHistoryItems`. The fix uses optional chaining syntax to correctly handle `null` value.