### PR TITLE
Preload graphviz layout PEDS-681

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import {
 } from './localconf';
 import {
   fetchDictionary,
+  fetchGraphvizLayout,
   fetchGuppySchema,
   fetchSchema,
   fetchVersionInfo,
@@ -137,7 +138,14 @@ function App() {
         <Route
           path='dd/*'
           element={
-            <ProtectedContent preload={() => dispatch(fetchDictionary())}>
+            <ProtectedContent
+              preload={() =>
+                Promise.all([
+                  dispatch(fetchDictionary()),
+                  dispatch(fetchGraphvizLayout()),
+                ])
+              }
+            >
               <DataDictionary />
             </ProtectedContent>
           }

--- a/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
+++ b/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
@@ -1,8 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  getAllTypes,
-  calculateGraphLayout,
   calculatePathRelatedToSecondHighlightingNode,
   calculateHighlightRelatedNodeIDs,
   calculateDataModelStructure,
@@ -16,16 +14,7 @@ class GraphCalculator extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.layoutInitialized) {
-      const layoutResult = calculateGraphLayout(
-        this.props.dictionary,
-        this.props.graphvizLayout
-      );
-
-      this.props.onGraphLayoutCalculated(layoutResult);
-      const legendItems = getAllTypes(layoutResult.nodes);
-      this.props.onGraphLegendCalculated(legendItems);
-    }
+    if (!this.props.layoutInitialized) this.props.initializeLayout();
   }
 
   // eslint-disable-next-line camelcase
