### PR TITLE
Create data requests page PEDS-643

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import useSessionMonitor from './hooks/useSessionMonitor';
 
 // lazy-loaded pages
 const DataDictionary = lazy(() => import('./DataDictionary'));
+const DataRequests = lazy(() => import('./DataRequests'));
 const Explorer = lazy(() => import('./GuppyDataExplorer'));
 const GraphQLQuery = lazy(() => import('./GraphQLEditor/ReduxGqlEditor'));
 const IndexPage = lazy(() => import('./Index/page'));
@@ -168,6 +169,14 @@ function App() {
             }
           />
         )}
+        <Route
+          path='requests'
+          element={
+            <ProtectedContent>
+              <DataRequests />
+            </ProtectedContent>
+          }
+        />
         <Route path='*' element={<Navigate to='' replace />} />
         {/* <Route
           path='/indexing'

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -1,0 +1,22 @@
+.data-requests {
+  margin: 20px;
+}
+
+.data-requests__header {
+  margin-bottom: 20px;
+}
+
+.data-requests__header > h1 {
+  font-size: 24px;
+  letter-spacing: 0.02rem;
+  line-height: 80px;
+  color: inherit;
+}
+
+.data-requests__status-approved {
+  color: var(--pcdc-color__primary);
+}
+
+.data-requests__status-rejected {
+  color: var(--g3-color__rose);
+}

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -20,3 +20,9 @@
 .data-requests__status-rejected {
   color: var(--g3-color__rose);
 }
+
+.data-requests main h2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -21,8 +21,16 @@
   color: var(--g3-color__rose);
 }
 
-.data-requests main h2 {
+.data-requests__table > h2 {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.data-requests__error {
+  text-align: center;
+}
+
+.data-requests__error > h2 {
+  display: block !important;
 }

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Spinner from '../components/Spinner';
 import Table from '../components/tables/base/Table';
 import Button from '../gen3-ui-component/components/Button';
@@ -34,7 +35,7 @@ function fetchProjects() {
  */
 function parseTableData(projects, showApprovedOnly) {
   return projects
-    .filter((project) => !showApprovedOnly || project.status === 'Approved')
+    ?.filter((project) => !showApprovedOnly || project.status === 'Approved')
     .map((project) => [
       project.id,
       project.name,
@@ -78,6 +79,7 @@ export default function DataRequests() {
     setIsLoading(true);
     fetchProjects()
       .then(setProjects)
+      .catch(() => setProjects(null))
       .finally(() => setIsLoading(false));
   }, []);
 
@@ -87,17 +89,35 @@ export default function DataRequests() {
         <h1>Data Requests</h1>
       </header>
       <main>
-        <h2>
-          List of My Requests
-          <Button
-            label={showApprovedOnly ? 'Show All' : 'Show Approved Only'}
-            onClick={() => setShowApprovedOnly((s) => !s)}
-          />
-        </h2>
-        {isLoading ? (
-          <Spinner />
+        {Array.isArray(tableData) ? (
+          <div className='data-requests__table'>
+            <h2>
+              List of My Requests
+              <Button
+                label={showApprovedOnly ? 'Show All' : 'Show Approved Only'}
+                onClick={() => setShowApprovedOnly((s) => !s)}
+              />
+            </h2>
+            {isLoading ? (
+              <Spinner />
+            ) : (
+              <Table header={tableHeader} data={tableData} />
+            )}
+          </div>
         ) : (
-          <Table header={tableHeader} data={tableData} />
+          <div className='data-requests__error'>
+            <h2>
+              <FontAwesomeIcon
+                icon='exclamation-triangle'
+                color='var(--g3-primary-btn__bg-color'
+              />{' '}
+              Error in fetching your projects...
+            </h2>
+            <p>
+              Please retry or refreshing the page. If the problem persists,
+              please contact administrator for more information.
+            </p>
+          </div>
         )}
       </main>
     </div>

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -69,7 +69,7 @@ function parseTableData(/** @type {DataRequestProject[]} */ projects) {
       buttonType='primary'
       enabled={project.status === 'APPROVED'}
       onClick={() =>
-        fetch(`amanuensis/downlod-links/${project.id}`)
+        fetch(`/amanuensis/download-urls/${project.id}`)
           .then((res) => res.json())
           .then((data) =>
             window.open(data.download_url, '_blank', 'noopener, noreferrer')

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -82,19 +82,14 @@ export default function DataRequests() {
         <h1>Data Requests</h1>
       </header>
       <main>
-        <Table
-          title={
-            <>
-              List of My Requests
-              <Button
-                label={showApprovedOnly ? 'Show All' : 'Show Approved Only'}
-                onClick={() => setShowApprovedOnly((s) => !s)}
-              />
-            </>
-          }
-          header={tableHeader}
-          data={tableData}
-        />
+        <h2>
+          List of My Requests
+          <Button
+            label={showApprovedOnly ? 'Show All' : 'Show Approved Only'}
+            onClick={() => setShowApprovedOnly((s) => !s)}
+          />
+        </h2>
+        <Table header={tableHeader} data={tableData} />
       </main>
     </div>
   );

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -17,7 +17,7 @@ const tableHeader = [
  * @typedef {Object} DataRequestProject
  * @property {number} id
  * @property {string} name
- * @property {'APPROVED' | 'REJECTED' | 'IN REVIEW'} status
+ * @property {'Approved' | 'Rejected' | 'In Review'} status
  * @property {string | null} submitted_at timestamp
  * @property {string | null} completed_at timestamp
  */
@@ -33,7 +33,7 @@ function fetchProjects() {
  */
 function parseTableData(projects, showApprovedOnly) {
   return projects
-    .filter((project) => !showApprovedOnly || project.status === 'APPROVED')
+    .filter((project) => !showApprovedOnly || project.status === 'Approved')
     .map((project) => [
       project.id,
       project.name,
@@ -48,7 +48,7 @@ function parseTableData(projects, showApprovedOnly) {
       </span>,
       <Button
         buttonType='primary'
-        enabled={project.status === 'APPROVED'}
+        enabled={project.status === 'Approved'}
         onClick={() =>
           fetch(`/amanuensis/download-urls/${project.id}`)
             .then((res) => res.json())

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import Spinner from '../components/Spinner';
 import Table from '../components/tables/base/Table';
 import Button from '../gen3-ui-component/components/Button';
 import { formatLocalTime } from '../utils';
@@ -66,6 +67,7 @@ function parseTableData(projects, showApprovedOnly) {
 const emptyProjects = [];
 
 export default function DataRequests() {
+  const [isLoading, setIsLoading] = useState(false);
   const [projects, setProjects] = useState(emptyProjects);
   const [showApprovedOnly, setShowApprovedOnly] = useState(false);
   const tableData = useMemo(
@@ -73,7 +75,10 @@ export default function DataRequests() {
     [projects, showApprovedOnly]
   );
   useEffect(() => {
-    fetchProjects().then(setProjects);
+    setIsLoading(true);
+    fetchProjects()
+      .then(setProjects)
+      .finally(() => setIsLoading(false));
   }, []);
 
   return (
@@ -89,7 +94,11 @@ export default function DataRequests() {
             onClick={() => setShowApprovedOnly((s) => !s)}
           />
         </h2>
-        <Table header={tableHeader} data={tableData} />
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <Table header={tableHeader} data={tableData} />
+        )}
       </main>
     </div>
   );

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import Table from '../components/tables/base/Table';
+import Button from '../gen3-ui-component/components/Button';
+import { capitalizeFirstLetter, formatLocalTime } from '../utils';
+import './DataRequests.css';
+
+const tableHeader = [
+  'ID',
+  'Research Title',
+  'Submitted Date',
+  'Completed Date',
+  'Status',
+  '',
+];
+
+/**
+ * @typedef {Object} DataRequestProject
+ * @property {number} id
+ * @property {string} name
+ * @property {'APPROVED' | 'REJECTED' | 'IN REVIEW'} status
+ * @property {string | null} submitted_at timestamp
+ * @property {string | null} completed_at timestamp
+ */
+
+/** @returns {Promise<DataRequestProject[]>} */
+function fetchProjects() {
+  return fetch('/amanuensis/projects').then((res) => res.json());
+}
+
+function parseTableData(/** @type {DataRequestProject[]} */ projects) {
+  return projects.map((project) => [
+    project.id,
+    project.name,
+    formatLocalTime(project.submitted_at),
+    formatLocalTime(project.completed_at),
+    <span
+      className={`data-requests__status-${project.status
+        .toLowerCase()
+        .replaceAll(' ', '-')}`}
+    >
+      {capitalizeFirstLetter(project.status)}
+    </span>,
+    <Button
+      buttonType='primary'
+      enabled={project.status === 'APPROVED'}
+      onClick={() =>
+        fetch(`amanuensis/downlod-links/${project.id}`)
+          .then((res) => res.json())
+          .then((data) =>
+            window.open(data.download_url, '_blank', 'noopener, noreferrer')
+          )
+      }
+      label='Download Data'
+      rightIcon='download'
+    />,
+  ]);
+}
+
+/** @type {(string | number | JSX.Element)[][]} */
+const emptyTableData = [];
+export default function DataRequests() {
+  const [tableData, setTableData] = useState(emptyTableData);
+  useEffect(() => {
+    fetchProjects().then((data) => setTableData(parseTableData(data)));
+  }, []);
+
+  return (
+    <div className='data-requests'>
+      <header className='data-requests__header'>
+        <h1>Data Requests</h1>
+      </header>
+      <main>
+        <Table
+          title='List of My Requests'
+          header={tableHeader}
+          data={tableData}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -22,31 +22,6 @@ const tableHeader = [
  * @property {string | null} completed_at timestamp
  */
 
-/** @type {DataRequestProject[]} */
-const mockProjects = [
-  {
-    id: 0,
-    name: 'Foo',
-    status: 'APPROVED',
-    submitted_at: new Date().toISOString(),
-    completed_at: new Date().toISOString(),
-  },
-  {
-    id: 1,
-    name: 'Bar',
-    status: 'REJECTED',
-    submitted_at: new Date().toISOString(),
-    completed_at: new Date().toISOString(),
-  },
-  {
-    id: 2,
-    name: 'Baz',
-    status: 'IN REVIEW',
-    submitted_at: new Date().toISOString(),
-    completed_at: null,
-  },
-];
-
 /** @returns {Promise<DataRequestProject[]>} */
 function fetchProjects() {
   return fetch('/amanuensis/projects').then((res) => res.json());
@@ -98,7 +73,7 @@ export default function DataRequests() {
     [projects, showApprovedOnly]
   );
   useEffect(() => {
-    fetchProjects().then((data) => setProjects([...data, ...mockProjects]));
+    fetchProjects().then(setProjects);
   }, []);
 
   return (

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Table from '../components/tables/base/Table';
 import Button from '../gen3-ui-component/components/Button';
-import { capitalizeFirstLetter, formatLocalTime } from '../utils';
+import { formatLocalTime } from '../utils';
 import './DataRequests.css';
 
 const tableHeader = [
@@ -44,7 +44,7 @@ function parseTableData(projects, showApprovedOnly) {
           .toLowerCase()
           .replaceAll(' ', '-')}`}
       >
-        {capitalizeFirstLetter(project.status)}
+        {project.status}
       </span>,
       <Button
         buttonType='primary'

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Table from '../components/tables/base/Table';
 import Button from '../gen3-ui-component/components/Button';
 import { capitalizeFirstLetter, formatLocalTime } from '../utils';
@@ -81,14 +81,14 @@ function parseTableData(/** @type {DataRequestProject[]} */ projects) {
   ]);
 }
 
-/** @type {(string | number | JSX.Element)[][]} */
-const emptyTableData = [];
+/** @type {DataRequestProject[]} */
+const emptyProjects = [];
+
 export default function DataRequests() {
-  const [tableData, setTableData] = useState(emptyTableData);
+  const [projects, setProjects] = useState(emptyProjects);
+  const tableData = useMemo(() => parseTableData(projects), [projects]);
   useEffect(() => {
-    fetchProjects().then((data) =>
-      setTableData(parseTableData([...data, ...mockProjects]))
-    );
+    fetchProjects().then((data) => setProjects([...data, ...mockProjects]));
   }, []);
 
   return (

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -22,6 +22,31 @@ const tableHeader = [
  * @property {string | null} completed_at timestamp
  */
 
+/** @type {DataRequestProject[]} */
+const mockProjects = [
+  {
+    id: 0,
+    name: 'Foo',
+    status: 'APPROVED',
+    submitted_at: new Date().toISOString(),
+    completed_at: new Date().toISOString(),
+  },
+  {
+    id: 1,
+    name: 'Bar',
+    status: 'REJECTED',
+    submitted_at: new Date().toISOString(),
+    completed_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    name: 'Baz',
+    status: 'IN REVIEW',
+    submitted_at: new Date().toISOString(),
+    completed_at: null,
+  },
+];
+
 /** @returns {Promise<DataRequestProject[]>} */
 function fetchProjects() {
   return fetch('/amanuensis/projects').then((res) => res.json());
@@ -61,7 +86,9 @@ const emptyTableData = [];
 export default function DataRequests() {
   const [tableData, setTableData] = useState(emptyTableData);
   useEffect(() => {
-    fetchProjects().then((data) => setTableData(parseTableData(data)));
+    fetchProjects().then((data) =>
+      setTableData(parseTableData([...data, ...mockProjects]))
+    );
   }, []);
 
   return (

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -32,6 +32,9 @@ function TopBarMenu({ items, onLogoutClick, username }) {
           <li className='top-bar-menu__item'>
             <Link to='/identity'>View Profile</Link>
           </li>
+          <li className='top-bar-menu__item'>
+            <Link to='/requests'>Data Requests</Link>
+          </li>
           {items?.map((item) => (
             <li key={item.link} className='top-bar-menu__item'>
               <a href={item.link} target='_blank' rel='noopener noreferrer'>

--- a/src/components/tables/base/Table.jsx
+++ b/src/components/tables/base/Table.jsx
@@ -26,7 +26,7 @@ function Table({ title, header, data, footer }) {
 }
 
 Table.propTypes = {
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   header: PropTypes.array,
   data: PropTypes.array,
   footer: PropTypes.array,

--- a/src/components/tables/base/Table.jsx
+++ b/src/components/tables/base/Table.jsx
@@ -26,7 +26,7 @@ function Table({ title, header, data, footer }) {
 }
 
 Table.propTypes = {
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  title: PropTypes.string,
   header: PropTypes.array,
   data: PropTypes.array,
   footer: PropTypes.array,


### PR DESCRIPTION
Ticket: [PEDS-643](https://pcdc.atlassian.net/browse/PEDS-643)

This PR creates a new page at `/requests` for data requests based on [this API spec](https://github.com/chicagopcdc/Documents/blob/19cdd0631502ee8e7e67e05dfa66dd443181b1b4/GEN3/project_request/requirements.md
). This page expects `amanuensis` service API endpoints for `/projects` and `/download-urls/:project-id`.

This new page provides UI to view users' data requests and download data for approved requests:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/159368007-6595ea9a-847f-4ff1-a730-e7087b74fcde.png">


The link to access this page is located under user menu on the top bar:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/22449454/159367856-90058993-dfb6-4c07-92ec-51be9c47f6da.png">

