### PR TITLE
Replace antd <Radio> with native input elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,63 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
-      "requires": {
-        "@ctrl/tinycolor": "^3.4.0"
-      }
-    },
-    "@ant-design/icons": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
-      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
-      "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.2.1",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.9.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "@ant-design/icons-svg": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
-      "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
-    },
-    "@ant-design/react-slick": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.28.4.tgz",
-      "integrity": "sha512-j9eAHTn7GxbXUFNknJoHS2ceAsqrQi2j8XykjZE1IXCD8kJF+t28EvhBLniDpbOsBk/3kjalnhriTfZcjBHNqg==",
-      "requires": {
-        "@babel/runtime": "^7.10.4",
-        "classnames": "^2.2.5",
-        "json2mq": "^0.2.0",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -5740,11 +5683,6 @@
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
-    },
-    "@ctrl/tinycolor": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
-      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",
@@ -13598,97 +13536,6 @@
         }
       }
     },
-    "antd": {
-      "version": "4.18.5",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.18.5.tgz",
-      "integrity": "sha512-5fN3C2lWAzonhOYYlNpzIw2OHl7vxFZ+4cJ7DK/XZrV+75OY61Y+OkanqMJwrFtDDamIez35OM7cAezGko9tew==",
-      "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.7.0",
-        "@ant-design/react-slick": "~0.28.1",
-        "@babel/runtime": "^7.12.5",
-        "@ctrl/tinycolor": "^3.4.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.21",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.25.3",
-        "rc-cascader": "~3.2.1",
-        "rc-checkbox": "~2.3.0",
-        "rc-collapse": "~3.1.0",
-        "rc-dialog": "~8.6.0",
-        "rc-drawer": "~4.4.2",
-        "rc-dropdown": "~3.2.0",
-        "rc-field-form": "~1.22.0-2",
-        "rc-image": "~5.2.5",
-        "rc-input-number": "~7.3.0",
-        "rc-mentions": "~1.6.1",
-        "rc-menu": "~9.2.1",
-        "rc-motion": "^2.4.4",
-        "rc-notification": "~4.5.7",
-        "rc-pagination": "~3.1.9",
-        "rc-picker": "~2.5.17",
-        "rc-progress": "~3.2.1",
-        "rc-rate": "~2.9.0",
-        "rc-resize-observer": "^1.2.0",
-        "rc-select": "~14.0.0-alpha.15",
-        "rc-slider": "~9.7.4",
-        "rc-steps": "~4.1.0",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.22.2",
-        "rc-tabs": "~11.10.0",
-        "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.1.1",
-        "rc-tree": "~5.4.3",
-        "rc-tree-select": "~5.1.1",
-        "rc-trigger": "^5.2.10",
-        "rc-upload": "~4.3.0",
-        "rc-util": "^5.14.0",
-        "scroll-into-view-if-needed": "^2.2.25"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-motion": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.4.tgz",
-          "integrity": "sha512-ms7n1+/TZQBS0Ydd2Q5P4+wJTSOrhIrwNxLXCZpR7Fa3/oac7Yi803HDALc2hLAKaCTQtw9LmQeB58zcwOsqlQ==",
-          "requires": {
-            "@babel/runtime": "^7.11.1",
-            "classnames": "^2.2.1",
-            "rc-util": "^5.2.1"
-          }
-        },
-        "rc-trigger": {
-          "version": "5.2.10",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.10.tgz",
-          "integrity": "sha512-FkUf4H9BOFDaIwu42fvRycXMAvkttph9AlbCZXssZDVzz2L+QZ0ERvfB/4nX3ZFPh1Zd+uVGr1DEDeXxq4J1TA==",
-          "requires": {
-            "@babel/runtime": "^7.11.2",
-            "classnames": "^2.2.6",
-            "rc-align": "^4.0.0",
-            "rc-motion": "^2.0.0",
-            "rc-util": "^5.5.0"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -13829,11 +13676,6 @@
           }
         }
       }
-    },
-    "array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -14019,11 +13861,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
-    },
-    "async-validator": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.0.7.tgz",
-      "integrity": "sha512-Pj2IR7u8hmUEDOwB++su6baaRi+QvsgajuFB9j95foM1N2gy5HM4z60hfusIO0fBPG5uLAEl6yCJr1jNSVugEQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -15895,7 +15732,8 @@
     "compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -16845,11 +16683,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
       "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
