### PR TITLE
Replace clipboard-plus with web standard Clipboard API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15634,11 +15634,6 @@
         "string-width": "^4.2.0"
       }
     },
-    "clipboard-plus": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/clipboard-plus/-/clipboard-plus-1.1.0.tgz",
-      "integrity": "sha1-P4YgareeFQLvNRNj1ziTKVwX208="
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "autoprefixer": "^10.4.2",
     "babel-loader": "^8.2.3",
     "babel-plugin-relay": "^11.0.2",
-    "clipboard-plus": "^1.0.0",
     "compression-webpack-plugin": "^9.2.0",
     "core-js": "^3.20.3",
     "css-loader": "^6.5.1",

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import copy from 'clipboard-plus';
 import Button from '../gen3-ui-component/components/Button';
 import Popup from '../components/Popup';
 import { userapiPath } from '../localconf';
@@ -106,7 +105,7 @@ function CoreMetadataHeader({
           rightButtons={[
             {
               caption: 'Copy',
-              fn: () => copy(signedURL),
+              fn: () => navigator.clipboard.writeText(signedURL),
               icon: 'copy',
               enabled: !error,
             },

--- a/src/UserProfile/UserProfile.jsx
+++ b/src/UserProfile/UserProfile.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import FileSaver from 'file-saver';
-import copy from 'clipboard-plus';
 import Button from '../gen3-ui-component/components/Button';
 import { jsonToString } from '../utils';
 import Popup from '../components/Popup';
@@ -137,7 +136,8 @@ function UserProfile({
                 },
                 {
                   caption: 'Copy',
-                  fn: () => copy(userProfile.strRefreshCred),
+                  fn: () =>
+                    navigator.clipboard.writeText(userProfile.strRefreshCred),
                   icon: 'copy',
                 },
               ]}


### PR DESCRIPTION
This PR replaces the use of `clipboard-plus` with the web standard Clipboard API, i.e. [`navigator.clipboard.writeText()`](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText). 

While `clipboard-plus` is a simple and lightweight library, it is not actively maintained (no new commit since 2017) and [relies on](https://github.com/icecreamliker/clipboard-plus/blob/8ca1776c1c1783e6fb65bf35f7cd145cf91a46ae/src/index.js#L31) now deprecated/non-standard [`document.execCommand()` API](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand). The Clipboard API has its own limitations (e.g. must be used in HTTPS context, etc.) but seems fully compatible with our use case on all popular modern browsers. This excludes IE, but we don't intend to support IE so it's okay.