### PR TITLE
Refactor fetching resources on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -160,7 +160,10 @@ function App() {
           element={
             <ProtectedContent
               preload={() =>
-                dispatch(fetchCoreMetadata(props.match.params[0]))
+                Promise.all([
+                  dispatch(fetchProjects()),
+                  dispatch(fetchCoreMetadata(props.match.params[0])),
+                ])
               }
             >
               <CoreMetadataPage />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,14 @@
 /* eslint-disable react/prop-types */
 import { lazy, Suspense, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import {
+  matchPath,
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
 import Layout from './Layout';
@@ -14,7 +21,12 @@ import {
   // workspaceUrl,
   // workspaceErrorUrl,
 } from './localconf';
-import { fetchGuppySchema, fetchSchema, fetchVersionInfo } from './actions';
+import {
+  fetchDictionary,
+  fetchGuppySchema,
+  fetchSchema,
+  fetchVersionInfo,
+} from './actions';
 import useSessionMonitor from './hooks/useSessionMonitor';
 
 // lazy-loaded pages
@@ -46,6 +58,8 @@ function App() {
   useEffect(() => {
     dispatch(fetchVersionInfo());
   }, []);
+
+  const location = useLocation();
 
   return (
     <Routes>
@@ -84,7 +98,16 @@ function App() {
         <Route
           path='submission'
           element={
-            <ProtectedContent isAdminOnly>
+            <ProtectedContent
+              isAdminOnly
+              preload={() =>
+                ['/submission/map', '/submission/:project/*'].some((pattern) =>
+                  matchPath(pattern, location.pathname)
+                )
+                  ? dispatch(fetchDictionary())
+                  : Promise.resolve()
+              }
+            >
               <Outlet />
             </ProtectedContent>
           }
@@ -123,7 +146,7 @@ function App() {
         <Route
           path='dd/*'
           element={
-            <ProtectedContent>
+            <ProtectedContent preload={() => dispatch(fetchDictionary())}>
               <DataDictionary />
             </ProtectedContent>
           }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,7 +108,7 @@ function App() {
         <Route
           path='identity'
           element={
-            <ProtectedContent filter={() => dispatch(fetchAccess())}>
+            <ProtectedContent preload={() => dispatch(fetchAccess())}>
               <UserProfile />
             </ProtectedContent>
           }
@@ -152,7 +152,7 @@ function App() {
           path='/files/*'
           element={
             <ProtectedContent
-              filter={() =>
+              preload={() =>
                 dispatch(fetchCoreMetadata(props.match.params[0]))
               }
             >

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import {
   // workspaceUrl,
   // workspaceErrorUrl,
 } from './localconf';
-import { fetchVersionInfo } from './actions';
+import { fetchGuppySchema, fetchSchema, fetchVersionInfo } from './actions';
 import useSessionMonitor from './hooks/useSessionMonitor';
 
 // lazy-loaded pages
@@ -100,7 +100,14 @@ function App() {
         <Route
           path='query'
           element={
-            <ProtectedContent>
+            <ProtectedContent
+              preload={() =>
+                Promise.all([
+                  dispatch(fetchSchema()),
+                  dispatch(fetchGuppySchema()),
+                ])
+              }
+            >
               <GraphQLQuery />
             </ProtectedContent>
           }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,7 @@
 /* eslint-disable react/prop-types */
 import { lazy, Suspense, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import {
-  matchPath,
-  Navigate,
-  Outlet,
-  Route,
-  Routes,
-  useLocation,
-} from 'react-router-dom';
+import { matchPath, Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import Spinner from './gen3-ui-component/components/Spinner/Spinner';
 
 import Layout from './Layout';
@@ -59,8 +52,6 @@ function App() {
     dispatch(fetchVersionInfo());
   }, []);
 
-  const location = useLocation();
-
   return (
     <Routes>
       <Route
@@ -100,9 +91,9 @@ function App() {
           element={
             <ProtectedContent
               isAdminOnly
-              preload={() =>
+              preload={(/** @type {import('react-router').Location} */ loc) =>
                 ['/submission/map', '/submission/:project/*'].some((pattern) =>
-                  matchPath(pattern, location.pathname)
+                  matchPath(pattern, loc.pathname)
                 )
                   ? dispatch(fetchDictionary())
                   : Promise.resolve()

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -139,11 +139,13 @@ function ProtectedContent({
         .then(checkAccess)
         .then(checkIfAdmin)
         .then((newState) => {
-          if (newState.redirectTo && newState.redirectTo !== location.pathname)
-            updateState(newState);
-          else if (newState.authenticated && typeof preload === 'function')
-            preload().finally(() => updateState(newState));
-          else updateState(newState);
+          const shouldPreload =
+            newState.authenticated && typeof preload === 'function';
+          const shouldRedirect =
+            newState.redirectTo && newState.redirectTo !== location.pathname;
+
+          if (!shouldPreload || shouldRedirect) updateState(newState);
+          else preload().finally(() => updateState(newState));
         });
   }, [location]);
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
-import { matchPath, Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { fetchDictionary, fetchUser, fetchUserAccess } from '../actions';
+import { fetchUser, fetchUserAccess } from '../actions';
 import Spinner from '../components/Spinner';
 import AuthPopup from './AuthPopup';
 import { fetchLogin } from './ReduxLogin';
@@ -26,12 +26,6 @@ import { fetchLogin } from './ReduxLogin';
  * @property {boolean} [isLoginPage] default false
  * @property {() => Promise} [preload] optional async function to run before rendering the child component, meant for fetching resources
  */
-
-const LOCATIONS_DICTIONARY = [
-  '/dd/*',
-  '/submission/map',
-  '/submission/:project/*',
-];
 
 /**
  * Container for components that require authentication to access.
@@ -117,17 +111,6 @@ function ProtectedContent({
     return isAdminUser ? currentState : { ...currentState, redirectTo: '/' };
   }
 
-  /** Fetch resources on demand based on path */
-  async function fetchResources() {
-    /** @param {string[]} patterns */
-    function matchPathOneOf(patterns) {
-      return patterns.some((pattern) => matchPath(pattern, location.pathname));
-    }
-
-    if (matchPathOneOf(LOCATIONS_DICTIONARY))
-      await reduxStore.dispatch(fetchDictionary());
-  }
-
   /** @param {ProtectedContentState} currentState */
   function updateState(currentState) {
     const newState = { ...currentState, dataLoaded: true };
@@ -158,12 +141,9 @@ function ProtectedContent({
         .then((newState) => {
           if (newState.redirectTo && newState.redirectTo !== location.pathname)
             updateState(newState);
-          else
-            fetchResources().then(() => {
-              if (newState.authenticated && typeof preload === 'function')
-                preload().finally(() => updateState(newState));
-              else updateState(newState);
-            });
+          else if (newState.authenticated && typeof preload === 'function')
+            preload().finally(() => updateState(newState));
+          else updateState(newState);
         });
   }, [location]);
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -2,12 +2,7 @@ import { useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import { matchPath, Navigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import {
-  fetchDictionary,
-  fetchProjects,
-  fetchUser,
-  fetchUserAccess,
-} from '../actions';
+import { fetchDictionary, fetchUser, fetchUserAccess } from '../actions';
 import Spinner from '../components/Spinner';
 import AuthPopup from './AuthPopup';
 import { fetchLogin } from './ReduxLogin';
@@ -37,7 +32,6 @@ const LOCATIONS_DICTIONARY = [
   '/submission/map',
   '/submission/:project/*',
 ];
-const LOCATIONS_PROJECTS = ['/files/*'];
 
 /**
  * Container for components that require authentication to access.
@@ -132,8 +126,6 @@ function ProtectedContent({
 
     if (matchPathOneOf(LOCATIONS_DICTIONARY))
       await reduxStore.dispatch(fetchDictionary());
-    else if (matchPathOneOf(LOCATIONS_PROJECTS))
-      await reduxStore.dispatch(fetchProjects());
   }
 
   /** @param {ProtectedContentState} currentState */

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -24,7 +24,7 @@ import { fetchLogin } from './ReduxLogin';
  * @property {JSX.Element} children required child component
  * @property {boolean} [isAdminOnly] default false - if true, redirect to index page
  * @property {boolean} [isLoginPage] default false
- * @property {(location?: import('react-router').Location) => Promise} [preload] optional async function to run before rendering the child component, meant for fetching resources
+ * @property {(location?: import('react-router').Location) => Promise} [preload] optional async function to preload resources before rendering the child component
  */
 
 /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -40,7 +40,7 @@ import { fetchLogin } from './ReduxLogin';
  * @property {JSX.Element} children required child component
  * @property {boolean} [isAdminOnly] default false - if true, redirect to index page
  * @property {boolean} [isLoginPage] default false
- * @property {() => Promise} [filter] optional filter to apply before rendering the child component
+ * @property {() => Promise} [preload] optional async function to run before rendering the child component, meant for fetching resources
  */
 
 const LOCATIONS_DICTIONARY = [
@@ -59,7 +59,7 @@ function ProtectedContent({
   children,
   isAdminOnly = false,
   isLoginPage = false,
-  filter,
+  preload,
 }) {
   /** @type {{  dispatch: ThunkDispatch; getState: () => ReduxState }} */
   const reduxStore = useStore();
@@ -185,8 +185,8 @@ function ProtectedContent({
             updateState(newState);
           else
             fetchResources().then(() => {
-              if (newState.authenticated && typeof filter === 'function')
-                filter().finally(() => updateState(newState));
+              if (newState.authenticated && typeof preload === 'function')
+                preload().finally(() => updateState(newState));
               else updateState(newState);
             });
         });
@@ -209,7 +209,7 @@ ProtectedContent.propTypes = {
   children: PropTypes.node.isRequired,
   isAdminOnly: PropTypes.bool,
   isLoginPage: PropTypes.bool,
-  filter: PropTypes.func,
+  preload: PropTypes.func,
 };
 
 export default ProtectedContent;

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import {
   fetchDictionary,
   fetchProjects,
-  fetchSchema,
-  fetchGuppySchema,
   fetchUser,
   fetchUserAccess,
 } from '../actions';
@@ -40,7 +38,6 @@ const LOCATIONS_DICTIONARY = [
   '/submission/:project/*',
 ];
 const LOCATIONS_PROJECTS = ['/files/*'];
-const LOCATIONS_SCHEMA = ['/query'];
 
 /**
  * Container for components that require authentication to access.
@@ -137,11 +134,6 @@ function ProtectedContent({
       await reduxStore.dispatch(fetchDictionary());
     else if (matchPathOneOf(LOCATIONS_PROJECTS))
       await reduxStore.dispatch(fetchProjects());
-    else if (matchPathOneOf(LOCATIONS_SCHEMA))
-      await Promise.all([
-        reduxStore.dispatch(fetchSchema()),
-        reduxStore.dispatch(fetchGuppySchema()),
-      ]);
   }
 
   /** @param {ProtectedContentState} currentState */

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -24,7 +24,7 @@ import { fetchLogin } from './ReduxLogin';
  * @property {JSX.Element} children required child component
  * @property {boolean} [isAdminOnly] default false - if true, redirect to index page
  * @property {boolean} [isLoginPage] default false
- * @property {() => Promise} [preload] optional async function to run before rendering the child component, meant for fetching resources
+ * @property {(location?: import('react-router').Location) => Promise} [preload] optional async function to run before rendering the child component, meant for fetching resources
  */
 
 /**
@@ -145,7 +145,7 @@ function ProtectedContent({
             newState.redirectTo && newState.redirectTo !== location.pathname;
 
           if (!shouldPreload || shouldRedirect) updateState(newState);
-          else preload().finally(() => updateState(newState));
+          else preload(location).finally(() => updateState(newState));
         });
   }, [location]);
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -147,10 +147,15 @@ function ProtectedContent({
       await reduxStore.dispatch(fetchDictionary());
     else if (matchPathOneOf(LOCATIONS_PROJECTS) && !project.projects)
       await reduxStore.dispatch(fetchProjects());
-    else if (matchPathOneOf(LOCATIONS_SCHEMA)) {
-      if (!graphiql.schema) await reduxStore.dispatch(fetchSchema());
-      if (!graphiql.guppySchema) await reduxStore.dispatch(fetchGuppySchema());
-    }
+    else if (matchPathOneOf(LOCATIONS_SCHEMA))
+      await Promise.all([
+        !graphiql.schema
+          ? reduxStore.dispatch(fetchSchema())
+          : Promise.resolve(),
+        !graphiql.guppySchema
+          ? reduxStore.dispatch(fetchGuppySchema())
+          : Promise.resolve(),
+      ]);
   }
 
   /** @param {ProtectedContentState} currentState */

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -15,17 +15,8 @@ import AuthPopup from './AuthPopup';
 import { fetchLogin } from './ReduxLogin';
 
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
-/** @typedef {import('../types').ProjectState} ProjectState */
 /** @typedef {import('../types').UserState} UserState */
-/** @typedef {import('../GraphQLEditor/types').GraphiqlState} GraphiqlState */
-/** @typedef {import('../Submission/types').SubmissionState} SubmissionState */
-/**
- * @typedef {Object} ReduxState
- * @property {GraphiqlState} graphiql
- * @property {ProjectState} project
- * @property {SubmissionState} submission
- * @property {UserState} user
- */
+/** @typedef {{ user: UserState }} ReduxState */
 
 /**
  * @typedef {Object} ProtectedContentState
@@ -137,24 +128,19 @@ function ProtectedContent({
 
   /** Fetch resources on demand based on path */
   async function fetchResources() {
-    const { graphiql, project, submission } = reduxStore.getState();
     /** @param {string[]} patterns */
     function matchPathOneOf(patterns) {
       return patterns.some((pattern) => matchPath(pattern, location.pathname));
     }
 
-    if (matchPathOneOf(LOCATIONS_DICTIONARY) && !submission.dictionary)
+    if (matchPathOneOf(LOCATIONS_DICTIONARY))
       await reduxStore.dispatch(fetchDictionary());
-    else if (matchPathOneOf(LOCATIONS_PROJECTS) && !project.projects)
+    else if (matchPathOneOf(LOCATIONS_PROJECTS))
       await reduxStore.dispatch(fetchProjects());
     else if (matchPathOneOf(LOCATIONS_SCHEMA))
       await Promise.all([
-        !graphiql.schema
-          ? reduxStore.dispatch(fetchSchema())
-          : Promise.resolve(),
-        !graphiql.guppySchema
-          ? reduxStore.dispatch(fetchGuppySchema())
-          : Promise.resolve(),
+        reduxStore.dispatch(fetchSchema()),
+        reduxStore.dispatch(fetchGuppySchema()),
       ]);
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -20,6 +20,9 @@ import { asyncSetInterval } from './utils';
 /** @typedef {import('./types').KubeState} KubeState */
 /** @typedef {import('./types').UserAccessState} UserAccessState */
 /** @typedef {import('./types').PopupState} PopupState */
+/** @typedef {import('./types').ProjectState} ProjectState */
+/** @typedef {import('./GraphQLEditor/types').GraphiqlState} GraphiqlState */
+/** @typedef {import('./Submission/types').SubmissionState} SubmissionState */
 
 /**
  * @param {Partial<PopupState>} state
@@ -281,60 +284,96 @@ export const fetchUserNoRefresh = () => (/** @type {Dispatch} */ dispatch) =>
  * redux-thunk support asynchronous redux actions via 'thunks' -
  * lambdas that accept dispatch and getState functions as arguments
  */
-export const fetchProjects = () => (/** @type {Dispatch} */ dispatch) =>
-  fetchWithCreds({
-    path: `${submissionApiPath}graphql`,
-    body: JSON.stringify({
-      query: 'query { project(first:0) {code, project_id, availability_type}}',
-    }),
-    method: 'POST',
-  }).then(({ status, data }) => {
-    if (status === 200)
-      dispatch({
-        type: 'RECEIVE_PROJECTS',
-        data: data.data.project,
-        status,
-      });
-    else
-      dispatch({
-        type: 'FETCH_ERROR',
-        error: data,
-        status,
-      });
-  });
+export const fetchProjects =
+  () =>
+  /**
+   * @param {Dispatch} dispatch
+   * @param {() => { project: ProjectState }} getState
+   */
+  (dispatch, getState) =>
+    getState().project.projects
+      ? Promise.resolve()
+      : fetchWithCreds({
+          path: `${submissionApiPath}graphql`,
+          body: JSON.stringify({
+            query:
+              'query { project(first:0) {code, project_id, availability_type}}',
+          }),
+          method: 'POST',
+        }).then(({ status, data }) => {
+          if (status === 200)
+            dispatch({
+              type: 'RECEIVE_PROJECTS',
+              data: data.data.project,
+              status,
+            });
+          else
+            dispatch({
+              type: 'FETCH_ERROR',
+              error: data,
+              status,
+            });
+        });
 
 /**
  * Fetch the schema for graphi, and stuff it into redux - handled by router
  */
-export const fetchSchema = () => (/** @type {Dispatch} */ dispatch) =>
-  fetch('/data/schema.json')
-    .then((response) => response.json())
-    .then(({ data }) =>
-      dispatch({ type: 'RECEIVE_SCHEMA', schema: buildClientSchema(data) })
-    );
+export const fetchSchema =
+  () =>
+  /**
+   * @param {Dispatch} dispatch
+   * @param {() => { graphiql: GraphiqlState }} getState
+   */
+  (dispatch, getState) =>
+    getState().graphiql.schema
+      ? Promise.resolve()
+      : fetch('/data/schema.json')
+          .then((response) => response.json())
+          .then(({ data }) =>
+            dispatch({
+              type: 'RECEIVE_SCHEMA',
+              schema: buildClientSchema(data),
+            })
+          );
 
-export const fetchGuppySchema = () => (/** @type {Dispatch} */ dispatch) =>
-  fetch(guppyGraphQLUrl, {
-    credentials: 'include',
-    headers,
-    method: 'POST',
-    body: JSON.stringify({
-      query: getIntrospectionQuery(),
-      operationName: 'IntrospectionQuery',
-    }),
-  })
-    .then((response) => response.json())
-    .then(({ data }) =>
-      dispatch({
-        type: 'RECEIVE_GUPPY_SCHEMA',
-        data: buildClientSchema(data),
-      })
-    );
+export const fetchGuppySchema =
+  () =>
+  /**
+   * @param {Dispatch} dispatch
+   * @param {() => { graphiql: GraphiqlState }} getState
+   */
+  (dispatch, getState) =>
+    getState().graphiql.guppySchema
+      ? Promise.resolve()
+      : fetch(guppyGraphQLUrl, {
+          credentials: 'include',
+          headers,
+          method: 'POST',
+          body: JSON.stringify({
+            query: getIntrospectionQuery(),
+            operationName: 'IntrospectionQuery',
+          }),
+        })
+          .then((response) => response.json())
+          .then(({ data }) =>
+            dispatch({
+              type: 'RECEIVE_GUPPY_SCHEMA',
+              data: buildClientSchema(data),
+            })
+          );
 
-export const fetchDictionary = () => (/** @type {Dispatch} */ dispatch) =>
-  fetch('/data/dictionary.json')
-    .then((response) => response.json())
-    .then((data) => dispatch({ type: 'RECEIVE_DICTIONARY', data }));
+export const fetchDictionary =
+  () =>
+  /**
+   * @param {Dispatch} dispatch
+   * @param {() => { submission: SubmissionState }} getState
+   */
+  (dispatch, getState) =>
+    getState().submission.dictionary
+      ? Promise.resolve()
+      : fetch('/data/dictionary.json')
+          .then((response) => response.json())
+          .then((data) => dispatch({ type: 'RECEIVE_DICTIONARY', data }));
 
 export const fetchVersionInfo = () => (/** @type {Dispatch} */ dispatch) =>
   fetchWithCreds({


### PR DESCRIPTION
This PR refactors how `<ProtectedContent>` fetches resources on route change by switching (back) to using `preload()` prop (previously `filter()`) from defining/using a dedicated `fetchResources()` clousure inside the component body. Unlike `filter()`, `preload()` accepts react-router `location` object as optional parameter (see `<Route>` with `"submission"` path for its use case).

In doing so, the relevant thunk actions for fetching resources are also modified to fetch only if resource is missing.