-    },
-    "date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
       "version": "1.10.7",
@@ -24371,14 +24204,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json2mq": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "requires": {
-        "string-convert": "^0.2.0"
-      }
-    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -24906,11 +24731,6 @@
         "fs-monkey": "1.0.3"
       }
     },
-    "memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-    },
     "memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -25263,11 +25083,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -27332,244 +27147,6 @@
         }
       }
     },
-    "rc-cascader": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.2.1.tgz",
-      "integrity": "sha512-Raxam9tFzBL4TCgHoyVcf7+Q2KSFneUk3FZXi9w1tfxEihLlezSH0oCNMjHJN8hxWwwx9ZbI9UzWTfFImjXc0Q==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
-        "classnames": "^2.3.1",
-        "rc-select": "~14.0.0-alpha.23",
-        "rc-tree": "~5.4.3",
-        "rc-util": "^5.6.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "classnames": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-        }
-      }
-    },
-    "rc-checkbox": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
-      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-collapse": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.2.tgz",
-      "integrity": "sha512-HujcKq7mghk/gVKeI6EjzTbb8e19XUZpakrYazu1MblEZ3Hu3WBMSN4A3QmvbF6n1g7x6lUlZvsHZ5shABWYOQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.3.4",
-        "rc-util": "^5.2.1",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-dialog": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.6.0.tgz",
-      "integrity": "sha512-GSbkfqjqxpZC5/zc+8H332+q5l/DKUhpQr0vdX2uDsxo5K0PhvaMEVjyoJUTkZ3+JstEADQji1PVLVb/2bJeOQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.3.0",
-        "rc-util": "^5.6.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-drawer": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.4.3.tgz",
-      "integrity": "sha512-FYztwRs3uXnFOIf1hLvFxIQP9MiZJA+0w+Os8dfDh/90X7z/HqP/Yg+noLCIeHEbKln1Tqelv8ymCAN24zPcfQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.7.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-dropdown": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.3.tgz",
-      "integrity": "sha512-IcGz4Hk2X86sb00lcBTXhPLmauF1fg3sQJiWVyOqJ2/yaFDYJa+3Y1FjtBwfCrBL6CYOia138339H7mbmeLjxQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.0.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-field-form": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.22.1.tgz",
-      "integrity": "sha512-LweU7nBeqmC5r3HDUjRprcOXXobHXp/TGIxD7ppBq5FX6Iptt3ibdpRVg4RSyNulBNGHOuknHlRcguuIpvVMVg==",
-      "requires": {
-        "@babel/runtime": "^7.8.4",
-        "async-validator": "^4.0.2",
-        "rc-util": "^5.8.0"
-      }
-    },
-    "rc-image": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.2.5.tgz",
-      "integrity": "sha512-qUfZjYIODxO0c8a8P5GeuclYXZjzW4hV/5hyo27XqSFo1DmTCs2HkVeQObkcIk5kNsJtgsj1KoPThVsSc/PXOw==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-dialog": "~8.6.0",
-        "rc-util": "^5.0.6"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-input-number": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.4.tgz",
-      "integrity": "sha512-W9uqSzuvJUnz8H8vsVY4kx+yK51SsAxNTwr8SNH4G3XqQNocLVmKIibKFRjocnYX1RDHMND9FFbgj2h7E7nvGA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.9.8"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-mentions": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.6.1.tgz",
-      "integrity": "sha512-LDzGI8jJVGnkhpTZxZuYBhMz3avcZZqPGejikchh97xPni/g4ht714Flh7DVvuzHQ+BoKHhIjobHnw1rcP8erg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-menu": "^9.0.0",
-        "rc-textarea": "^0.3.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-menu": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.2.1.tgz",
-      "integrity": "sha512-UbEtn3rflJ8zS+etYGTVQuzy7Fm+yWXR5c0Rl6ecNTS/dPknRyWAyhJcbeR0Hu1+RdQT+0VCqrUPrgKnm4iY+w==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.2.0",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.12.0",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
     "rc-motion": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.3.tgz",
@@ -27586,207 +27163,6 @@
           "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-notification": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.5.7.tgz",
