### PR TITLE
Update user agreement UI for survival analysis tool PEDS-114

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -177,11 +177,17 @@
   width: 100%;
 }
 
-.explorer-survival-analysis__user-agreement > ul {
-  list-style-type: initial;
-  margin-top: 1rem;
+.explorer-survival-analysis__user-agreement > * {
+  margin-bottom: 1rem;
   max-width: 80ch;
+}
+
+.explorer-survival-analysis__user-agreement > ul {
   padding-left: 2rem;
+}
+
+.explorer-survival-analysis__user-agreement > ul > li {
+  margin-top: 0.5rem;
 }
 
 .explorer-survival-analysis__user-agreement > button {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -103,7 +103,7 @@
   left: var(--dashboard__sidebar-width);
   padding: 1rem 1rem 2rem;
   position: fixed;
-  width: inherit;
+  width: 100%;
   z-index: 1;
 }
 
@@ -173,11 +173,13 @@
 }
 
 .explorer-survival-analysis__user-agreement {
-  margin: 1rem;
+  margin: 1rem 1rem 2rem;
   width: 100%;
 }
 
-.explorer-survival-analysis__user-agreement > * {
+.explorer-survival-analysis__user-agreement > p,
+.explorer-survival-analysis__user-agreement > ul,
+.explorer-survival-analysis__user-agreement > video {
   margin-bottom: 1rem;
   max-width: 80ch;
 }
@@ -188,8 +190,4 @@
 
 .explorer-survival-analysis__user-agreement > ul > li {
   margin-top: 0.5rem;
-}
-
-.explorer-survival-analysis__user-agreement > button {
-  margin-top: 2rem;
 }

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
@@ -1,42 +1,96 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import Button from '../../gen3-ui-component/components/Button';
+
+// The following resources are currently works in progress
+const statisticalManualHref = '/';
+const summaryVideoHref = '/';
+
+const pcdcStatisticalManualLink = (
+  <a href={statisticalManualHref} target='_black' rel='noopener noreferrer'>
+    PCDC Statistical Manual
+    <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
+  </a>
+);
+
+const checkItems = [
+  <>I have read and understand the {pcdcStatisticalManualLink}.</>,
+  <>
+    I will abide by the principles and policies set forth in the{' '}
+    {pcdcStatisticalManualLink}.
+  </>,
+  'My activity on PCDC web-based analytics tools will be recorded and audited to assess the effectiveness of the pilot and to investigate possible misuse or abuse.',
+  'PCDC may contact me to investigate cases of suspected abuse or misuse of web-based analytics tools. I will promptly respond to inquiries regarding my use of the tools.',
+  'I will not violate PCDC policies or terms of use.',
+  'I will not engage in p-hacking or other forms of statistical misuse.',
+  'I will not reproduce or distribute results generated using web-based analytics tools.',
+  'I will follow a hypothesis-driven approach when performing analyses and maintain a hypothesis record, which may be audited.',
+];
+
+function fullnameSelector(state) {
+  const { additional_info: info, username } = state.user;
+  return info?.firstName && info?.lastName
+    ? `${info?.firstName} ${info?.lastName}`
+    : username;
+}
 
 /**
  * @param {Object} props
  * @param {() => void} props.onAgree
  */
 function UserAgreement({ onAgree }) {
+  const fullname = useSelector(fullnameSelector);
+
+  const initalCheckStatus = {};
+  for (const i of checkItems.keys()) initalCheckStatus[i] = false;
+  const [checkStatus, setCheckstatus] = useState(initalCheckStatus);
+
   return (
     <div className='explorer-survival-analysis__user-agreement'>
       <p>
-        In order to use the Survival Analysis analytics tool, you must agree to
-        the following:
+        The PCDC has partnered with consortia to pilot web-based analytics
+        tools. Due to the potential for statistical misuse and abuse with use of
+        the tools, safeguards have been implemented to facilitate responsible
+        data exploration.
       </p>
+      <p>
+        All users of analytics tools are required to review the{' '}
+        {pcdcStatisticalManualLink}. The manual outlines principles for
+        responsible data exploration and sets forth policies users must agree to
+        abide by. A summary video is included below:
+      </p>
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video controls>
+        <source src={summaryVideoHref} type='video/mp4' />
+      </video>
+      <p>I, {fullname}, agree that:</p>
       <ul>
-        <li>
-          I will not engage in “p-hacking” or other forms of statistical abuse.
-        </li>
-        <li>
-          I will maintain a hypothesis record and declare a hypothesis before
-          analyzing data.
-        </li>
-        <li>
-          I will not reproduce or distribute results generated using analytics
-          tools.
-        </li>
-        <li>
-          I understand and agree that use of analytics tools is logged and
-          monitored to identify abuse and improve the tools. Individual user
-          data may be shared with partners of the PCDC (e.g., member consortia)
-          for operational purposes. Aggregate or de-identified user data may be
-          shared outside of the PCDC without limitation.
-        </li>
-        <li>
-          I understand that access may be revoked if a user is suspected to
-          engage in statistical abuse.
-        </li>
+        {checkItems.map((item, i) => (
+          <li>
+            <label>
+              <input
+                type='checkbox'
+                checked={checkStatus[i]}
+                onChange={(e) => {
+                  e.persist();
+                  setCheckstatus((prev) => ({
+                    ...prev,
+                    [i]: e.target.checked,
+                  }));
+                }}
+              />{' '}
+              {item}
+            </label>
+          </li>
+        ))}
       </ul>
-      <Button buttonType='primary' label='I Agree' onClick={onAgree} />
+      <Button
+        buttonType='primary'
+        label='I Agree'
+        enabled={Object.values(checkStatus).every(Boolean)}
+        onClick={onAgree}
+      />
     </div>
   );
 }

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types';
+import Button from '../../gen3-ui-component/components/Button';
+
+/**
+ * @param {Object} props
+ * @param {() => void} props.onAgree
+ */
+function UserAgreement({ onAgree }) {
+  return (
+    <div className='explorer-survival-analysis__user-agreement'>
+      <p>
+        In order to use the Survival Analysis analytics tool, you must agree to
+        the following:
+      </p>
+      <ul>
+        <li>
+          I will not engage in “p-hacking” or other forms of statistical abuse.
+        </li>
+        <li>
+          I will maintain a hypothesis record and declare a hypothesis before
+          analyzing data.
+        </li>
+        <li>
+          I will not reproduce or distribute results generated using analytics
+          tools.
+        </li>
+        <li>
+          I understand and agree that use of analytics tools is logged and
+          monitored to identify abuse and improve the tools. Individual user
+          data may be shared with partners of the PCDC (e.g., member consortia)
+          for operational purposes. Aggregate or de-identified user data may be
+          shared outside of the PCDC without limitation.
+        </li>
+        <li>
+          I understand that access may be revoked if a user is suspected to
+          engage in statistical abuse.
+        </li>
+      </ul>
+      <Button buttonType='primary' label='I Agree' onClick={onAgree} />
+    </div>
+  );
+}
+
+UserAgreement.propTypes = {
+  onAgree: PropTypes.func,
+};
+
+export default UserAgreement;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreeement.jsx
@@ -85,12 +85,14 @@ function UserAgreement({ onAgree }) {
           </li>
         ))}
       </ul>
