### PR TITLE
Remove isomorphic-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21375,15 +21375,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
@@ -32855,11 +32846,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "graphiql": "^1.5.16",
     "graphql": "^15.8.0",
     "html-webpack-plugin": "^5.5.0",
-    "isomorphic-fetch": "^3.0.0",
     "jszip": "^3.7.1",
     "lodash.clonedeep": "^4.5.0",
     "node-fetch": "^2.6.7",

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -1,5 +1,4 @@
 import cloneDeep from 'lodash.clonedeep';
-import fetch from 'isomorphic-fetch';
 import flat from 'flat';
 import papaparse from 'papaparse';
 import { FILE_DELIMITERS, GUPPY_URL } from './const';

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import { buildClientSchema, getIntrospectionQuery } from 'graphql/utilities';
 import {
   userapiPath,


### PR DESCRIPTION
This PR removes the use of `isomorphic-fetch`, which serves to polyfill the browser `fetch` API. Since `fetch` API is now widely available and supported on all popular modern browsers, this is no longer necessary.