### PR TITLE
Replace react-responsive with react-resize-detector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12954,9 +12954,9 @@
       }
     },
     "@types/resize-observer-browser": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz",
-      "integrity": "sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg=="
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
+      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "@types/retry": {
       "version": "0.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16505,11 +16505,6 @@
         }
       }
     },
-    "css-mediaquery": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
-    },
     "css-select": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
@@ -20764,11 +20759,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
-    "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -24798,14 +24788,6 @@
       "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
       "dev": true
     },
-    "matchmediaquery": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
-      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
-      "requires": {
-        "css-mediaquery": "^0.1.2"
-      }
-    },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -28355,17 +28337,6 @@
         "resize-observer-polyfill": "^1.5.1"
       }
     },
-    "react-responsive": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
-      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1",
-        "shallow-equal": "^1.1.0"
-      }
-    },
     "react-router": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
@@ -29875,11 +29846,6 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
-    },
-    "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-helmet": "^6.1.0",
     "react-redux": "^7.2.6",
     "react-relay": "^11.0.2",
+    "react-resize-detector": "^6.7.8",
     "react-responsive": "^8.2.0",
     "react-router-dom": "^6.2.1",
     "react-select": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "react-redux": "^7.2.6",
     "react-relay": "^11.0.2",
     "react-resize-detector": "^6.7.8",
-    "react-responsive": "^8.2.0",
     "react-router-dom": "^6.2.1",
     "react-select": "^5.2.2",
     "react-select-async-paginate": "^0.6.1",

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
-import MediaQuery from 'react-responsive';
+import { useResizeDetector } from 'react-resize-detector';
 import Select from 'react-select';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Spinner from '../components/Spinner';
@@ -14,6 +14,11 @@ const defaultConsortiumOption = { label: 'All PCDC', value: 'total' };
 
 /** @param {{ overviewCounts: import('./types').OverviewCounts }} props */
 function IndexOverview({ overviewCounts }) {
+  const { width: screenWidth } = useResizeDetector({
+    handleHeight: false,
+    targetRef: useRef(document.body),
+  });
+
   const [consortium, setConsortium] = useState(defaultConsortiumOption);
   const consortiumOptions = [
     defaultConsortiumOption,
@@ -77,13 +82,13 @@ function IndexOverview({ overviewCounts }) {
               theme={overrideSelectTheme}
             />
           </div>
-          <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
+          {screenWidth > breakpoints.tablet && (
             <Button
               label='Explore more'
               buttonType='primary'
               onClick={() => navigate(explorerLocation)}
             />
-          </MediaQuery>
+          )}
         </div>
       </div>
       <div className='index-overview__body'>
@@ -101,7 +106,7 @@ function IndexOverview({ overviewCounts }) {
           <Spinner />
         )}
       </div>
-      <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
+      {screenWidth <= breakpoints.tablet && (
         <div className='index-overview__footer'>
           <Button
             label='Explore more'
@@ -109,7 +114,7 @@ function IndexOverview({ overviewCounts }) {
             onClick={() => navigate(explorerLocation)}
           />
         </div>
-      </MediaQuery>
+      )}
     </div>
   );
 }

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import MediaQuery from 'react-responsive';
+import { useResizeDetector } from 'react-resize-detector';
 import {
   ReduxIndexButtonBar,
   ReduxIndexBarChart,
@@ -20,6 +20,11 @@ function IndexPage() {
     dispatch(getIndexPageCounts());
   }, []);
 
+  const { width: screenWidth } = useResizeDetector({
+    handleHeight: false,
+    targetRef: useRef(document.body),
+  });
+
   return (
     <div className='index-page'>
       <div className='index-page__top'>
@@ -29,11 +34,11 @@ function IndexPage() {
             dictIcons={dictIcons}
           />
         </div>
-        <div className='index-page__bar-chart'>
-          <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
+        {screenWidth > breakpoints.tablet && (
+          <div className='index-page__bar-chart'>
             <ReduxIndexBarChart />
-          </MediaQuery>
-        </div>
+          </div>
+        )}
       </div>
       <ReduxIndexOverview />
       <ReduxIndexButtonBar />

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import MediaQuery from 'react-responsive';
+import { useResizeDetector } from 'react-resize-detector';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import NavButton from './NavButton';
@@ -36,6 +36,11 @@ import './NavBar.css';
 function NavBar({ dictIcons, navItems, navTitle, userAccess }) {
   const location = useLocation();
   if (location.pathname === '/login') return null;
+
+  const { width: screenWidth } = useResizeDetector({
+    handleHeight: false,
+    targetRef: useRef(document.body),
+  });
 
   const navButtonRefs = {};
   for (const { link } of navItems)
@@ -121,34 +126,41 @@ function NavBar({ dictIcons, navItems, navTitle, userAccess }) {
           </div>
         )}
       </div>
-      <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
-        <div
-          className='nav-bar__menu'
-          onClick={toggleMenu}
-          onKeyPress={(e) => {
-            if (e.charCode === 13 || e.charCode === 32) {
-              e.preventDefault();
-              toggleMenu();
-            }
-          }}
-          role='button'
-          tabIndex={0}
-          aria-expanded={isMenuOpen}
-          aria-label={`${isMenuOpen ? 'Expand' : 'Collapse'} navigation menu`}
-        >
-          Menu
-          <FontAwesomeIcon
-            className='nav-bar__menu-icon'
-            icon={isMenuOpen ? 'angle-down' : 'angle-up'}
-            size='lg'
-          />
-        </div>
-        {isMenuOpen && <div className='nav-bar__nav--items'>{navButtons}</div>}
-      </MediaQuery>
-      <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
-        <div className='nav-bar__nav--items'>{navButtons}</div>
-        {tooltipDetails.content !== '' && <NavBarTooltip {...tooltipDetails} />}
-      </MediaQuery>
+      {screenWidth <= breakpoints.tablet ? (
+        <>
+          <div
+            className='nav-bar__menu'
+            onClick={toggleMenu}
+            onKeyPress={(e) => {
+              if (e.charCode === 13 || e.charCode === 32) {
+                e.preventDefault();
+                toggleMenu();
+              }
+            }}
+            role='button'
+            tabIndex={0}
+            aria-expanded={isMenuOpen}
+            aria-label={`${isMenuOpen ? 'Expand' : 'Collapse'} navigation menu`}
+          >
+            Menu
+            <FontAwesomeIcon
+              className='nav-bar__menu-icon'
+              icon={isMenuOpen ? 'angle-down' : 'angle-up'}
+              size='lg'
+            />
+          </div>
+          {isMenuOpen && (
+            <div className='nav-bar__nav--items'>{navButtons}</div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className='nav-bar__nav--items'>{navButtons}</div>
+          {tooltipDetails.content !== '' && (
+            <NavBarTooltip {...tooltipDetails} />
+          )}
+        </>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
This PR replaces the use of `<MediaQuery>` component from `react-responsive` with `useResizeDetector()` hook from `react-resize-detector`.

While `react-responsive` is not a particularly heavy dependency, its use can be fully replaced by `react-resize-detector`, which is already included as a dependency for `recharts`. The result is a simple removal of `react-responsive` and all its dependencies, i.e. smaller production bundle and docker image sizes.

Note: `react-resize-detector` relies on [`ResizeObserver` API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) that is supported by all popular modern browsers but not by IE. We don't intend to support IE, so it's ok.