### PR TITLE
Patch release 1.3.3 PEDS-686

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.5",

--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -9,6 +9,8 @@ import ReduxGraphCalculator from './graph/GraphCalculator';
 import ReduxDictionarySearcher from './search/DictionarySearcher';
 import ReduxDictionarySearchHistory from './search/DictionarySearchHistory';
 import './DataDictionary.css';
+import Button from '../gen3-ui-component/components/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 /**
  * @param {Object} props
@@ -27,6 +29,7 @@ function DataDictionary({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const isInitialRenderRef = useRef(true);
+  const graphCalculatorRef = useRef(null);
   useEffect(() => {
     if (isInitialRenderRef.current) {
       isInitialRenderRef.current = false;
@@ -122,12 +125,30 @@ function DataDictionary({
             isGraphView ? '' : 'data-dictionary__graph--hidden'
           }`}
         >
-          <ReduxGraphCalculator />
-          {isGraphView && layoutInitialized && (
-            <DataDictionaryGraph
-              onClearSearchResult={handleClearSearchResult}
-            />
-          )}
+          <ReduxGraphCalculator ref={graphCalculatorRef} />
+          {isGraphView &&
+            (layoutInitialized ? (
+              <DataDictionaryGraph
+                onClearSearchResult={handleClearSearchResult}
+              />
+            ) : (
+              <div style={{ margin: '1rem', textAlign: 'center' }}>
+                <h2 style={{ marginBottom: '1rem' }}>
+                  {' '}
+                  <FontAwesomeIcon
+                    icon='exclamation-triangle'
+                    color='var(--g3-color__highlight-orange)'
+                    size='sm'
+                  />{' '}
+                  Error in drawing the Data Dictionary graph...
+                </h2>
+                <Button
+                  buttonType='primary'
+                  label='Redraw graph'
+                  onClick={() => graphCalculatorRef.current.calculateLayout()}
+                />
+              </div>
+            ))}
         </div>
         <div
           className={`data-dictionary__table ${

--- a/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
+++ b/src/DataDictionary/graph/GraphCalculator/GraphCalculator.jsx
@@ -16,17 +16,7 @@ class GraphCalculator extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.layoutInitialized) {
-      calculateGraphLayout(
-        this.props.dictionary,
-        this.props.countsSearch,
-        this.props.linksSearch
-      ).then((layoutResult) => {
-        this.props.onGraphLayoutCalculated(layoutResult);
-        const legendItems = getAllTypes(layoutResult.nodes);
-        this.props.onGraphLegendCalculated(legendItems);
-      });
-    }
+    if (!this.props.layoutInitialized) this.calculateLayout();
   }
 
   // eslint-disable-next-line camelcase
@@ -153,6 +143,18 @@ class GraphCalculator extends Component {
       dataModelStructureRelatedNodeIDs: subgraphNodeIDs,
       routesBetweenStartEndNodes,
     };
+  }
+
+  calculateLayout() {
+    calculateGraphLayout(
+      this.props.dictionary,
+      this.props.countsSearch,
+      this.props.linksSearch
+    ).then((layoutResult) => {
+      this.props.onGraphLayoutCalculated(layoutResult);
+      const legendItems = getAllTypes(layoutResult.nodes);
+      this.props.onGraphLegendCalculated(legendItems);
+    });
   }
 
   render() {

--- a/src/DataDictionary/graph/GraphCalculator/index.js
+++ b/src/DataDictionary/graph/GraphCalculator/index.js
@@ -73,7 +73,9 @@ const ReduxGraphCalculator = (() => {
       ),
   });
 
-  return connect(mapStateToProps, mapDispatchToProps)(GraphCalculator);
+  return connect(mapStateToProps, mapDispatchToProps, null, {
+    forwardRef: true,
+  })(GraphCalculator);
 })();
 
 export default ReduxGraphCalculator;


### PR DESCRIPTION
Ticket: [PEDS-686](https://pcdc.atlassian.net/browse/PEDS-686)

This PR bumps the project version to 1.3.3.

The PR includes the fix for unsuccessful calculation of graph layout when cached bundles are served.

More specifically, the bug is seemingly due to the race condition between fetching/evaluating component bundles vs fetching `dictionary.json`. When `<GraphCalculator>` is served from cache and mounts before `dictionary.json` is ready, the component still proceeds and fails to initialize graph layout.

The fix is a temporary workaround that displays a simple button to retry calculating/initializing layout:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/158621193-565b5144-0c20-4c43-8082-7f8aa83fa75c.png">

It's probably not a problem in the existing `pcdc_dev` branch where a lot has changed for preparing layout since `1.3.0` release.