-      "integrity": "sha512-zhTGUjBIItbx96SiRu3KVURcLOydLUHZCPpYEn1zvh+re//Tnq/wSxN4FKgp38n4HOgHSVxcLEeSxBMTeBBDdw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.2.0",
-        "rc-util": "^5.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-overflow": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.2.2.tgz",
-      "integrity": "sha512-X5kj9LDU1ue5wHkqvCprJWLKC+ZLs3p4He/oxjZ1Q4NKaqKBaYf5OdSzRSgh3WH8kSdrfU8LjvlbWnHgJOEkNQ==",
-      "requires": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-pagination": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.15.tgz",
-      "integrity": "sha512-4L3fot8g4E+PjWEgoVGX0noFCg+8ZFZmeLH4vsnZpB3O2T2zThtakjNxG+YvSaYtyMVT4B+GLayjKrKbXQpdAg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-picker": {
-      "version": "2.5.19",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.5.19.tgz",
-      "integrity": "sha512-u6myoCu/qiQ0vLbNzSzNrzTQhs7mldArCpPHrEI6OUiifs+IPXmbesqSm0zilJjfzrZJLgYeyyOMSznSlh0GKA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "date-fns": "2.x",
-        "dayjs": "1.x",
-        "moment": "^2.24.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-progress": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.2.4.tgz",
-      "integrity": "sha512-M9WWutRaoVkPUPIrTpRIDpX0SPSrVHzxHdCRCbeoBFrd9UFWTYNWRlHsruJM5FH1AZI+BwB4wOJUNNylg/uFSw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.16.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
-    "rc-rate": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.1.tgz",
-      "integrity": "sha512-MmIU7FT8W4LYRRHJD1sgG366qKtSaKb67D0/vVvJYR0lrCuRrCiVQ5qhfT5ghVO4wuVIORGpZs7ZKaYu+KMUzA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-resize-observer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.0.tgz",
-      "integrity": "sha512-6W+UzT3PyDM0wVCEHfoW3qTHPTvbdSgiA43buiy8PzmeMnfgnDeb9NjdimMXMl3/TcrvvWl5RRVdp+NqcR47pQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.15.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
-    "rc-select": {
-      "version": "14.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.0.0-alpha.25.tgz",
-      "integrity": "sha512-U9AMzXsOCCdtn96YIZdUrYbxk+5u6uWUCaYH2129X3FTjQITqAjEPYHfPcxU/G7+lwiD0pIaU95W0NMkg+26qw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.0.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.2.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
           }
         }
       }
@@ -27823,123 +27199,6 @@
         }
       }
     },
-    "rc-steps": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.4.tgz",
-      "integrity": "sha512-qoCqKZWSpkh/b03ASGx1WhpKnuZcRWmvuW+ZUu4mvMdfvFzVxblTwUM+9aBd0mlEUFmt6GW8FXhMpHkK3Uzp3w==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "classnames": "^2.2.3",
-        "rc-util": "^5.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-table": {
-      "version": "7.22.2",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.22.2.tgz",
-      "integrity": "sha512-Ng2gNkGi6ybl6dzneRn2H4Gp8XhIbRa5rXQ7ZhZcgWVmfVMok70UHGPXcf68tXW6O0/qckTf/eOVsoviSvK4sw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.14.0",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
-    "rc-tabs": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.10.5.tgz",
-      "integrity": "sha512-DDuUdV6b9zGRYLtjI5hyejWLKoz1QiLWNgMeBzc3aMeQylZFhTYnFGdDc6HRqj5IYearNTsFPVSA+6VIT8g5cg==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "^3.2.0",
-        "rc-menu": "^9.0.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-textarea": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.7.tgz",
-      "integrity": "sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.7.0",
-        "shallowequal": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
     "rc-tooltip": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.1.tgz",
@@ -27955,70 +27214,6 @@
           "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-tree": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.4.3.tgz",
-      "integrity": "sha512-WAHV8FkBerulj9J/+61+Qn0TD/Zo37PrDG8/45WomzGTYavxFMur9YguKjQj/J+NxjVJzrJL3lvdSZsumfdbiA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.4.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
-          }
-        }
-      }
-    },
-    "rc-tree-select": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.1.2.tgz",
-      "integrity": "sha512-sTulyQZB1SgF2HzAR49i4vjMNvV/tfPxCTc+qNuWOwaAtSm2bwGH6/wfi3k3Dw2/5PPOGpRRpgCMltoP9aG0+w==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-select": "~14.0.0-alpha.8",
-        "rc-tree": "~5.4.3",
-        "rc-util": "^5.16.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "rc-util": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
-          "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "react-is": "^16.12.0",
-            "shallowequal": "^1.1.0"
           }
         }
       }
