### PR TITLE
 Patch release 1.3.2 PEDS-685

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.5",

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -187,10 +187,11 @@ export function createFilterInfo(filterConfig, fieldMapping = []) {
 }
 
 /** @param {SurvivalAnalysisConfig} config */
-export function isSurvivalAnalysisEnabled({ result }) {
-  if (result !== undefined)
+export function isSurvivalAnalysisEnabled(config) {
+  if (config?.result !== undefined)
     for (const option of ['risktable', 'survival'])
-      if (result[option] !== undefined && result[option]) return true;
+      if (config.result[option] !== undefined && config.result[option])
+        return true;
 
   return false;
 }

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -190,7 +190,7 @@ export function createFilterInfo(filterConfig, fieldMapping = []) {
 export function isSurvivalAnalysisEnabled({ result }) {
   if (result !== undefined)
     for (const option of ['risktable', 'survival'])
-      if (result[option] !== undefined) return true;
+      if (result[option] !== undefined && result[option]) return true;
 
   return false;
 }

--- a/src/GuppyDataExplorer/utils.test.js
+++ b/src/GuppyDataExplorer/utils.test.js
@@ -2,6 +2,7 @@ import {
   calculateDropdownButtonConfigs,
   createFilterInfo,
   humanizeNumber,
+  isSurvivalAnalysisEnabled,
 } from './utils';
 
 describe('utils for data visualization explorer', () => {
@@ -92,5 +93,34 @@ describe('utils for data visualization explorer', () => {
     expect(humanizeNumber(1200000000, 1)).toBe('1.2B');
     expect(humanizeNumber(1200000000000, 1)).toBe('1.2T');
     expect(humanizeNumber(1200000000000000, 1)).toBe('1.2Qa');
+  });
+
+  it('checks whether survival analysis is enabled', () => {
+    // not enabled
+    let falsyConfig;
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+    falsyConfig = {};
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+    falsyConfig = { result: {} };
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+    falsyConfig = { result: { survival: false } };
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+    falsyConfig = { result: { risktable: false } };
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+    falsyConfig = { result: { survival: false, risktable: false } };
+    expect(isSurvivalAnalysisEnabled(falsyConfig)).toBe(false);
+
+    // enabled
+    let truthyConfig;
+    truthyConfig = { result: { survival: true } };
+    expect(isSurvivalAnalysisEnabled(truthyConfig)).toBe(true);
+    truthyConfig = { result: { risktable: true } };
+    expect(isSurvivalAnalysisEnabled(truthyConfig)).toBe(true);
+    truthyConfig = { result: { survival: true, risktable: false } };
+    expect(isSurvivalAnalysisEnabled(truthyConfig)).toBe(true);
+    truthyConfig = { result: { survival: false, risktable: true } };
+    expect(isSurvivalAnalysisEnabled(truthyConfig)).toBe(true);
+    truthyConfig = { result: { survival: true, risktable: true } };
+    expect(isSurvivalAnalysisEnabled(truthyConfig)).toBe(true);
   });
 });


### PR DESCRIPTION
Ticket: [PEDS-685](https://pcdc.atlassian.net/browse/PEDS-685)

This PR bumps the project version to 1.3.2.

The PR includes the fix for incorrect logic to check if survival analysis is enabled based on related config.

This bug was caused by an erroneous refactoring attempt to check whether survival analysis is enabled once at `ExplorerConfigContext` rather than repeatedly executing the check on each re-render. (21cbfd1b0b4454adaa0eb82f6ee02ec94ec236b0 and 6984bec80b2035395855b2f97a1d3dad76afbd51). In addition to the fix, this PR also includes tests to make sure `isSurvivalAnalysisEnabled()` correctly handles all cases.