### PR TITLE
Patch release 1.3.1 PEDS-677

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.5",


### PR DESCRIPTION
Ticket: [PEDS-677](https://pcdc.atlassian.net/browse/PEDS-677)

This PR bumps the project version to 1.3.1.

The PR includes the fix for occasionally failing to draw the dictionary graph on `/DD` page--especially when directly accessed instead of navigating from another page on the portal.

This bug was caused by a race condition between the component rendering and loading `dictionary.json` resource, which was in turn caused by a recent change (https://github.com/chicagopcdc/data-portal/pull/338) that led to rendering both table and graph views at once, instead of switching between them based on active view. The fix to this simply awaits `fetchResources()` call before rendering the page in `<ProtectedContent>`.