### PR TITLE
Fix unhandled missing resources on /DD page PEDS-686

### DIFF
--- a/src/DataDictionary/graph/GraphCalculator/index.js
+++ b/src/DataDictionary/graph/GraphCalculator/index.js
@@ -20,14 +20,31 @@ function initializeLayout() {
    * @param {() => { ddgraph: DdgraphState; submission: SubmissionState }} getState
    */
   return (dispatch, getState) => {
-    const {
-      submission: { dictionary },
-      ddgraph: { graphvizLayout },
-    } = getState();
-    const graphLayout = calculateGraphLayout(dictionary, graphvizLayout);
-    dispatch(setGraphLayout(graphLayout));
-    const legendItems = getAllTypes(graphLayout.nodes);
-    dispatch(setGraphLegend(legendItems));
+    function loadResources() {
+      const { ddgraph, submission } = getState();
+      const { graphvizLayout } = ddgraph;
+      const { dictionary } = submission;
+      const isLoaded = dictionary !== undefined && graphvizLayout !== undefined;
+      return { dictionary, graphvizLayout, isLoaded };
+    }
+
+    /**
+     * @param {SubmissionState['dictionary']} dictionary
+     * @param {DdgraphState['graphvizLayout']} graphvizLayout
+     * @param {number} interval
+     */
+    function init(dictionary, graphvizLayout, interval) {
+      window.clearInterval(interval);
+      const graphLayout = calculateGraphLayout(dictionary, graphvizLayout);
+      dispatch(setGraphLayout(graphLayout));
+      const legendItems = getAllTypes(graphLayout.nodes);
+      dispatch(setGraphLegend(legendItems));
+    }
+
+    const interval = window.setInterval(() => {
+      const { dictionary, graphvizLayout, isLoaded } = loadResources();
+      if (isLoaded) init(dictionary, graphvizLayout, interval);
+    }, 100);
   };
 }
 

--- a/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.jsx
+++ b/src/DataDictionary/search/DictionarySearcher/DictionarySearcher.jsx
@@ -37,6 +37,11 @@ class DictionarySearcher extends Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.searchData.length === 0)
+      this.searchData = prepareSearchData(this.props.dictionary);
+  }
+
   onClearResult = () => {
     this.resetSearchResult();
     this.autoCompleteRef.current.clearInput();

--- a/src/DataDictionary/search/DictionarySearcher/index.js
+++ b/src/DataDictionary/search/DictionarySearcher/index.js
@@ -17,7 +17,7 @@ import DictionarySearcher from './DictionarySearcher';
 const ReduxDictionarySearcher = (() => {
   /** @param {{ ddgraph: DdgraphState; submission: SubmissionState }} state */
   const mapStateToProps = (state) => ({
-    dictionary: state.submission.dictionary,
+    dictionary: state.submission.dictionary ?? {},
     currentSearchKeyword: state.ddgraph.currentSearchKeyword,
   });
 


### PR DESCRIPTION
Ticket: [PEDS-686](https://pcdc.atlassian.net/browse/PEDS-686)

This PR implements handling missing resources on the /DD page (`dictionary.json`, `graphvizLayout.json`). This is seemingly due to the race condition between fetching/evaluating component bundles vs fetching resources (related: https://github.com/chicagopcdc/data-portal/pull/352).

The PR implements fix for `<GraphCalculator>` and `<DictionarySearcher>` components:
* `initializeLayout()` callback for `<GraphCalculator>` now checks if resources are loaded and retries until they are loaded.
*  `<DictionarySearcher>` now retries to set `this.searchData` if it's an empty array (shouldn't be the case if using `dictionary.json` data