### PR TITLE
Dncode data dictionary view in URL search param

### DIFF
--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -5,6 +5,7 @@ import Dashboard from '../Layout/Dashboard';
 import ReduxDataDictionaryTable from './table/DataDictionaryTable';
 import ReduxDataModelStructure from './DataModelStructure';
 import DataDictionaryGraph from './graph/DataDictionaryGraph';
+import ReduxGraphCalculator from './graph/GraphCalculator';
 import ReduxDictionarySearcher from './search/DictionarySearcher';
 import ReduxDictionarySearchHistory from './search/DictionarySearchHistory';
 import './DataDictionary.css';
@@ -13,12 +14,14 @@ import './DataDictionary.css';
  * @param {Object} props
  * @param {string} props.dataVersion
  * @param {boolean} props.isGraphView
+ * @param {boolean} props.layoutInitialized
  * @param {(isGraphView: boolean) => void} props.onSetGraphView
  * @param {string} props.portalVersion
  */
 function DataDictionary({
   dataVersion,
   isGraphView,
+  layoutInitialized,
   onSetGraphView,
   portalVersion,
 }) {
@@ -114,25 +117,25 @@ function DataDictionary({
         </div>
       </Dashboard.Sidebar>
       <Dashboard.Main className='data-dictionary__main'>
-        {isGraphView ? (
-          <div
-            className={`data-dictionary__graph ${
-              isGraphView ? '' : 'data-dictionary__graph--hidden'
-            }`}
-          >
+        <div
+          className={`data-dictionary__graph ${
+            isGraphView ? '' : 'data-dictionary__graph--hidden'
+          }`}
+        >
+          <ReduxGraphCalculator />
+          {isGraphView && layoutInitialized && (
             <DataDictionaryGraph
               onClearSearchResult={handleClearSearchResult}
             />
-          </div>
-        ) : (
-          <div
-            className={`data-dictionary__table ${
-              !isGraphView ? '' : 'data-dictionary__table--hidden'
-            }`}
-          >
-            <ReduxDataDictionaryTable />
-          </div>
-        )}
+          )}
+        </div>
+        <div
+          className={`data-dictionary__table ${
+            !isGraphView ? '' : 'data-dictionary__table--hidden'
+          }`}
+        >
+          <ReduxDataDictionaryTable />
+        </div>
       </Dashboard.Main>
     </Dashboard>
   );
@@ -141,6 +144,7 @@ function DataDictionary({
 DataDictionary.propTypes = {
   dataVersion: PropTypes.string,
   isGraphView: PropTypes.bool,
+  layoutInitialized: PropTypes.bool,
   onSetGraphView: PropTypes.func,
   portalVersion: PropTypes.string,
 };

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -1,5 +1,6 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useSearchParams } from 'react-router-dom';
 import Dashboard from '../Layout/Dashboard';
 import ReduxDataDictionaryTable from './table/DataDictionaryTable';
 import ReduxDataModelStructure from './DataModelStructure';
@@ -21,6 +22,22 @@ function DataDictionary({
   onSetGraphView,
   portalVersion,
 }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const isInitialRenderRef = useRef(true);
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+
+      const searchParamView = searchParams.get('view');
+      if (!['graph', 'table'].includes(searchParamView))
+        setSearchParams(isGraphView ? 'view=graph' : 'view=table');
+      else if (isGraphView !== (searchParamView === 'graph'))
+        onSetGraphView(searchParamView === 'graph');
+    } else {
+      setSearchParams(isGraphView ? 'view=graph' : 'view=table');
+    }
+  }, [isGraphView]);
+
   const dictionarySearcherRef = useRef(null);
 
   function handleClickSearchHistoryItem(keyword) {

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -1,4 +1,4 @@
-import { Component, createRef } from 'react';
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Dashboard from '../Layout/Dashboard';
 import ReduxDataDictionaryTable from './table/DataDictionaryTable';
@@ -8,118 +8,117 @@ import ReduxDictionarySearcher from './search/DictionarySearcher';
 import ReduxDictionarySearchHistory from './search/DictionarySearchHistory';
 import './DataDictionary.css';
 
-class DataDictionary extends Component {
-  constructor(props) {
-    super(props);
-    this.dictionarySearcherRef = createRef();
+/**
+ * @param {Object} props
+ * @param {string} props.dataVersion
+ * @param {boolean} props.isGraphView
+ * @param {(isGraphView: boolean) => void} props.onSetGraphView
+ * @param {string} props.portalVersion
+ */
+function DataDictionary({
+  dataVersion,
+  isGraphView,
+  onSetGraphView,
+  portalVersion,
+}) {
+  const dictionarySearcherRef = useRef(null);
+
+  function handleClickSearchHistoryItem(keyword) {
+    dictionarySearcherRef.current.launchSearchFromOutside(keyword);
   }
 
-  setGraphView = (isGraphView) => {
-    this.props.onSetGraphView(isGraphView);
-  };
+  function handleClearSearchResult() {
+    dictionarySearcherRef.current.launchClearSearchFromOutside();
+  }
 
-  handleClickSearchHistoryItem = (keyword) => {
-    this.dictionarySearcherRef.current.launchSearchFromOutside(keyword);
-  };
-
-  handleClearSearchResult = () => {
-    this.dictionarySearcherRef.current.launchClearSearchFromOutside();
-  };
-
-  render() {
-    return (
-      <Dashboard>
-        <Dashboard.Sidebar className='data-dictionary__sidebar'>
-          <div>
-            <div className='data-dictionary__switch'>
-              <span
-                className={`data-dictionary__switch-button ${
-                  !this.props.isGraphView
-                    ? ''
-                    : 'data-dictionary__switch-button--active'
-                }`}
-                onClick={() => {
-                  this.setGraphView(true);
-                }}
-                onKeyPress={(e) => {
-                  if (e.charCode === 13 || e.charCode === 32) {
-                    e.preventDefault();
-                    this.setGraphView(true);
-                  }
-                }}
-                role='button'
-                tabIndex={0}
-                aria-label='Graph view'
-              >
-                Graph View
-              </span>
-              <span
-                className={`data-dictionary__switch-button ${
-                  this.props.isGraphView
-                    ? ''
-                    : 'data-dictionary__switch-button--active'
-                }`}
-                onClick={() => {
-                  this.setGraphView(false);
-                }}
-                onKeyPress={(e) => {
-                  if (e.charCode === 13 || e.charCode === 32) {
-                    e.preventDefault();
-                    this.setGraphView(false);
-                  }
-                }}
-                role='button'
-                tabIndex={0}
-                aria-label='Dictionary view'
-              >
-                Table View
-              </span>
-            </div>
-            <ReduxDictionarySearcher ref={this.dictionarySearcherRef} />
-            <ReduxDataModelStructure />
-            <ReduxDictionarySearchHistory
-              onClickSearchHistoryItem={this.handleClickSearchHistoryItem}
+  return (
+    <Dashboard>
+      <Dashboard.Sidebar className='data-dictionary__sidebar'>
+        <div>
+          <div className='data-dictionary__switch'>
+            <span
+              className={`data-dictionary__switch-button ${
+                !isGraphView ? '' : 'data-dictionary__switch-button--active'
+              }`}
+              onClick={() => {
+                onSetGraphView(true);
+              }}
+              onKeyPress={(e) => {
+                if (e.charCode === 13 || e.charCode === 32) {
+                  e.preventDefault();
+                  onSetGraphView(true);
+                }
+              }}
+              role='button'
+              tabIndex={0}
+              aria-label='Graph view'
+            >
+              Graph View
+            </span>
+            <span
+              className={`data-dictionary__switch-button ${
+                isGraphView ? '' : 'data-dictionary__switch-button--active'
+              }`}
+              onClick={() => {
+                onSetGraphView(false);
+              }}
+              onKeyPress={(e) => {
+                if (e.charCode === 13 || e.charCode === 32) {
+                  e.preventDefault();
+                  onSetGraphView(false);
+                }
+              }}
+              role='button'
+              tabIndex={0}
+              aria-label='Dictionary view'
+            >
+              Table View
+            </span>
+          </div>
+          <ReduxDictionarySearcher ref={dictionarySearcherRef} />
+          <ReduxDataModelStructure />
+          <ReduxDictionarySearchHistory
+            onClickSearchHistoryItem={handleClickSearchHistoryItem}
+          />
+        </div>
+        <div className='data-dictionary__version-info-area'>
+          <div className='data-dictionary__version-info-list'>
+            {dataVersion !== '' && (
+              <div className='data-dictionary__version-info'>
+                <span>Data Release Version:</span> {dataVersion}
+              </div>
+            )}
+            {portalVersion !== '' && (
+              <div className='data-dictionary__version-info'>
+                <span>Portal Version:</span> {portalVersion}
+              </div>
+            )}
+          </div>
+        </div>
+      </Dashboard.Sidebar>
+      <Dashboard.Main className='data-dictionary__main'>
+        {isGraphView ? (
+          <div
+            className={`data-dictionary__graph ${
+              isGraphView ? '' : 'data-dictionary__graph--hidden'
+            }`}
+          >
+            <DataDictionaryGraph
+              onClearSearchResult={handleClearSearchResult}
             />
           </div>
-          <div className='data-dictionary__version-info-area'>
-            <div className='data-dictionary__version-info-list'>
-              {this.props.dataVersion !== '' && (
-                <div className='data-dictionary__version-info'>
-                  <span>Data Release Version:</span> {this.props.dataVersion}
-                </div>
-              )}
-              {this.props.portalVersion !== '' && (
-                <div className='data-dictionary__version-info'>
-                  <span>Portal Version:</span> {this.props.portalVersion}
-                </div>
-              )}
-            </div>
+        ) : (
+          <div
+            className={`data-dictionary__table ${
+              !isGraphView ? '' : 'data-dictionary__table--hidden'
+            }`}
+          >
+            <ReduxDataDictionaryTable />
           </div>
-        </Dashboard.Sidebar>
-        <Dashboard.Main className='data-dictionary__main'>
-          {this.props.isGraphView ? (
-            <div
-              className={`data-dictionary__graph ${
-                this.props.isGraphView ? '' : 'data-dictionary__graph--hidden'
-              }`}
-            >
-              <DataDictionaryGraph
-                onClearSearchResult={this.handleClearSearchResult}
-              />
-            </div>
-          ) : (
-            <div
-              className={`data-dictionary__table ${
-                !this.props.isGraphView ? '' : 'data-dictionary__table--hidden'
-              }`}
-            >
-              <ReduxDataDictionaryTable />
-            </div>
-          )}
-        </Dashboard.Main>
-      </Dashboard>
-    );
-  }
+        )}
+      </Dashboard.Main>
+    </Dashboard>
+  );
 }
 
 DataDictionary.propTypes = {

--- a/src/DataDictionary/graph/DataDictionaryGraph/index.jsx
+++ b/src/DataDictionary/graph/DataDictionaryGraph/index.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import ReduxGraphCalculator from '../GraphCalculator';
 import ReduxLegend from '../Legend';
 import ReduxCanvas from '../Canvas';
 import ReduxGraphDrawer from '../GraphDrawer';
@@ -11,7 +10,6 @@ import ReduxActionLayer from '../ActionLayer';
 function DataDictionaryGraph({ onClearSearchResult }) {
   return (
     <>
-      <ReduxGraphCalculator />
       <ReduxCanvas>
         <ReduxGraphDrawer />
       </ReduxCanvas>

--- a/src/DataDictionary/index.jsx
+++ b/src/DataDictionary/index.jsx
@@ -9,6 +9,7 @@ const ReduxDataDictionary = (() => {
   /** @param {{ ddgraph: DdgraphState, versionInfo: VersionInfoState }} state */
   const mapStateToProps = (state) => ({
     isGraphView: state.ddgraph.isGraphView,
+    layoutInitialized: state.ddgraph.layoutInitialized,
     ...state.versionInfo,
   });
 


### PR DESCRIPTION
This PR implements encoding the active Data Dictionary view state `isGraphView` in URL search param `?view`. Valid `?view` values include `"graph"` and `"table"`.

When `?view` is not specified or invalid during the first render of the explorer page, `isGraphView` defaults to `false` to match the current behavior, i.e. table view (`?view=table`).

The PR makes a slight change to the component tree by pulling `<ReduxGraphCalculator>` out of `<DataDictionaryGraph>` and render it directly in `<DataDictionary>`. This allows the page to start initializing graph view layout as soon as the user reaches data dictionary page and thus provide a more consistent UX (i.e. removes the flickering of table view when the initial search parameter value matches `?view=graph`). One downside of this change is that the user has to always pay for the expensive `calculateGraphLayout()` call even if she does not select the graph view.