### PR TITLE
Optimize dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ docs
 node_modules
 src/**/__generated__
 src/stories
+**/setupJest.js
+**/*.test.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 __mocks__
 .git
 .storybook
+data/dictionary.*
+data/schema.*
 docs
 node_modules
 src/**/__generated__


### PR DESCRIPTION
This PR updates `.dockerignore` to reduce the Docker image size by >5mb through omitting unnecessary files for deploying the portal app.

The image size decrease is largely based on skipping the copy of `data/dictionary.json` and `data/schema.json` files that are generated/overwritten during the build process.