### PR TITLE
Report subject count per filter set for survival analysis tool PEDS-665 

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -126,7 +126,7 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval, isError }) {
   };
 
   const resetUserInput = () => {
-    setLocalTimeInterval(2);
+    setLocalTimeInterval(4);
     setStartTime(0);
     setEndTime(undefined);
     setSurvivalType(survivalTypeOptions[0]);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -8,6 +8,7 @@ import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import FilterSetCard from './FilterSetCard';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('./types').ParsedSurvivalAnalysisResult} ParsedSurvivalAnalysisResult */
 /** @typedef {import('./types').UserInputSubmitHandler} UserInputSubmitHandler */
 
 /** @param {{ label: string; [x: string]: any }} props */
@@ -78,11 +79,12 @@ function validateNumberInput(e, setStateAction) {
 
 /**
  * @param {Object} prop
+ * @param {ParsedSurvivalAnalysisResult['count']} [prop.countByFilterSet]
  * @param {UserInputSubmitHandler} prop.onSubmit
  * @param {number} prop.timeInterval
  * @param {boolean} prop.isError
  */
-function ControlForm({ onSubmit, timeInterval, isError }) {
+function ControlForm({ countByFilterSet, onSubmit, timeInterval, isError }) {
   const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(undefined);
@@ -225,6 +227,7 @@ function ControlForm({ onSubmit, timeInterval, isError }) {
         usedFilterSets.map((filterSet, i) => (
           <FilterSetCard
             key={filterSet.id}
+            count={countByFilterSet?.[filterSet.name]}
             filterSet={filterSet}
             label={`${i + 1}. ${filterSet.name}`}
             onClose={() => {
@@ -250,6 +253,12 @@ function ControlForm({ onSubmit, timeInterval, isError }) {
 }
 
 ControlForm.propTypes = {
+  countByFilterSet: PropTypes.objectOf(
+    PropTypes.exact({
+      fitted: PropTypes.number,
+      total: PropTypes.number,
+    })
+  ),
   onSubmit: PropTypes.func.isRequired,
   timeInterval: PropTypes.number.isRequired,
   isError: PropTypes.bool,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -79,6 +79,10 @@
   margin-right: 0.5rem;
 }
 
+.explorer-survival-analysis__filter-set-card > header > em {
+  margin: 0 0.5rem;
+}
+
 .explorer-survival-analysis__filter-set-select {
   margin: 1rem;
   display: flex;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
 import SimpleInputField from '../../components/SimpleInputField';
 import { stringifyFilters } from '../ExplorerFilterSet/utils';
 
@@ -7,13 +8,14 @@ import { stringifyFilters } from '../ExplorerFilterSet/utils';
 
 /**
  * @typedef {Object} FilterSetCardProps
+ * @property {{ fitted: number; total: number }} [count]
  * @property {ExplorerFilterSet} filterSet
  * @property {string} label
  * @property {React.MouseEventHandler<HTMLButtonElement>} onClose
  */
 
 /** @param {FilterSetCardProps} props */
-export default function FilterSetCard({ filterSet, label, onClose }) {
+export default function FilterSetCard({ count, filterSet, label, onClose }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const toggleCard = () => setIsExpanded((s) => !s);
   return (
@@ -27,6 +29,21 @@ export default function FilterSetCard({ filterSet, label, onClose }) {
           />
           {label}
         </button>
+        {count === undefined ? (
+          <em style={{ margin: '0 .5rem' }}>N/A</em>
+        ) : (
+          <Tooltip
+            arrowContent={<div className='rc-tooltip-arrow-inner' />}
+            mouseLeaveDelay={0}
+            overlay={`${count.fitted} of ${count.total} subjects for this Filter Set is used to calculate survival rates`}
+            placement='top'
+            trigger={['hover', 'focus']}
+          >
+            <em style={{ margin: '0 .5rem' }}>
+              {count.fitted}/{count.total}
+            </em>
+          </Tooltip>
+        )}
         <button aria-label='Clear' type='button' onClick={onClose}>
           <i className='g3-icon g3-icon--sm g3-icon--cross' />
         </button>
@@ -60,6 +77,10 @@ export default function FilterSetCard({ filterSet, label, onClose }) {
 }
 
 FilterSetCard.propTypes = {
+  count: PropTypes.exact({
+    fitted: PropTypes.number,
+    total: PropTypes.number,
+  }),
   filterSet: PropTypes.object,
   label: PropTypes.string,
   onClose: PropTypes.func,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -30,7 +30,7 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
           {label}
         </button>
         {count === undefined ? (
-          <em style={{ margin: '0 .5rem' }}>N/A</em>
+          <em>N/A</em>
         ) : (
           <Tooltip
             arrowContent={<div className='rc-tooltip-arrow-inner' />}
@@ -39,9 +39,11 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
             placement='top'
             trigger={['hover', 'focus']}
           >
-            <em style={{ margin: '0 .5rem' }}>
-              {count.fitted}/{count.total}
-            </em>
+            <button type='button'>
+              <em>
+                {count.fitted}/{count.total}
+              </em>
+            </button>
           </Tooltip>
         )}
         <button aria-label='Clear' type='button' onClick={onClose}>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -15,7 +15,7 @@ import './ExplorerSurvivalAnalysis.css';
 function ExplorerSurvivalAnalysis() {
   const [isUserCompliant, setIsUserCompliant] = useState(checkUserAgreement());
 
-  const [{ risktable, survival }, refershResult] = useSurvivalAnalysisResult();
+  const [parsedResult, refershResult] = useSurvivalAnalysisResult();
   const [timeInterval, setTimeInterval] = useState(4);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(undefined);
@@ -51,6 +51,7 @@ function ExplorerSurvivalAnalysis() {
         <>
           <div className='explorer-survival-analysis__column-left'>
             <ControlForm
+              countByFilterSet={parsedResult.count}
               onSubmit={handleSubmit}
               timeInterval={timeInterval}
               isError={isError}
@@ -73,7 +74,7 @@ function ExplorerSurvivalAnalysis() {
               <>
                 {config.result?.survival && (
                   <SurvivalPlot
-                    data={survival}
+                    data={parsedResult.survival}
                     endTime={endTime}
                     startTime={startTime}
                     timeInterval={timeInterval}
@@ -81,7 +82,7 @@ function ExplorerSurvivalAnalysis() {
                 )}
                 {config.result?.risktable && (
                   <RiskTable
-                    data={risktable}
+                    data={parsedResult.risktable}
                     endTime={endTime}
                     startTime={startTime}
                     timeInterval={timeInterval}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -15,7 +15,7 @@ import './ExplorerSurvivalAnalysis.css';
 function ExplorerSurvivalAnalysis() {
   const [isUserCompliant, setIsUserCompliant] = useState(checkUserAgreement());
 
-  const [[risktable, survival], refershResult] = useSurvivalAnalysisResult();
+  const [{ risktable, survival }, refershResult] = useSurvivalAnalysisResult();
   const [timeInterval, setTimeInterval] = useState(4);
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(undefined);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/types.d.ts
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/types.d.ts
@@ -27,12 +27,24 @@ export type SurvivalData = {
 
 export type SurvivalResultForFilterSet = {
   name: string;
+  count: {
+    fitted: number;
+    total: number;
+  };
   risktable: RisktableDataPoint[];
   survival: SurvivalDataPoint[];
 };
 
 export type SurvivalAnalysisResult = {
   [id: string]: SurvivalResultForFilterSet;
+};
+
+export type ParsedSurvivalAnalysisResult = {
+  count: {
+    [name: string]: SurvivalResultForFilterSet['count'];
+  };
+  risktable: RisktableData[];
+  survival: SurvivalData[];
 };
 
 export type UserInput = {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -17,6 +17,12 @@ import { useExplorerConfig } from '../ExplorerConfigContext';
  */
 
 /**
+ * @typedef {Object} ParsedSurvivalAnalysisResult
+ * @property {RisktableData[]} risktable
+ * @property {SurvivalData[]} survival
+ */
+
+/**
  * @param {{ name: string }} a a.name has a format: [index]. [filterSetName]
  * @param {{ name: string }} b b.name has a format: [index]. [filterSetName]
  */
@@ -29,16 +35,16 @@ function sortByIndexCompareFn(a, b) {
 /** @type {SurvivalAnalysisResult} */
 const emptyData = {};
 
-/** @returns {[[RisktableData[], SurvivalData[]], (usedFilterSets: ExplorerFilterSet[]) => Promise<void>]} */
+/** @returns {[ParsedSurvivalAnalysisResult, (usedFilterSets: ExplorerFilterSet[]) => Promise<void>]} */
 export default function useSurvivalAnalysisResult() {
   const { current, explorerId } = useExplorerConfig();
   const config = current.survivalAnalysisConfig;
 
   const [result, setResult] = useState(emptyData);
   const parsedResult = useMemo(() => {
-    /** @type {[RisktableData[], SurvivalData[]]} */
-    const parsed = [[], []];
-    const [r, s] = parsed;
+    /** @type {ParsedSurvivalAnalysisResult} */
+    const parsed = { risktable: [], survival: [] };
+    const { risktable: r, survival: s } = parsed;
     for (const { name, risktable, survival } of Object.values(result)) {
       if (config.result?.risktable) r.push({ data: risktable, name });
       if (config.result?.survival) s.push({ data: survival, name });

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -8,18 +8,13 @@ import { useExplorerConfig } from '../ExplorerConfigContext';
 /** @typedef {import('./types').RisktableData} RisktableData */
 /** @typedef {import('./types').SurvivalAnalysisResult} SurvivalAnalysisResult */
 /** @typedef {import('./types').SurvivalData} SurvivalData */
+/** @typedef {import('./types').ParsedSurvivalAnalysisResult} ParsedSurvivalAnalysisResult */
 
 /**
  * @typedef {Object} ExplorerFilterSetDTO
  * @property {GqlFilter} filters
  * @property {number} id
  * @property {string} name
- */
-
-/**
- * @typedef {Object} ParsedSurvivalAnalysisResult
- * @property {RisktableData[]} risktable
- * @property {SurvivalData[]} survival
  */
 
 /**
@@ -43,9 +38,10 @@ export default function useSurvivalAnalysisResult() {
   const [result, setResult] = useState(emptyData);
   const parsedResult = useMemo(() => {
     /** @type {ParsedSurvivalAnalysisResult} */
-    const parsed = { risktable: [], survival: [] };
-    const { risktable: r, survival: s } = parsed;
-    for (const { name, risktable, survival } of Object.values(result)) {
+    const parsed = { count: {}, risktable: [], survival: [] };
+    const { count: c, risktable: r, survival: s } = parsed;
+    for (const { name, count, risktable, survival } of Object.values(result)) {
+      if (count !== undefined) c[name.split('. ')[1]] = count;
       if (config.result?.risktable) r.push({ data: risktable, name });
       if (config.result?.survival) s.push({ data: survival, name });
     }


### PR DESCRIPTION
Ticket: [PEDS-665](https://pcdc.atlassian.net/browse/PEDS-665)

This PR implements a feature to report fitted vs total subject counts per filter set for survival analysis tool. This allows users to see how many subjects in the used filter set is actually used to fit the generated Kaplan-Meier curve.

This PR is based on [the revised spec](https://github.com/chicagopcdc/Documents/commit/88a78e421c103084543d0d4c04f5742fa52d3e09) for the survival analysis tool response data. Deploying it must be coupled with a corresponding change to the survival analysis tool Microservice (https://github.com/chicagopcdc/PcdcAnalysisTools/pull/44 & https://github.com/chicagopcdc/PcdcAnalysisTools/pull/45).

See the following demo:

https://user-images.githubusercontent.com/22449454/154126282-5ce2fd22-9050-427d-8fb0-f4374a3da6b9.mov

The PR also includes a fix to the inconsistent time interval reset value (0830d406a5b483446736f41c9423ba49fb0545e5).