@@ -28039,26 +27234,6 @@
           "version": "7.14.0",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
           "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
-      }
-    },
-    "rc-upload": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.3.tgz",
-      "integrity": "sha512-YoJ0phCRenMj1nzwalXzciKZ9/FAaCrFu84dS5pphwucTC8GUWClcDID/WWNGsLFcM97NqIboDqrV82rVRhW/w==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.2.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -28088,16 +27263,6 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
-      }
-    },
-    "rc-virtual-list": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.4.2.tgz",
-      "integrity": "sha512-OyVrrPvvFcHvV0ssz5EDZ+7Rf5qLat/+mmujjchNw5FfbJWNDwkpQ99EcVE6+FtNRmX9wFa1LGNpZLUTvp/4GQ==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.0.7"
       }
     },
     "react": {
@@ -29656,14 +28821,6 @@
         }
       }
     },
-    "scroll-into-view-if-needed": {
-      "version": "2.2.28",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz",
-      "integrity": "sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==",
-      "requires": {
-        "compute-scroll-into-view": "^1.0.17"
-      }
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -30433,11 +29590,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "string-convert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-env-interpolation": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@svgr/webpack": "^6.2.0",
     "ace-builds": "^1.4.14",
     "acorn": "^8.7.0",
-    "antd": "^4.18.5",
     "autoprefixer": "^10.4.2",
     "babel-loader": "^8.2.3",
     "babel-plugin-relay": "^11.0.2",

--- a/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
+++ b/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
@@ -113,10 +113,6 @@
   padding: 5px 0 5px 8px;
 }
 
