### PR TITLE
Fix lost Explorer view state on filter change PEDS-696

### DIFF
--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -131,7 +131,7 @@ export function ExplorerStateProvider({ children }) {
       clearFilters,
       updateFilters: setFilters,
     }),
-    [filters, patientIds]
+    [filters, patientIds, searchParams]
   );
 
   return (


### PR DESCRIPTION
Ticket: [PEDS-696](https://pcdc.atlassian.net/browse/PEDS-696)

This PR fixes the bug where Explorer view state gets lost on filter change. This is caused by the outdated `searchParams` value in the memoized `handleFilterChange()` closure in `<ExplorerStateContext>`, which is then called on filter change. 

The fix involves adding `searchParams` to the `useMemo()` dependency array, which then updates the memoized value on `searchParams` change, thus ensuring that `handleFilterChange()` always uses the current `searchParams` value. As a result, updating `searchParams` on filter change doesn't lose the encoded Explorer `view` state.