### PR TITLE
Patch release 1.2.2 PEDS-668

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.16.12",

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -186,7 +186,8 @@ function ProtectedContent({
         });
   }, [location]);
 
-  if (state.redirectTo) return <Navigate to={state.redirectTo} replace />;
+  if (state.redirectTo && state.redirectTo !== location.pathname)
+    return <Navigate to={state.redirectTo} replace />;
   if (isPublic && (state.dataLoaded || typeof filter !== 'function'))
     return children;
   if (state.authenticated)


### PR DESCRIPTION
Ticket: [PEDS-668](https://pcdc.atlassian.net/browse/PEDS-668)

This PR bumps the project version to 1.2.2.

The PR includes the fix for the crashing of the app for unauthenticated users caused by infinite redirect loop on `/login` route. While it is not 100% clear what of the recent changes is directly responsible for this infinite loop, the gist is that returning `<Navigate>` from `<ProtectedContent>` now leads to re-rendering of `<ProtectedContent>` with its `state.redirectTo` state persisted, which in turn leads to yet another `<Navigate>`. The fix is to return <Navigate> only if the `state.redirectTo` value is different form the current location. 