@@ -160,10 +149,7 @@ class GraphCalculator extends Component {
 }
 
 GraphCalculator.propTypes = {
-  dictionary: PropTypes.object,
-  graphvizLayout: PropTypes.object,
-  onGraphLayoutCalculated: PropTypes.func,
-  onGraphLegendCalculated: PropTypes.func,
+  initializeLayout: PropTypes.func,
   nodes: PropTypes.arrayOf(PropTypes.object),
   edges: PropTypes.arrayOf(PropTypes.object),
   highlightingNode: PropTypes.object,
@@ -176,10 +162,7 @@ GraphCalculator.propTypes = {
 };
 
 GraphCalculator.defaultProps = {
-  dictionary: {},
-  graphvizLayout: {},
-  onGraphLayoutCalculated: () => {},
-  onGraphLegendCalculated: () => {},
+  initializeLayout: () => {},
   highlightingNode: null,
   nodes: [],
   edges: [],

--- a/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
+++ b/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
@@ -17,11 +17,14 @@ class GraphCalculator extends Component {
 
   componentDidMount() {
     if (!this.props.layoutInitialized) {
-      calculateGraphLayout(this.props.dictionary).then((layoutResult) => {
-        this.props.onGraphLayoutCalculated(layoutResult);
-        const legendItems = getAllTypes(layoutResult.nodes);
-        this.props.onGraphLegendCalculated(legendItems);
-      });
+      const layoutResult = calculateGraphLayout(
+        this.props.dictionary,
+        this.props.graphvizLayout
+      );
+
+      this.props.onGraphLayoutCalculated(layoutResult);
+      const legendItems = getAllTypes(layoutResult.nodes);
+      this.props.onGraphLegendCalculated(legendItems);
     }
   }
 
@@ -158,6 +161,7 @@ class GraphCalculator extends Component {
 
 GraphCalculator.propTypes = {
   dictionary: PropTypes.object,
+  graphvizLayout: PropTypes.object,
   onGraphLayoutCalculated: PropTypes.func,
   onGraphLegendCalculated: PropTypes.func,
   nodes: PropTypes.arrayOf(PropTypes.object),
@@ -173,6 +177,7 @@ GraphCalculator.propTypes = {
 
 GraphCalculator.defaultProps = {
   dictionary: {},
+  graphvizLayout: {},
   onGraphLayoutCalculated: () => {},
   onGraphLegendCalculated: () => {},
   highlightingNode: null,

--- a/src/DataDictionary/graph/GraphCalculator/GraphCalculator.test.jsx
+++ b/src/DataDictionary/graph/GraphCalculator/GraphCalculator.test.jsx
@@ -1,22 +1,16 @@
 import { render, waitFor } from '@testing-library/react';
 import GraphCalculator from './GraphCalculator';
-import { buildTestData, testGraph1 } from '../../../GraphUtils/testData';
+import { testGraph1 } from '../../../GraphUtils/testData';
 
-const data = buildTestData();
-
-test('calculates layout and legend on mount', () => {
-  const onGraphLayoutCalculated = jest.fn();
-  const onGraphLegendCalculated = jest.fn();
+test('initializes layout on mount', () => {
+  const initializeGraphLayout = jest.fn();
   const props = {
-    dictionary: data.dictionary,
-    onGraphLayoutCalculated,
-    onGraphLegendCalculated,
+    initializeGraphLayout,
   };
   render(<GraphCalculator {...props} />);
 
   waitFor(() => {
-    expect(onGraphLayoutCalculated).toHaveBeenCalledTimes(1);
-    expect(onGraphLegendCalculated).toHaveBeenCalledTimes(1);
+    expect(initializeGraphLayout).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -26,7 +20,6 @@ test('updates related highlighted nodes and clickable nodes when highlighted nod
   const onPathRelatedToSecondHighlightingNodeCalculated = jest.fn();
   const onSecondHighlightingNodeCandidateIDsCalculated = jest.fn();
   const props = {
-    dictionary: data.dictionary,
     edges: testGraph1.graphEdges,
     nodes: testGraph1.graphNodes,
     onDataModelStructureCalculated,

--- a/src/DataDictionary/graph/GraphCalculator/graphCalculatorHelper.test.js
+++ b/src/DataDictionary/graph/GraphCalculator/graphCalculatorHelper.test.js
@@ -8,10 +8,11 @@ import {
 } from './graphCalculatorHelper';
 
 describe('graphCalculatorHelper', () => {
-  const { dictionary, nodes, edges } = buildTestData();
+  const { dictionary, nodes, edges, getGraphvizLayout } = buildTestData();
 
   it('can calculate layout', async () => {
-    const layout = await calculateGraphLayout(dictionary);
+    const graphvizLayout = await getGraphvizLayout(dictionary);
+    const layout = await calculateGraphLayout(dictionary, graphvizLayout);
     layout.nodes.forEach((n) => {
       expect(nodes.find((testN) => testN.id === n.id)).toBeDefined();
     });
@@ -39,11 +40,12 @@ describe('graphCalculatorHelper', () => {
   });
 
   it('can calculate second highlighting node path', () => {
-    const pathRelatedToSecondHighlightingNode = calculatePathRelatedToSecondHighlightingNode(
-      testGraph1.testClickNode,
-      testGraph1.testSecondClickNodeID,
-      testGraph1.graphNodes
-    );
+    const pathRelatedToSecondHighlightingNode =
+      calculatePathRelatedToSecondHighlightingNode(
+        testGraph1.testClickNode,
+        testGraph1.testSecondClickNodeID,
+        testGraph1.graphNodes
+      );
     expect(pathRelatedToSecondHighlightingNode).toEqual(
       testGraph1.expectedSecondHighlightedPath
     );

--- a/src/DataDictionary/graph/GraphCalculator/index.js
+++ b/src/DataDictionary/graph/GraphCalculator/index.js
@@ -32,7 +32,7 @@ const ReduxGraphCalculator = (() => {
     /** @param {DdgraphState['legendItems']} legendItems */
     onGraphLegendCalculated: (legendItems) =>
       dispatch(setGraphLegend(legendItems)),
-    /** @param {DdgraphState['relatedNodeIDs']} legendItems */
+    /** @param {DdgraphState['relatedNodeIDs']} relatedNodeIDs */
     onHighlightRelatedNodesCalculated: (relatedNodeIDs) =>
       dispatch(setRelatedNodeIDs(relatedNodeIDs)),
     /** @param {DdgraphState['secondHighlightingNodeCandidateIDs']} secondHighlightingNodeCandidateIDs */

--- a/src/DataDictionary/graph/GraphCalculator/index.js
+++ b/src/DataDictionary/graph/GraphCalculator/index.js
@@ -8,16 +8,32 @@ import {
   setPathRelatedToSecondHighlightingNode,
   setDataModelStructure,
 } from '../../action';
+import { calculateGraphLayout, getAllTypes } from './graphCalculatorHelper';
 
 /** @typedef {import('../../types').DdgraphState} DdgraphState */
 /** @typedef {import('../../types').GraphLayout} GraphLayout */
 /** @typedef {import('../../../Submission/types').SubmissionState} SubmissionState */
 
+function initializeLayout() {
+  /**
+   * @param {import('redux').Dispatch} dispatch
+   * @param {() => { ddgraph: DdgraphState; submission: SubmissionState }} getState
+   */
+  return (dispatch, getState) => {
+    const {
+      submission: { dictionary },
+      ddgraph: { graphvizLayout },
+    } = getState();
+    const graphLayout = calculateGraphLayout(dictionary, graphvizLayout);
+    dispatch(setGraphLayout(graphLayout));
+    const legendItems = getAllTypes(graphLayout.nodes);
+    dispatch(setGraphLegend(legendItems));
+  };
+}
+
 const ReduxGraphCalculator = (() => {
-  /** @param {{ ddgraph: DdgraphState; submission: SubmissionState }} state */
+  /** @param {{ ddgraph: DdgraphState }} state */
   const mapStateToProps = (state) => ({
-    dictionary: state.submission.dictionary,
-    graphvizLayout: state.ddgraph.graphvizLayout,
     highlightingNode: state.ddgraph.highlightingNode,
     nodes: state.ddgraph.nodes,
     edges: state.ddgraph.edges,
@@ -25,13 +41,9 @@ const ReduxGraphCalculator = (() => {
     layoutInitialized: state.ddgraph.layoutInitialized,
   });
 
-  /** @param {import('redux').Dispatch} dispatch */
+  /** @param {import('redux-thunk').ThunkDispatch} dispatch */
   const mapDispatchToProps = (dispatch) => ({
-    /** @param {GraphLayout} layout */
-    onGraphLayoutCalculated: (layout) => dispatch(setGraphLayout(layout)),
-    /** @param {DdgraphState['legendItems']} legendItems */
-    onGraphLegendCalculated: (legendItems) =>
-      dispatch(setGraphLegend(legendItems)),
+    initializeLayout: () => dispatch(initializeLayout()),
     /** @param {DdgraphState['relatedNodeIDs']} relatedNodeIDs */
     onHighlightRelatedNodesCalculated: (relatedNodeIDs) =>
       dispatch(setRelatedNodeIDs(relatedNodeIDs)),

--- a/src/DataDictionary/graph/GraphCalculator/index.js
+++ b/src/DataDictionary/graph/GraphCalculator/index.js
@@ -17,6 +17,7 @@ const ReduxGraphCalculator = (() => {
   /** @param {{ ddgraph: DdgraphState; submission: SubmissionState }} state */
   const mapStateToProps = (state) => ({
     dictionary: state.submission.dictionary,
+    graphvizLayout: state.ddgraph.graphvizLayout,
     highlightingNode: state.ddgraph.highlightingNode,
     nodes: state.ddgraph.nodes,
     edges: state.ddgraph.edges,

--- a/src/DataDictionary/reducers.js
+++ b/src/DataDictionary/reducers.js
@@ -13,6 +13,7 @@ const ddgraphInitialState = {
   nodes: [],
   edges: [],
   graphBoundingBox: [],
+  graphvizLayout: null,
   legendItems: [],
   hoveringNode: null,
   highlightingNode: null,
@@ -39,6 +40,12 @@ const ddgraphInitialState = {
 /** @type {import('redux').Reducer<DdgraphState>} */
 const ddgraph = (state = ddgraphInitialState, action) => {
   switch (action.type) {
+    case 'RECEIVE_GRAPHVIZ_LAYOUT': {
+      return {
+        ...state,
+        graphvizLayout: action.data,
+      };
+    }
     case 'TOGGLE_GRAPH_TABLE_VIEW': {
       return {
         ...state,

--- a/src/DataDictionary/types.d.ts
+++ b/src/DataDictionary/types.d.ts
@@ -49,6 +49,29 @@ export type GraphLayout = {
   graphBoundingBox: GraphBoundingBox;
 };
 
+export type GraphvizLayout = {
+  _draw_: { p: string; points?: [number, number] }[];
+  edges: {
+    _draw_: { points: [number, number] }[];
+    head: number;
+    tail: number;
+  }[];
+  objects: (
+    | {
+        _draw_: { points: [number, number] }[];
+        _gvid: number;
+        label: string;
+        name: string;
+        type: string;
+      }
+    | {
+        _gvid: number;
+        name: string;
+        rank: string;
+      }
+  )[];
+};
+
 export type SearchItemProperty = {
   description: string;
   name: string;
@@ -93,6 +116,7 @@ export type DdgraphState = {
   edges: GraphEdge[];
   graphBoundingBox: GraphBoundingBox;
   graphNodesSVGElements: { [x: string]: SVGSVGElement };
+  graphvizLayout: GraphvizLayout;
   highlightingMatchedNodeID: GraphNode['id'];
   highlightingMatchedNodeOpened: boolean;
   highlightingNode: GraphNode;

--- a/src/DataDictionary/types.d.ts
+++ b/src/DataDictionary/types.d.ts
@@ -50,7 +50,7 @@ export type GraphLayout = {
 };
 
 export type GraphvizLayout = {
-  _draw_: { p: string; points?: [number, number] }[];
+  _draw_: { op: string; points?: [number, number][] }[];
   edges: {
     _draw_: { points: [number, number] }[];
     head: number;

--- a/src/GraphUtils/testData.js
+++ b/src/GraphUtils/testData.js
@@ -1,3 +1,12 @@
+import { graphviz } from '@hpcc-js/wasm';
+import { createDotStringFromDictionary } from '../../data/graphvizLayoutHelper';
+
+function getGraphvizLayout(dictionary) {
+  return graphviz
+    .layout(createDotStringFromDictionary(dictionary), 'json', 'dot')
+    .then((json) => JSON.parse(json));
+}
+
 /**
  * Little helper for building test data
  */
@@ -102,6 +111,7 @@ export const buildTestData = () => {
   const expectedTree = [['project'], ['b'], ['c', 'x', 'y'], ['d', 'a']];
   return {
     dictionary,
+    getGraphvizLayout,
     nodes,
     edges: edges.concat(expectedSubgoupLinks),
     countsSearch: nodeCounts,

--- a/src/actions.js
+++ b/src/actions.js
@@ -21,6 +21,7 @@ import { asyncSetInterval } from './utils';
 /** @typedef {import('./types').UserAccessState} UserAccessState */
 /** @typedef {import('./types').PopupState} PopupState */
 /** @typedef {import('./types').ProjectState} ProjectState */
+/** @typedef {import('./DataDictionary/types').DdgraphState} DdgraphState */
 /** @typedef {import('./GraphQLEditor/types').GraphiqlState} GraphiqlState */
 /** @typedef {import('./Submission/types').SubmissionState} SubmissionState */
 
@@ -374,6 +375,19 @@ export const fetchDictionary =
       : fetch('/data/dictionary.json')
           .then((response) => response.json())
           .then((data) => dispatch({ type: 'RECEIVE_DICTIONARY', data }));
+
+export const fetchGraphvizLayout =
+  () =>
+  /**
+   * @param {import('redux').Dispatch} dispatch
+   * @param {() => { ddgraph: DdgraphState }} getState
+   */
+  (dispatch, getState) =>
+    getState().ddgraph.graphvizLayout
+      ? Promise.resolve()
+      : fetch('/data/graphvizLayout.json')
+          .then((response) => response.json())
+          .then((data) => dispatch({ type: 'RECEIVE_GRAPHVIZ_LAYOUT', data }));
 
 export const fetchVersionInfo = () => (/** @type {Dispatch} */ dispatch) =>
   fetchWithCreds({


### PR DESCRIPTION
Ticket: [PEDS-681](https://pcdc.atlassian.net/browse/PEDS-681)
 
This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/347, which moved creating graphviz layout from runtime to build time. The PR goes a step further to preload graphviz layout when navigating to the data dictionary page, in order to avoid the waterfall and start calculating/initializing the graph layout faster:

_Without preloading:_
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/157521669-936dfad2-f046-444c-8f66-e5c39532aa2c.png">

_With preloading:_
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/157521696-ac20d230-86b4-428c-93eb-37362d56df44.png">

In doing so, the PR also refactors `<GraphCalculator>` to use a single callback to initialize graph layer, instead of multiple props and callbacks. 
