### PR TITLE
Fix validateDOMNesting error in explorer table

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTable/Table.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/Table.jsx
@@ -96,15 +96,16 @@ function Table({
             page.map((row, i) => {
               prepareRow(row);
               return (
-                <div className='rt-tr-group' {...row.getRowProps()}>
-                  <tr className={`rt-tr ${i % 2 === 0 ? '-even' : '-odd'}`}>
-                    {row.cells.map((cell) => (
-                      <td {...cell.getCellProps()} className='rt-td'>
-                        {cell.render('Cell')}
-                      </td>
-                    ))}
-                  </tr>
-                </div>
+                <tr
+                  className={`rt-tr ${i % 2 === 0 ? '-even' : '-odd'}`}
+                  {...row.getRowProps()}
+                >
+                  {row.cells.map((cell) => (
+                    <td {...cell.getCellProps()} className='rt-td'>
+                      {cell.render('Cell')}
+                    </td>
+                  ))}
+                </tr>
               );
             })
           ) : (

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -287,12 +287,16 @@ function ExplorerTable({
         defaultPageSize={defaultPageSize}
         NoDataComponent={() =>
           isLocked ? (
-            <div className='rt-noData'>
-              <LockIcon width={30} />
-              <p>You only have access to summary data</p>
-            </div>
+            <tr className='rt-noData'>
+              <td>
+                <LockIcon width={30} />
+                <p>You only have access to summary data</p>
+              </td>
+            </tr>
           ) : (
-            <div className='rt-noData'>No data to display</div>
+            <tr className='rt-noData'>
+              <td>No data to display</td>
+            </tr>
           )
         }
         // SubComponent={isLocked ? null : SubComponent}


### PR DESCRIPTION
This PR fixes `validateDOMNesting` error in `<ExplorerTable>` component. This is caused by mixing table and non-table elements. The fix involves modifying `<NoDataComponent>` elements to use table elements and removing unnecessary element for "tr-group".