-      <Button
-        buttonType='primary'
-        label='I Agree'
-        enabled={Object.values(checkStatus).every(Boolean)}
-        onClick={onAgree}
-      />
+      <div className='explorer-survival-analysis__button-group'>
+        <Button
+          buttonType='primary'
+          label='I Agree'
+          enabled={Object.values(checkStatus).every(Boolean)}
+          onClick={onAgree}
+        />
+      </div>
     </div>
   );
 }

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-shadow */
 import { memo, useState } from 'react';
 import Spinner from '../../components/Spinner';
-import Button from '../../gen3-ui-component/components/Button';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import useSurvivalAnalysisResult from './useSurvivalAnalysisResult';
 import SurvivalPlot from './SurvivalPlot';
 import ControlForm from './ControlForm';
 import RiskTable from './RiskTable';
+import UserAgreement from './UserAgreeement';
 import { checkUserAgreement, handleUserAgreement } from './utils';
 import './ExplorerSurvivalAnalysis.css';
 
@@ -94,45 +94,12 @@ function ExplorerSurvivalAnalysis() {
           </div>
         </>
       ) : (
-        <div className='explorer-survival-analysis__user-agreement'>
-          <p>
-            In order to use the Survival Analysis analytics tool, you must agree
-            to the following:
-          </p>
-          <ul>
-            <li>
-              I will not engage in “p-hacking” or other forms of statistical
-              abuse.
-            </li>
-            <li>
-              I will maintain a hypothesis record and declare a hypothesis
-              before analyzing data.
-            </li>
-            <li>
-              I will not reproduce or distribute results generated using
-              analytics tools.
-            </li>
-            <li>
-              I understand and agree that use of analytics tools is logged and
-              monitored to identify abuse and improve the tools. Individual user
-              data may be shared with partners of the PCDC (e.g., member
-              consortia) for operational purposes. Aggregate or de-identified
-              user data may be shared outside of the PCDC without limitation.
-            </li>
-            <li>
-              I understand that access may be revoked if a user is suspected to
-              engage in statistical abuse.
-            </li>
-          </ul>
-          <Button
-            buttonType='primary'
-            label='I Agree'
-            onClick={() => {
-              handleUserAgreement();
-              setIsUserCompliant(checkUserAgreement());
-            }}
-          />
-        </div>
+        <UserAgreement
+          onAgree={() => {
+            handleUserAgreement();
+            setIsUserCompliant(checkUserAgreement());
+          }}
+        />
       )}
     </div>
   );

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -48,9 +48,9 @@ export const filterRisktableByTime = (data, startTime, endTime = Infinity) =>
 const userAgreementLocalStorageKey = `survival:userAgreement`;
 
 export function checkUserAgreement() {
-  return window.sessionStorage.getItem(userAgreementLocalStorageKey) === 'true';
+  return window.localStorage.getItem(userAgreementLocalStorageKey) === 'true';
 }
 
 export function handleUserAgreement() {
-  return window.sessionStorage.setItem(userAgreementLocalStorageKey, 'true');
+  return window.localStorage.setItem(userAgreementLocalStorageKey, 'true');
 }


### PR DESCRIPTION
Ticket: [PEDS-114](https://pcdc.atlassian.net/browse/PEDS-114)

This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/320 and adds the following changes to the user agreement UI:

* Updated text with hyperlinks and video (resource are currently unavailable)
* Checkbox for each item
* Using "button group" UI to match unlocked survival analysis tool.

See the following demo video:

https://user-images.githubusercontent.com/22449454/155219189-63b409d1-adac-46ef-ae05-4f31f1385097.mov

The  PR also includes a fix for using browser storage API (2630b66e9ea392e278ff46df770e2261e449c2bc).

