### PR TITLE
Require user agreement for survival analysis tool PEDS-114

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -167,3 +167,19 @@
     max-width: auto;
   }
 }
+
+.explorer-survival-analysis__user-agreement {
+  margin: 1rem;
+  width: 100%;
+}
+
+.explorer-survival-analysis__user-agreement > ul {
+  list-style-type: initial;
+  margin-top: 1rem;
+  max-width: 80ch;
+  padding-left: 2rem;
+}
+
+.explorer-survival-analysis__user-agreement > button {
+  margin-top: 2rem;
+}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -1,16 +1,20 @@
 /* eslint-disable no-shadow */
 import { memo, useState } from 'react';
 import Spinner from '../../components/Spinner';
+import Button from '../../gen3-ui-component/components/Button';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import useSurvivalAnalysisResult from './useSurvivalAnalysisResult';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
 import RiskTable from './RiskTable';
+import { checkUserAgreement, handleUserAgreement } from './utils';
 import './ExplorerSurvivalAnalysis.css';
 
 /** @typedef {import('./types').UserInputSubmitHandler} UserInputSubmitHandler */
 
 function ExplorerSurvivalAnalysis() {
+  const [isUserCompliant, setIsUserCompliant] = useState(checkUserAgreement());
+
   const [[risktable, survival], refershResult] = useSurvivalAnalysisResult();
   const [timeInterval, setTimeInterval] = useState(4);
   const [startTime, setStartTime] = useState(0);
@@ -43,47 +47,91 @@ function ExplorerSurvivalAnalysis() {
 
   return (
     <div className='explorer-survival-analysis'>
-      <div className='explorer-survival-analysis__column-left'>
-        <ControlForm
-          onSubmit={handleSubmit}
-          timeInterval={timeInterval}
-          isError={isError}
-        />
-      </div>
-      <div className='explorer-survival-analysis__column-right'>
-        {/* eslint-disable-next-line no-nested-ternary */}
-        {isUpdating ? (
-          <Spinner />
-        ) : isError ? (
-          <div className='explorer-survival-analysis__error'>
-            <h1>Error obtaining survival analysis result...</h1>
-            <p>
-              Please retry by clicking {'"Apply"'} button or refreshing the
-              page. If the problem persists, please contact administrator for
-              more information.
-            </p>
+      {isUserCompliant ? (
+        <>
+          <div className='explorer-survival-analysis__column-left'>
+            <ControlForm
+              onSubmit={handleSubmit}
+              timeInterval={timeInterval}
+              isError={isError}
+            />
           </div>
-        ) : (
-          <>
-            {config.result?.survival && (
-              <SurvivalPlot
-                data={survival}
-                endTime={endTime}
-                startTime={startTime}
-                timeInterval={timeInterval}
-              />
+          <div className='explorer-survival-analysis__column-right'>
+            {/* eslint-disable-next-line no-nested-ternary */}
+            {isUpdating ? (
+              <Spinner />
+            ) : isError ? (
+              <div className='explorer-survival-analysis__error'>
+                <h1>Error obtaining survival analysis result...</h1>
+                <p>
+                  Please retry by clicking {'"Apply"'} button or refreshing the
+                  page. If the problem persists, please contact administrator
+                  for more information.
+                </p>
+              </div>
+            ) : (
+              <>
+                {config.result?.survival && (
+                  <SurvivalPlot
+                    data={survival}
+                    endTime={endTime}
+                    startTime={startTime}
+                    timeInterval={timeInterval}
+                  />
+                )}
+                {config.result?.risktable && (
+                  <RiskTable
+                    data={risktable}
+                    endTime={endTime}
+                    startTime={startTime}
+                    timeInterval={timeInterval}
+                  />
+                )}
+              </>
             )}
-            {config.result?.risktable && (
-              <RiskTable
-                data={risktable}
-                endTime={endTime}
-                startTime={startTime}
-                timeInterval={timeInterval}
-              />
-            )}
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      ) : (
+        <div className='explorer-survival-analysis__user-agreement'>
+          <p>
+            In order to use the Survival Analysis analytics tool, you must agree
+            to the following:
+          </p>
+          <ul>
+            <li>
+              I will not engage in “p-hacking” or other forms of statistical
+              abuse.
+            </li>
+            <li>
+              I will maintain a hypothesis record and declare a hypothesis
+              before analyzing data.
+            </li>
+            <li>
+              I will not reproduce or distribute results generated using
+              analytics tools.
+            </li>
+            <li>
+              I understand and agree that use of analytics tools is logged and
+              monitored to identify abuse and improve the tools. Individual user
+              data may be shared with partners of the PCDC (e.g., member
+              consortia) for operational purposes. Aggregate or de-identified
+              user data may be shared outside of the PCDC without limitation.
+            </li>
+            <li>
+              I understand that access may be revoked if a user is suspected to
+              engage in statistical abuse.
+            </li>
+          </ul>
+          <Button
+            buttonType='primary'
+            label='I Agree'
+            onClick={() => {
+              handleUserAgreement();
+              setIsUserCompliant(checkUserAgreement());
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -44,3 +44,13 @@ export const filterRisktableByTime = (data, startTime, endTime = Infinity) =>
     data: data.filter(({ time }) => time >= startTime && time <= endTime),
     name,
   }));
+
+const userAgreementLocalStorageKey = `survival:userAgreement`;
+
+export function checkUserAgreement() {
+  return window.sessionStorage.getItem(userAgreementLocalStorageKey) === 'true';
+}
+
+export function handleUserAgreement() {
+  return window.sessionStorage.setItem(userAgreementLocalStorageKey, 'true');
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -240,6 +240,8 @@ export const logoutAPI =
           },
         });
       else document.location.replace(response.url);
+
+      window.localStorage.clear();
     });
 
 /**


### PR DESCRIPTION
Ticket: [PEDS-114](https://pcdc.atlassian.net/browse/PEDS-114)

This PR adds a user agreement UI that users must agree to before accessing survival analysis tool. See the image below:

<img width="861" alt="image" src="https://user-images.githubusercontent.com/22449454/152015866-05537103-433d-4531-953f-868445a134fd.png">

The agreement is required for each login session--i.e. users must agree to it each time they log in and access the tool. The agreement status is stored in the browser local storage, which is cleared on logout.

The PR also impacts other value stored in local storage, which are now cleared on logout as well and include:
* Data dictionary page search history state
* Query page `graphiql` editor state (query string, query history, etc.)

This change seems reasonable and even desirable since it prevents the saved state to be applied across different users on the same browser.