### PR TITLE
Support event-free survival PEDS-570

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -139,7 +139,6 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval, isError }) {
     <form className='explorer-survival-analysis__control-form'>
       <ControlFormSelect
         inputId='survival-type'
-        isDisabled
         label='Survival type'
         options={[
           { label: 'Overall Survival', value: 'all' },

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -27,6 +27,7 @@ function ExplorerSurvivalAnalysis() {
     timeInterval,
     startTime,
     endTime,
+    efsFlag,
     usedFilterSets,
   }) => {
     if (isError) setIsError(false);
@@ -35,7 +36,7 @@ function ExplorerSurvivalAnalysis() {
     setStartTime(startTime);
     setEndTime(endTime);
 
-    refershResult(usedFilterSets)
+    refershResult({ efsFlag, usedFilterSets })
       .then(() => setIsUpdating(false))
       .catch(() => {
         setIsError(true);


### PR DESCRIPTION
Ticket: [PEDS-570](https://pcdc.atlassian.net/browse/PEDS-570)

This PR implements support for using event-free survival option for survival type input to generate survival results. The PR also modifies the caching mechanism so that using a different survival type always fetches new results.

Deploying this feature must be coupled with corresponding changes to the survival analysis tool Microservice (https://github.com/chicagopcdc/PcdcAnalysisTools/pull/43 through https://github.com/chicagopcdc/PcdcAnalysisTools/pull/46).