### PR TITLE
Refactor graph utils

### DIFF
--- a/src/GraphUtils/utils.js
+++ b/src/GraphUtils/utils.js
@@ -124,32 +124,22 @@ export function createNodesAndEdges(
 
 /**
  * Find the root of the given graph (no edges out)
- * @method findRoot
- * @param nodes
- * @param edges
+ * @param {{ id: string }[]} nodes
+ * @param {{ source: { id: string } | string }[]} edges
  * @return {string} rootName or null if no root
  */
 export function findRoot(nodes, edges) {
-  const couldBeRoot = edges.reduce(
-    (db, edge) => {
-      // At some point the d3 force layout converts
-      //   edge.source and edge.target into node references ...
-      const sourceName =
-        typeof edge.source === 'object' ? edge.source.id : edge.source;
-      if (db[sourceName]) {
-        db[sourceName] = false;
-      }
-      return db;
-    },
-    // initialize emptyDb - any node could be the root
-    nodes.reduce((emptyDb, node) => {
-      const res = emptyDb;
-      res[node.id] = true;
-      return res;
-    }, {})
-  );
-  const rootNode = nodes.find((n) => couldBeRoot[n.id]);
-  return rootNode ? rootNode.id : null;
+  /** @type {{ [name: string]: boolean }} */
+  const couldBeRoot = {};
+  for (const node of nodes) couldBeRoot[node.id] = true;
+  for (const edge of edges) {
+    const sourceName =
+      typeof edge.source === 'object' ? edge.source.id : edge.source;
+    if (couldBeRoot[sourceName]) couldBeRoot[sourceName] = false;
+  }
+
+  const rootNode = nodes.find(({ id }) => couldBeRoot[id]);
+  return rootNode?.id ?? null;
 }
 
 /**

--- a/src/GraphUtils/utils.js
+++ b/src/GraphUtils/utils.js
@@ -361,11 +361,6 @@ fixedsize=true width=${nodeWidth} height=${nodeHeight} shape=rectangle]\n`;
 };
 
 export function createDotStrinByNodesEdges(nodes, edges) {
-  const posInfo = assignNodePositions(nodes, edges);
-  const dotString = buildGraphVizDOTString(
-    nodes,
-    edges,
-    posInfo.treeLevel2Names
-  );
-  return dotString;
+  const { treeLevel2Names } = assignNodePositions(nodes, edges);
+  return buildGraphVizDOTString(nodes, edges, treeLevel2Names);
 }

--- a/src/GraphUtils/utils.js
+++ b/src/GraphUtils/utils.js
@@ -146,42 +146,39 @@ export function findRoot(nodes, edges) {
  * Recursive helper function for getTreeHierarchy
  * Returns the hierarchy of the tree in the form of a map
  * Each (key, value) consists of (node, node's descendants including the node itself)
- * @method getTreeHierarchyHelper
- * @param root
- * @param name2EdgesIn
- * @param hierarchy
- * @return {map}
+ * @param {string} root
+ * @param {{ [name:string]: { source: { id: string } | string }[] }} name2EdgesIn
+ * @param {Map<string, Set<string>>} hierarchy
  */
-function getTreeHierarchyHelper(node, name2EdgesIn, hierarchy) {
-  const descendants = new Set();
-  descendants.add(node);
-  hierarchy.set(node, descendants);
-  name2EdgesIn[node].forEach((edge) => {
+function getTreeHierarchyHelper(root, name2EdgesIn, hierarchy) {
+  const descendants = /** @type {Set<string>} */ (new Set());
+  descendants.add(root);
+
+  hierarchy.set(root, descendants);
+  for (const edge of name2EdgesIn[root]) {
     const sourceName =
       typeof edge.source === 'object' ? edge.source.id : edge.source;
     if (!hierarchy.get(sourceName)) {
       // don't want to visit node again
       hierarchy = getTreeHierarchyHelper(sourceName, name2EdgesIn, hierarchy);
       descendants.add(sourceName);
-      hierarchy.get(sourceName).forEach((n) => {
-        descendants.add(n);
-      });
+      for (const n of hierarchy.get(sourceName)) descendants.add(n);
     }
-  });
-  hierarchy.set(node, descendants);
+  }
+
+  hierarchy.set(root, descendants);
   return hierarchy;
 }
 
 /**
  * Returns the hierarchy of the tree in the form of a map
  * Each (key, value) consists of (node, node's descendants including the node itself)
- * @method getTreeHierarchy
- * @param root
- * @param name2EdgesIn
- * @return {map}
+ * @param {string} root
+ * @param {{ [name:string]: { source: { id: string } | string }[] }} name2EdgesIn
  */
 export function getTreeHierarchy(root, name2EdgesIn) {
-  return getTreeHierarchyHelper(root, name2EdgesIn, new Map());
+  const hierarchy = /** @type {Map<string, Set<string>>} */ (new Map());
+  return getTreeHierarchyHelper(root, name2EdgesIn, hierarchy);
 }
 
 /**

--- a/src/GraphUtils/utils.js
+++ b/src/GraphUtils/utils.js
@@ -1,30 +1,34 @@
 /**
- * Get subgroup links from link
- * @param {object} link - array of links
- * @param {object} nameToNode - key (node name) value (node object) map
- * @param {string} sourceId - source id for subgroup links
- * This function traverse links recursively and return all nested subgroup lnks
+ * @typedef {Object} Link
+ * @property {Link[]} [subgroup]
+ * @property {string} target_type
  */
-const getSubgroupLinks = (link, nameToNode, sourceId) => {
-  let subgroupLinks = [];
-  if (link.subgroup) {
-    link.subgroup.forEach((sgLink) => {
-      if (sgLink.subgroup) {
-        subgroupLinks = subgroupLinks.concat(
-          getSubgroupLinks(sgLink, nameToNode, sourceId)
-        );
-      } else {
-        subgroupLinks.push({
-          source: nameToNode[sourceId],
-          target: nameToNode[sgLink.target_type],
-          exists: 1,
-          ...sgLink,
-        });
-      }
-    });
-  }
+
+/**
+ * Get subgroup links from link.
+ * Traverse links recursively and return all nested subgroup lnks.
+ * @param {Link} link - array of links
+ * @param {{ [name: string]: any }} nameToNode - key (node name) value (node object) map
+ * @param {string} sourceId - source id for subgroup links
+ * @returns {Array}
+ */
+function getSubgroupLinks(link, nameToNode, sourceId) {
+  if (!link.subgroup) return [];
+
+  const subgroupLinks = [];
+  for (const sgLink of link.subgroup)
+    if (sgLink.subgroup)
+      subgroupLinks.push(...getSubgroupLinks(sgLink, nameToNode, sourceId));
+    else
+      subgroupLinks.push({
+        source: nameToNode[sourceId],
+        target: nameToNode[sgLink.target_type],
+        exists: 1,
+        ...sgLink,
+      });
+
   return subgroupLinks;
-};
+}
 
 /**
  * Given a data dictionary that defines a set of nodes

--- a/src/GraphUtils/utils.js
+++ b/src/GraphUtils/utils.js
@@ -332,7 +332,7 @@ export function assignNodePositions(nodes, edges, opts) {
  * DOT Language ref: http://www.graphviz.org/doc/info/lang.html
  * @param {Array} nodes
  * @param {Array} edges
- * @params {Object} treeLevel2Names - levels and nodes in each level, {levelNum:[nodeNameList]}
+ * @param {string[][]} treeLevel2Names - levels and nodes in each level, {levelNum:[nodeNameList]}
  * @returns {string} graph translated into DOT language
  */
 const buildGraphVizDOTString = (nodes, edges, treeLevel2Names) => {
@@ -340,24 +340,22 @@ const buildGraphVizDOTString = (nodes, edges, treeLevel2Names) => {
   const canvasSize = 5;
   const nodeWidth = 1.2;
   const nodeHeight = 0.8;
-  let graphString = 'digraph dictionary {\n';
-  graphString += `size="${canvasSize}, ${canvasSize}"\n`;
-  graphString += `ratio=${whRatio}\n`;
-  nodes.forEach((node) => {
-    graphString += `${node.id} [type="${node.category}" \
-label="${node.name}" \
-fixedsize=true width=${nodeWidth} height=${nodeHeight} \
-shape=rectangle
-]\n`;
-  });
-  edges.forEach((edge) => {
+
+  let graphString = `digraph dictionary {
+size="${canvasSize}, ${canvasSize}"
+ratio=${whRatio}\n`;
+
+  for (const node of nodes)
+    graphString += `${node.id} [type="${node.category}" label="${node.name}" \
+fixedsize=true width=${nodeWidth} height=${nodeHeight} shape=rectangle]\n`;
+
+  for (const edge of edges)
     graphString += `${edge.source.id} -> ${edge.target.id}[arrowhead=none tailport=s ]\n`;
-  });
-  if (treeLevel2Names) {
-    treeLevel2Names.forEach((IDsInThisLevel, i) => {
+
+  if (treeLevel2Names)
+    for (const [i, IDsInThisLevel] of treeLevel2Names.entries())
       graphString += `{rank=${i} ${IDsInThisLevel.join(' ')}}\n`;
-    });
-  }
+
   graphString += '}';
   return graphString;
 };


### PR DESCRIPTION
This PR includes refactoring efforts on `src/GraphUtils/utils` functions that

* reduce clutter 
* favor simple loops over chaining array methods
* improve JSDoc comments