### PR TITLE
Encode explorer view (tab) in URL search param

### DIFF
--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import SummaryChartGroup from '../../gen3-ui-component/components/charts/SummaryChartGroup';
 import PercentageStackedBarChart from '../../gen3-ui-component/components/charts/PercentageStackedBarChart';
 import Spinner from '../../components/Spinner';
@@ -166,6 +165,9 @@ function ExplorerVisualization({
   getTotalCountsByTypeAndFilter,
   className = '',
 }) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
   const {
     buttonConfig,
     chartConfig,
@@ -183,7 +185,15 @@ function ExplorerVisualization({
   const explorerViews = ['summary view'];
   if (tableConfig.enabled) explorerViews.push('table view');
   if (survivalAnalysisConfig.enabled) explorerViews.push('survival analysis');
-  const [explorerView, setExplorerView] = useState(explorerViews[0]);
+
+  const explorerView = searchParams.get('view') ?? explorerViews[0];
+  function updateExplorerView(view) {
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    newSearchParams.set('view', view);
+    navigate(`?${decodeURIComponent(newSearchParams.toString())}`, {
+      state: { scrollY: window.scrollY },
+    });
+  }
 
   const chartData = getChartData({
     aggsChartData,
@@ -206,7 +216,7 @@ function ExplorerVisualization({
     downloadRawDataByTypeAndFilter,
     getTotalCountsByTypeAndFilter,
     filter,
-    navigate: useNavigate(),
+    navigate,
     isLocked: isComponentLocked,
     isPending: isLoadingAggsData,
   };
@@ -236,7 +246,7 @@ function ExplorerVisualization({
             <button
               key={view}
               className={explorerView === view ? 'active' : ''}
-              onClick={() => setExplorerView(view)}
+              onClick={() => updateExplorerView(view)}
               type='button'
             >
               {view}

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SummaryChartGroup from '../../gen3-ui-component/components/charts/SummaryChartGroup';
@@ -194,6 +195,10 @@ function ExplorerVisualization({
       state: { scrollY: window.scrollY },
     });
   }
+  useEffect(() => {
+    if (!explorerViews.includes(explorerView))
+      updateExplorerView(explorerViews[0]);
+  }, []);
 
   const chartData = getChartData({
     aggsChartData,


### PR DESCRIPTION
This PR implements encoding the active explorer view state `explorerView` in URL search param `?view`.

When `?view` is not specified or invalid during the first render of the explorer page, `explorerView` value defaults to the first element of the `explorerViews` array, which is currently `"summary view"`.