### PR TITLE
Add researcher info to requests list table + @ PEDS-693

### DIFF
--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Spinner from '../components/Spinner';
 import Table from '../components/tables/base/Table';
@@ -15,6 +16,8 @@ const tableHeader = [
   'Status',
   '',
 ];
+
+/** @typedef {import('../types').UserState} UserState */
 
 /**
  * @typedef {Object} ResearcherInfo
@@ -49,14 +52,17 @@ function parseResearcherInfo(researcher) {
 /**
  * @param {DataRequestProject[]} projects
  * @param {boolean} showApprovedOnly
+ * @param {UserState['user_id']} userId
  */
-function parseTableData(projects, showApprovedOnly) {
+function parseTableData(projects, showApprovedOnly, userId) {
   return projects
     ?.filter((project) => !showApprovedOnly || project.status === 'Approved')
     .map((project) => [
       project.id,
       project.name,
-      parseResearcherInfo(project.researcher),
+      project.researcher?.id === userId
+        ? 'Me'
+        : parseResearcherInfo(project.researcher),
       formatLocalTime(project.submitted_at),
       formatLocalTime(project.completed_at),
       <span
@@ -86,12 +92,16 @@ function parseTableData(projects, showApprovedOnly) {
 const emptyProjects = [];
 
 export default function DataRequests() {
+  const userId = useSelector(
+    (/** @type {{ user: UserState }} */ state) => state.user.user_id
+  );
+
   const [isLoading, setIsLoading] = useState(false);
   const [projects, setProjects] = useState(emptyProjects);
   const [showApprovedOnly, setShowApprovedOnly] = useState(false);
   const tableData = useMemo(
-    () => parseTableData(projects, showApprovedOnly),
-    [projects, showApprovedOnly]
+    () => parseTableData(projects, showApprovedOnly, userId),
+    [projects, showApprovedOnly, userId]
   );
   useEffect(() => {
     setIsLoading(true);

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -35,6 +35,7 @@ const tableHeader = [
  * @property {string | null} submitted_at timestamp
  * @property {string | null} completed_at timestamp
  * @property {ResearcherInfo} researcher
+ * @property {boolean} has_access
  */
 
 /** @returns {Promise<DataRequestProject[]>} */
@@ -79,7 +80,7 @@ function parseTableData(projects, showApprovedOnly, userId) {
       </span>,
       <Button
         buttonType='primary'
-        enabled={project.status === 'Approved'}
+        enabled={project.status === 'Approved' && project.has_access}
         onClick={() =>
           fetch(`/amanuensis/download-urls/${project.id}`)
             .then((res) => res.json())

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -9,11 +9,20 @@ import './DataRequests.css';
 const tableHeader = [
   'ID',
   'Research Title',
+  'Researcher',
   'Submitted Date',
   'Completed Date',
   'Status',
   '',
 ];
+
+/**
+ * @typedef {Object} ResearcherInfo
+ * @property {number} id
+ * @property {string} first_name
+ * @property {string} last_name
+ * @property {string} institution
+ */
 
 /**
  * @typedef {Object} DataRequestProject
@@ -22,11 +31,19 @@ const tableHeader = [
  * @property {'Approved' | 'Rejected' | 'In Review'} status
  * @property {string | null} submitted_at timestamp
  * @property {string | null} completed_at timestamp
+ * @property {ResearcherInfo} researcher
  */
 
 /** @returns {Promise<DataRequestProject[]>} */
 function fetchProjects() {
   return fetch('/amanuensis/projects').then((res) => res.json());
+}
+
+/** @param {ResearcherInfo} researcher */
+function parseResearcherInfo(researcher) {
+  return researcher
+    ? `${researcher.first_name} ${researcher.last_name} (${researcher.institution})`
+    : '';
 }
 
 /**
@@ -39,6 +56,7 @@ function parseTableData(projects, showApprovedOnly) {
     .map((project) => [
       project.id,
       project.name,
+      parseResearcherInfo(project.researcher),
       formatLocalTime(project.submitted_at),
       formatLocalTime(project.completed_at),
       <span

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -44,9 +44,14 @@ function fetchProjects() {
 
 /** @param {ResearcherInfo} researcher */
 function parseResearcherInfo(researcher) {
-  return researcher
-    ? `${researcher.first_name} ${researcher.last_name} (${researcher.institution})`
-    : '';
+  return researcher ? (
+    <span>
+      {researcher.first_name} {researcher.last_name}
+      <br />({researcher.institution})
+    </span>
+  ) : (
+    ''
+  );
 }
 
 /**

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -78,19 +78,21 @@ function parseTableData(projects, showApprovedOnly, userId) {
       >
         {project.status}
       </span>,
-      <Button
-        buttonType='primary'
-        enabled={project.status === 'Approved' && project.has_access}
-        onClick={() =>
-          fetch(`/amanuensis/download-urls/${project.id}`)
-            .then((res) => res.json())
-            .then((data) =>
-              window.open(data.download_url, '_blank', 'noopener, noreferrer')
-            )
-        }
-        label='Download Data'
-        rightIcon='download'
-      />,
+      project.has_access ? (
+        <Button
+          buttonType='primary'
+          enabled={project.status === 'Approved' && project.has_access}
+          onClick={() =>
+            fetch(`/amanuensis/download-urls/${project.id}`)
+              .then((res) => res.json())
+              .then((data) =>
+                window.open(data.download_url, '_blank', 'noopener, noreferrer')
+              )
+          }
+          label='Download Data'
+          rightIcon='download'
+        />
+      ) : null,
     ]);
 }
 


### PR DESCRIPTION
Ticket: [PEDS-693](https://pcdc.atlassian.net/browse/PEDS-693)

This PR extends requests list table on the data request page to show researcher info and limit download data button for each project only to users with access. Researcher info shows "Me" if the user is the requestor for the given project.

For example, in the following screenshot
* Row 1: Project is approved and user has access to data
* Row 2: Project is rejected and user has access to data (user is also the requestor)
* Row 3: Project is approved and user does not have access to data

![image](https://user-images.githubusercontent.com/22449454/161616291-2f183d8e-7e45-4864-bf81-8f3b05a816db.png)
