### PR TITLE
Replace viz.js with graphviz wasm PEDS-204

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30818,11 +30818,6 @@
         "unist-util-stringify-position": "^2.0.0"
       }
     },
-    "viz.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-2.0.0.tgz",
-      "integrity": "sha512-OzUX9NWBc4u9QjFjVZYXGf7evbDHD8D9YcnVk9qEgrpYzWmeX+9Cov0n2KxbIidRRAef8OXwGrPfwnWubasKQg=="
-    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6172,6 +6172,40 @@
         "value-or-promise": "1.0.11"
       }
     },
+    "@hpcc-js/wasm": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.13.0.tgz",
+      "integrity": "sha512-pRR1ykx7FK1z7gxYDi7QRBv7eH7vvcCcmLC2n28CtIoN1fXrpxNMN7UbxjmWCDIeCJ6fGQBJSxh8XnMdVGb16w==",
+      "requires": {
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -13389,8 +13423,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -15373,7 +15406,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -17078,8 +17110,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -19182,8 +19213,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.0.2",
@@ -20795,8 +20825,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-function": {
       "version": "1.0.2",
@@ -29207,7 +29236,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -29303,7 +29331,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -31719,7 +31746,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "stylelint": "stylelint 'src/**/*.css' --config .stylelintrc.js --fix",
     "sanity-check": "node ./sanity-check",
     "format": "prettier --write .",
-    "graphvizlib": "test -f ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm && gzip -k ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm"
+    "graphvizlib": "test -f ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm && gzip -fk ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm"
   },
   "graphql": {
     "file": "./data/schema.json"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.3.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.17",
+    "@hpcc-js/wasm": "^1.13.0",
     "@svgr/webpack": "^6.2.1",
     "ace-builds": "^1.4.14",
     "acorn": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "storybook": "STORYBOOK_PROJECT_ID=search start-storybook -p 9001 -c .storybook",
     "stylelint": "stylelint 'src/**/*.css' --config .stylelintrc.js --fix",
     "sanity-check": "node ./sanity-check",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "graphvizlib": "test -f ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm && gzip -k ./node_modules/@hpcc-js/wasm/dist/graphvizlib.wasm"
   },
   "graphql": {
     "file": "./data/schema.json"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "relay-runtime": "^11.0.2",
     "string-similarity": "^4.0.4",
     "style-loader": "^3.3.1",
-    "viz.js": "2.0.0",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2"
   },

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -33,6 +33,8 @@ npm run relay
 npm run params
 # run a sanity check to make sure portal config works
 npm run sanity-check
+# create a compressed file for graphvizlib wasm
+npm run graphvizlib
 
 export STORYBOOK_PROJECT_ID=search
 export REACT_APP_PROJECT_ID=search


### PR DESCRIPTION
Ticket: [PEDS-204](https://pcdc.atlassian.net/browse/PEDS-204)

This PR replaces long-unmaintained [`viz.js`](https://github.com/mdaines/viz.js/) (last release on 2018/12) with actively maintained [`@hpcc-js/wasm`](https://github.com/hpcc-systems/hpcc-js-wasm) for drawing data dictionary graph. `@hpcc-js/wasm` relies on the WebAssembly compilation of the C/C++ graphviz library. WebAssembly is [supported by all popular modern browsers](https://caniuse.com/wasm).

A brief comparison between using `viz.js` vs `@hpcc-js/wasm` shows
- a slight increase in the image size (~3mb)
- a slight increase in network-transfer size for the data dictionary page (~40kb).
- a decrease in resource size for the data dictionary page (~400kb).
- a performance gain in total blocking time (~500ms) & TTI (~0.5s)
