### PR TITLE
Patch release 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.5",

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -94,7 +94,7 @@ function getCellElement({
     return <span title={valueStr}>{humanFileSize(valueStr)}</span>;
 
   if (field === 'external_references.external_links') {
-    if (!value) return null;
+    if (!value?.[0]?.external_links) return null;
     const [resourceName, resourceIconPath, subjectUrl] =
       value[0].external_links.split('|');
     return (


### PR DESCRIPTION
This PR bumps the project version to 1.3.4.

The PR includes the fix for crashing exploration page due to invalid external link value in `<ExplorerTable>`.