### PR TITLE
Fix guppy data double fetching on navigation PEDS-675

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -331,20 +331,26 @@ function GuppyWrapper({
     });
   }
 
+  /**
+   * @param {Object} args
+   * @param {string} [args.anchorValue]
+   * @param {string[]} args.fields
+   */
+  function fetchGuppyData({ anchorValue, fields }) {
+    fetchAggsDataFromGuppy({ anchorValue, filter: state.filter });
+    fetchRawDataFromGuppy({ fields, updateDataWhenReceive: true });
+  }
+
   useEffect(() => {
     getAllFieldsFromGuppy({
       type: guppyConfig.dataType,
     }).then((allFields) => {
       if (isMounted.current) {
         setState((prevState) => ({ ...prevState, allFields }));
-        fetchAggsDataFromGuppy({
+        fetchGuppyData({
           anchorValue: filterConfig.anchor !== undefined ? '' : undefined,
-          filter: state.filter,
-        });
-        fetchRawDataFromGuppy({
           fields:
             rawDataFieldsConfig?.length > 0 ? rawDataFieldsConfig : allFields,
-          updateDataWhenReceive: true,
         });
       }
     });
@@ -359,11 +365,7 @@ function GuppyWrapper({
       isInitialRenderRef.current = false;
       return;
     }
-    fetchAggsDataFromGuppy({ filter: state.filter });
-    fetchRawDataFromGuppy({
-      fields: rawDataFields,
-      updateDataWhenReceive: true,
-    });
+    fetchGuppyData({ fields: rawDataFields });
   }, [patientIds]);
 
   /**

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -337,6 +337,8 @@ function GuppyWrapper({
    * @param {string[]} args.fields
    */
   function fetchGuppyData({ anchorValue, fields }) {
+    controller.current.abort();
+    controller.current = new AbortController();
     fetchAggsDataFromGuppy({ anchorValue, filter: state.filter });
     fetchRawDataFromGuppy({ fields, updateDataWhenReceive: true });
   }


### PR DESCRIPTION
Ticket: [PEDS-675](https://pcdc.atlassian.net/browse/PEDS-675)

This PR fixes the double-fetching of guppy data when user navigates to `/explorer`. This is triggered by handling the invalid `?id` search parameter for the page in `<ExplorerConfigProvider>`, which is, in turn, caused by the initially missing `?id` value on navigating to the page via UI.

The fix relies on aborting the previous queries when new queries are made before their responses arrive. 