### PR TITLE
Use filter display component in forms PEDS-695

### DIFF
--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -7,7 +7,7 @@ import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
 import { fetchWithCreds } from '../../actions';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
-import { stringifyFilters } from '../ExplorerFilterSet/utils';
+import FilterSetFilterDisplay from '../ExplorerFilterSet/FilterSetFilterDisplay';
 import './ExplorerExploreExternalButton.css';
 
 /** @typedef {import('../types').ExplorerFilters} ExplorerFilters */
@@ -82,17 +82,7 @@ function ExplorerExploreExternalButton({ filter }) {
                   />
                 }
               />
-              <SimpleInputField
-                label='Filters'
-                input={
-                  <textarea
-                    id='explore-external-filters'
-                    disabled
-                    placeholder='No filters'
-                    value={stringifyFilters(filter)}
-                  />
-                }
-              />
+              <FilterSetFilterDisplay filters={filter} />
             </form>
             <div>
               <Button

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/ExplorerFilterDisplay.css
@@ -1,15 +1,15 @@
-.explorer-filter-info {
+.explorer-filter-display {
   background-color: var(--g3-color__white);
   padding: 0.5rem 1rem;
   margin: 0.5rem 0;
 }
 
-.explorer-filter-info__collapsed {
+.explorer-filter-display__collapsed {
   max-height: 5.5rem;
   overflow-y: scroll;
 }
 
-.explorer-filter-info > button {
+.explorer-filter-display > button {
   background-color: inherit;
   border: none;
   height: 1rem;
@@ -17,25 +17,25 @@
   margin-right: 0.25rem;
 }
 
-.explorer-filter-info > button:disabled {
+.explorer-filter-display > button:disabled {
   cursor: not-allowed;
 }
 
-.explorer-filter-info > button > i {
+.explorer-filter-display > button > i {
   background-color: var(--g3-color__bg-coal);
 }
 
-.explorer-filter-info__collapse {
+.explorer-filter-display__collapse {
   max-height: 90px;
   overflow-x: scroll;
 }
 
-.explorer-filter-info > h4 {
+.explorer-filter-display > h4 {
   display: inline-block;
   margin-right: 0.25rem;
 }
 
-.explorer-filter-info .pill {
+.filter-display .pill {
   background-color: var(--g3-color__bg-cloud);
   border: 1px solid var(--g3-color__lightgray);
   border-radius: 4px;
@@ -46,26 +46,26 @@
 
 /* Tablet width and less */
 @media screen and (max-width: 820px) {
-  .explorer-filter-info .pill {
+  .filter-display .pill {
     font-size: 12px;
   }
 }
 
-.explorer-filter-info .pill.anchor {
+.filter-display .pill.anchor {
   padding: 8px 4px;
   line-height: 2.2rem;
 }
 
-.explorer-filter-info .pill > * {
+.filter-display .pill > * {
   border-right: 1px solid var(--g3-color__lightgray);
   padding: 2px 4px;
   margin: 0 2px;
 }
 
-.explorer-filter-info .pill > *:last-child {
+.filter-display .pill > *:last-child {
   border-right: none;
 }
 
-.explorer-filter-info .pill code {
+.filter-display .pill code {
   background-color: inherit;
 }

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -2,16 +2,12 @@ import PropTypes from 'prop-types';
 import { useEffect, useRef, useState } from 'react';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
+import { useExplorerConfig } from '../ExplorerConfigContext';
 import './ExplorerFilterDisplay.css';
 
-/**
- * @typedef {Object} FilterDisplayProps
- * @property {import('../types').ExplorerFilters} filter
- * @property {import('../types').FilterConfig['info']} filterInfo
- */
-
-/** @param {FilterDisplayProps} props */
-function FilterDisplay({ filter, filterInfo }) {
+/** @param {{ filter: import('../types').ExplorerFilters }} props */
+function FilterDisplay({ filter }) {
+  const filterInfo = useExplorerConfig().current.filterConfig.info;
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   for (const [key, value] of Object.entries(filter))
     if ('filter' in value) {
@@ -23,7 +19,7 @@ function FilterDisplay({ filter, filterInfo }) {
             <code>{`"${anchorValue}"`}</code>
           </span>
           <span className='token'>
-            ( <FilterDisplay filter={value.filter} filterInfo={filterInfo} /> )
+            ( <FilterDisplay filter={value.filter} /> )
           </span>
         </span>
       );
@@ -81,11 +77,10 @@ function FilterDisplay({ filter, filterInfo }) {
 
 FilterDisplay.propTypes = {
   filter: PropTypes.any,
-  filterInfo: PropTypes.any,
 };
 
-/** @param {FilterDisplayProps} props */
-function ExplorerFilterDisplay({ filter, filterInfo }) {
+/** @param {{ filter: import('../types').ExplorerFilters }} props */
+function ExplorerFilterDisplay({ filter }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const ref = useRef(null);
@@ -117,7 +112,7 @@ function ExplorerFilterDisplay({ filter, filterInfo }) {
             />
           </button>
           <h4>Filters in Use:</h4>
-          <FilterDisplay filter={filter} filterInfo={filterInfo} />
+          <FilterDisplay filter={filter} />
         </>
       ) : (
         <h4>← Try Filters to explore data</h4>

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -64,14 +64,14 @@ function FilterDisplay({ filter }) {
     }
 
   return (
-    <>
+    <span className='filter-display'>
       {filterElements.map((filterElement, i) => (
         <>
           {filterElement}
           {i < filterElements.length - 1 && <span className='pill'>AND</span>}
         </>
       ))}
-    </>
+    </span>
   );
 }
 
@@ -94,8 +94,8 @@ function ExplorerFilterDisplay({ filter }) {
   return (
     <div
       ref={ref}
-      className={`explorer-filter-info ${
-        isCollapsed ? 'explorer-filter-info__collapsed' : ''
+      className={`explorer-filter-display ${
+        isCollapsed ? 'explorer-filter-display__collapsed' : ''
       }`.trim()}
     >
       {Object.keys(filter).length > 0 ? (

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -6,7 +6,7 @@ import { useExplorerConfig } from '../ExplorerConfigContext';
 import './ExplorerFilterDisplay.css';
 
 /** @param {{ filter: import('../types').ExplorerFilters }} props */
-function FilterDisplay({ filter }) {
+export function FilterDisplay({ filter }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   for (const [key, value] of Object.entries(filter))

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
@@ -6,7 +6,7 @@ import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
 import { defaultFilterSet as survivalDefaultFilterSet } from '../ExplorerSurvivalAnalysis/ControlForm';
-import { stringifyFilters } from './utils';
+import FilterSetFilterDisplay from './FilterSetFilterDisplay';
 import './ExplorerFilterSet.css';
 
 /** @typedef {import('./types').ExplorerFilters} ExplorerFilters */
@@ -105,17 +105,7 @@ function FilterSetOpenForm({
             />
           }
         />
-        <SimpleInputField
-          label='Filters'
-          input={
-            <textarea
-              id='open-filter-set-filters'
-              disabled
-              placeholder='No filters'
-              value={stringifyFilters(selected.value.filters)}
-            />
-          }
-        />
+        <FilterSetFilterDisplay filters={selected.value.filters} />
       </form>
       <div>
         <FilterSetButton
@@ -227,17 +217,7 @@ function FilterSetCreateForm({
             />
           }
         />
-        <SimpleInputField
-          label='Filters'
-          input={
-            <textarea
-              id='create-filter-set-filters'
-              disabled
-              placeholder='No filters'
-              value={stringifyFilters(currentFilters)}
-            />
-          }
-        />
+        <FilterSetFilterDisplay filters={currentFilters} />
       </form>
       <div>
         <FilterSetButton
@@ -353,28 +333,11 @@ function FilterSetUpdateForm({
             />
           }
         />
-        <SimpleInputField
-          label='Filters'
-          input={
-            <textarea
-              id='update-filter-set-filters'
-              disabled
-              placeholder='No filters'
-              value={stringifyFilters(filterSet.filters)}
-            />
-          }
-        />
+        <FilterSetFilterDisplay filters={filterSet.filters} />
         {isFiltersChanged && (
-          <SimpleInputField
-            label='Filters (changed)'
-            input={
-              <textarea
-                id='update-filter-set-changed-filters'
-                disabled
-                placeholder='No filters'
-                value={stringifyFilters(currentFilters)}
-              />
-            }
+          <FilterSetFilterDisplay
+            filters={currentFilters}
+            title='Filters (changed)'
           />
         )}
       </form>

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.css
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.css
@@ -1,0 +1,17 @@
+.filter-set-filter-display {
+  margin: 1rem;
+  min-height: 6.5rem;
+}
+
+.filter-set-filter-display header {
+  margin-bottom: 0.25rem;
+}
+
+.filter-set-filter-display main {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 12px;
+  height: 5rem;
+  overflow: scroll;
+  padding: 4px;
+}

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { FilterDisplay } from '../ExplorerFilterDisplay';
+import './FilterSetFilterDisplay.css';
+
+/**
+ * @param {Object} props
+ * @param {import('../types').ExplorerFilters} props.filters
+ * @param {string} [props.title]
+ */
+function FilterSetFilterDisplay({ filters, title = 'Filters' }) {
+  return (
+    <div className='filter-set-filter-display'>
+      {Object.keys(filters).length > 0 ? (
+        <>
+          <header>{title}</header>
+          <main>
+            <FilterDisplay filter={filters} />
+          </main>
+        </>
+      ) : (
+        <header>
+          <em>No Filters</em>
+        </header>
+      )}
+    </div>
+  );
+}
+
+FilterSetFilterDisplay.propTypes = {
+  filters: PropTypes.any,
+  title: PropTypes.string,
+};
+
+export default FilterSetFilterDisplay;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import SimpleInputField from '../../components/SimpleInputField';
-import { stringifyFilters } from '../ExplorerFilterSet/utils';
+import FilterSetFilterDisplay from '../ExplorerFilterSet/FilterSetFilterDisplay';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
 
@@ -62,16 +62,7 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
               />
             }
           />
-          <SimpleInputField
-            label='Filters'
-            input={
-              <textarea
-                disabled
-                placeholder='No filters'
-                value={stringifyFilters(filterSet.filters)}
-              />
-            }
-          />
+          <FilterSetFilterDisplay filters={filterSet.filters} />
         </>
       ) : null}
     </div>

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -276,7 +276,7 @@ function ExplorerVisualization({
         </div>
       </div>
       {explorerView !== 'survival analysis' && (
-        <ExplorerFilterDisplay filter={filter} filterInfo={filterConfig.info} />
+        <ExplorerFilterDisplay filter={filter} />
       )}
       <ViewContainer
         showIf={explorerView === 'summary view'}


### PR DESCRIPTION
Ticket: [PEDS-695](https://pcdc.atlassian.net/browse/PEDS-695)

This PR makes use of `<FilterDisplay>` component to display filters in the following locations:
* `<ExplorerExplorerExternalButton>` form
* `<FilterSetActionForm>` forms for open, create, and update filter sets
* `<FilterSetCard>` form to display selected filter set info in survival analysis

See the following comparison in `<FilterSetCreateForm>`:

_Before:_
<image alt="before" width="450" src="https://user-images.githubusercontent.com/22449454/161129478-fb590d26-2b60-4752-925f-44a5d7654dd1.png" />

_After:_
<img width="450" alt="image" src="https://user-images.githubusercontent.com/22449454/161131196-9beb28da-abf3-429f-815b-41a0514f722f.png">