-.g3-filter-section__combine_label {
-  text-overflow: ellipsis;
-}
-
 .g3-filter-section__and-or-toggle label {
   align-items: baseline;
   display: inline-flex;
@@ -159,28 +155,6 @@
   width: 10px;
   height: 10px;
   background-color: var(--g3-color__gray);
-}
-
-.g3-filter-section__search-input-spinner {
-  width: 20px;
-  height: 10px;
-  position: relative;
-  top: 10px;
-  right: 6px;
-  cursor: pointer;
-}
-
-.g3-filter-section__search-input-separator {
-  width: 1px;
-  border-left: 1px solid var(--g3-color__lightgray);
-  margin: 0 10px;
-}
-
-.g3-filter-section__search-input-icon {
-  background-color: var(--g3-color__gray);
-  position: relative;
-  top: 3px;
-  cursor: pointer;
 }
 
 .g3-filter-section__search-filter--hidden {
@@ -242,10 +216,6 @@
 .g3-filter-section__and-or-toggle-helper-tooltip .rc-tooltip-content {
   top: -1px;
   position: relative;
-}
-
-.g3-select-filter {
-  margin-top: 14px;
 }
 
 .g3-filter-section__no-option {

--- a/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
+++ b/src/gen3-ui-component/components/filters/FilterSection/FilterSection.css
@@ -117,6 +117,17 @@
   text-overflow: ellipsis;
 }
 
+.g3-filter-section__and-or-toggle label {
+  align-items: baseline;
+  display: inline-flex;
+  margin: 0 4px;
+}
+
+.g3-filter-section__and-or-toggle input[type='radio'] {
+  margin-right: 4px;
+  align-self: center;
+}
+
 .g3-filter-section__and-or-toggle button {
   background: none;
   border-radius: 3px;
@@ -128,42 +139,6 @@
   padding: 2px 3px;
   font-weight: 200;
   color: #333;
-}
-
-.g3-filter-section__and-or-toggle .ant-radio-button-wrapper {
-  text-align: center;
-}
-
-.ant-radio-button-wrapper:hover {
-  /* stylelint-disable-next-line declaration-no-important */
-  color: var(--g3-primary-btn__bg-color) !important;
-}
-
-.ant-radio-button-wrapper.ant-radio-button-wrapper-checked:hover {
-  color: white !important; /* stylelint-disable-line declaration-no-important */
-}
-
-.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled)::before {
-  background-color: #d9d9d9 !important; /* stylelint-disable-line declaration-no-important */
-}
-
-.ant-radio-button-wrapper-checked {
-  background-color: var(--g3-primary-btn__bg-color);
-}
-
-.ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled) {
-  background-color: var(--g3-primary-btn__bg-color);
-  color: white;
-  border-color: var(--g3-primary-btn__bg-color);
-}
-
-.ant-radio-group-solid
-  .ant-radio-button-wrapper-checked:not(.ant-radio-button-wrapper-disabled) {
-  /* stylelint-disable-next-line declaration-no-important */
-  background: var(--g3-primary-btn__bg-color) !important;
-  color: white;
-  /* stylelint-disable-next-line declaration-no-important */
-  border-color: var(--g3-primary-btn__bg-color) !important;
 }
 
 .g3-filter-section__search-input-box {

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -488,7 +488,7 @@ function FilterSection({
                 reset
               </div>
               <div className='g3-filter-section__range-filter-clear-btn-icon'>
-                <i className='g3-icon g3-icon--sm g3-icon-color__lightgray g3-icon--sm g3-icon--undo' />
+                <i className='g3-icon g3-icon--sm g3-icon-color__lightgray g3-icon--undo' />
               </div>
             </div>
           </div>

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -2,8 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
-import { Radio } from 'antd';
-import 'antd/lib/radio/style/index.css';
 import { AsyncPaginate } from 'react-select-async-paginate';
 import SingleSelectFilter from '../SingleSelectFilter';
 import Chip from '../Chip';
@@ -136,10 +134,11 @@ function FilterSection({
     }));
   }
 
-  /** @param {import('antd').RadioChangeEvent} e */
+  /** @param {React.ChangeEvent<HTMLInputElement>} e */
   function handleSetCombineModeOption(e) {
-    /** @type {'AND' | 'OR'} combineMode */
-    const combineMode = e.target.value;
+    const combineMode = /** @type {FilterSectionState['combineMode']} */ (
+      e.target.value
+    );
     setState((prevState) => ({ ...prevState, combineMode }));
     onToggleCombineMode('__combineMode', combineMode);
   }
@@ -242,16 +241,20 @@ function FilterSection({
         }
       >
         <span style={{ marginRight: '5px' }}>Combine with </span>
-        <Radio.Group
-          buttonStyle='solid'
-          defaultValue={state.combineMode}
-          onChange={handleSetCombineModeOption}
-          options={[
-            { label: 'AND', value: 'AND' },
-            { label: 'OR', value: 'OR' },
-          ]}
-          optionType='button'
-        />
+        {['AND', 'OR'].map(
+          (/** @type {FilterSectionState['combineMode']} */ combineMode) => (
+            <label>
+              <input
+                checked={state.combineMode === combineMode}
+                name='combineMode'
+                onChange={handleSetCombineModeOption}
+                value={combineMode}
+                type='radio'
+              />
+              {combineMode}
+            </label>
+          )
+        )}
         <Tooltip
           arrowContent={<div className='rc-tooltip-arrow-inner' />}
           overlay={tooltipText}

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -243,7 +243,7 @@ function FilterSection({
         <span style={{ marginRight: '5px' }}>Combine with </span>
         {['AND', 'OR'].map(
           (/** @type {FilterSectionState['combineMode']} */ combineMode) => (
-            <label>
+            <label key={combineMode}>
               <input
                 checked={state.combineMode === combineMode}
                 name='combineMode'


### PR DESCRIPTION
This PR replaces the use of `<Radio>` component from `antd` with the native `<input>`. See the before and after screenshots:

_Before_
<img width="545" alt="image" src="https://user-images.githubusercontent.com/22449454/152408945-a46c8dd7-ffb0-429d-9284-8b53a09125f8.png">

_After_
<img width="545" alt="image" src="https://user-images.githubusercontent.com/22449454/152408834-067be4e4-90bc-4064-924a-e3ad305ee281.png">


While the impact of using `<Radio>` on final bundle size is arguably minor (~40kb minified, ~10kb gzipped) thanks to tree-shaking, the real cost is having to install `antd` in its entirety, which is **~170mb** in `node_modules` and **~100mb** increase in docker image size. This also adds a few seconds in time for installing dependencies.

Please note that the PCDC use case does not include array filters and therefore does not display the UI while still paying the cost. If the button-looking UI is strongly preferable, it can be implemented in future.