### PR TITLE
Redirect authenticated users on login page to home page PEDS-671

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
 import Layout from './Layout';
-import ReduxLogin, { fetchLogin } from './Login/ReduxLogin';
+import ReduxLogin from './Login/ReduxLogin';
 import ProtectedContent from './Login/ProtectedContent';
 // import { fetchCoreMetadata } from './CoreMetadata/reduxer';
 import { fetchAccess } from './UserProfile/ReduxUserProfile';
@@ -76,7 +76,7 @@ function App() {
         <Route
           path='login'
           element={
-            <ProtectedContent isLoginPage filter={() => dispatch(fetchLogin())}>
+            <ProtectedContent isLoginPage>
               <ReduxLogin />
             </ProtectedContent>
           }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,7 +76,7 @@ function App() {
         <Route
           path='login'
           element={
-            <ProtectedContent isPublic filter={() => dispatch(fetchLogin())}>
+            <ProtectedContent isLoginPage filter={() => dispatch(fetchLogin())}>
               <ReduxLogin />
             </ProtectedContent>
           }

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -12,6 +12,7 @@ import {
 } from '../actions';
 import Spinner from '../components/Spinner';
 import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
+import { fetchLogin } from './ReduxLogin';
 
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
 /** @typedef {import('../types').ProjectState} ProjectState */
@@ -153,7 +154,6 @@ function ProtectedContent({
   /** @param {ProtectedContentState} currentState */
   function updateState(currentState) {
     const newState = { ...currentState, dataLoaded: true };
-    if (isLoginPage && currentState.authenticated) newState.redirectTo = '/';
     setState(newState);
   }
   useEffect(() => {
@@ -166,9 +166,14 @@ function ProtectedContent({
     reduxStore.dispatch({ type: 'CLEAR_QUERY_NODES' });
 
     if (isLoginPage)
-      checkLoginStatus(state).then((newState) =>
-        filter().finally(() => updateState(newState))
-      );
+      checkLoginStatus(state).then((newState) => {
+        if (newState.authenticated)
+          updateState({ ...newState, redirectTo: '/' });
+        else
+          reduxStore
+            .dispatch(fetchLogin())
+            .finally(() => updateState(newState));
+      });
     else
       checkLoginStatus(state)
         .then(checkIfRegisterd)

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -165,7 +165,11 @@ function ProtectedContent({
     reduxStore.dispatch({ type: 'CLEAR_COUNTS' }); // clear some counters
     reduxStore.dispatch({ type: 'CLEAR_QUERY_NODES' });
 
-    if (isPublic)
+    if (location.pathname === '/login')
+      checkLoginStatus(state).then((newState) =>
+        filter().finally(() => updateState(newState))
+      );
+    else if (isPublic)
       if (typeof filter === 'function')
         filter().finally(() => updateState(state));
       else updateState(state);

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -153,7 +153,8 @@ function ProtectedContent({
   /** @param {ProtectedContentState} currentState */
   function updateState(currentState) {
     const newState = { ...currentState, dataLoaded: true };
-    if (isPublic) newState.redirectTo = null;
+    if (isPublic)
+      newState.redirectTo = location.pathname === '/login' ? '/' : null;
     setState(newState);
   }
   useEffect(() => {

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -34,9 +34,6 @@ import './NavBar.css';
  * @param {NavBarProps} props
  */
 function NavBar({ dictIcons, navItems, navTitle, userAccess }) {
-  const location = useLocation();
-  if (location.pathname === '/login') return null;
-
   const { width: screenWidth } = useResizeDetector({
     handleHeight: false,
     targetRef: useRef(document.body),
@@ -48,6 +45,9 @@ function NavBar({ dictIcons, navItems, navTitle, userAccess }) {
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [tooltipDetails, setTooltipDetails] = useState({ content: '' });
+
+  const location = useLocation();
+  if (location.pathname === '/login') return null;
 
   function toggleMenu() {
     setIsMenuOpen(!isMenuOpen);


### PR DESCRIPTION
Ticket: [PEDS-671](https://pcdc.atlassian.net/browse/PEDS-671)

This PR implements redirecting already authenticated users on login page to home page to avoid confusion.

In doing so, the PR also refactors `<ProtectedContent>` component to handle the prep work for login page directly, rather then using `isPublic` and `filter` props in combination. 