### PR TITLE
Fix failing tests before 1.4.0

### DIFF
--- a/src/DataDictionary/graph/GraphDrawer/GraphDrawer.test.jsx
+++ b/src/DataDictionary/graph/GraphDrawer/GraphDrawer.test.jsx
@@ -1,11 +1,19 @@
 import { render, fireEvent } from '@testing-library/react';
+import { graphviz } from '@hpcc-js/wasm';
+import { createDotStringFromDictionary } from '../../../../data/graphvizLayoutHelper';
 import GraphDrawer from './GraphDrawer';
 import { calculateGraphLayout } from '../GraphCalculator/graphCalculatorHelper';
 import { buildTestData } from '../../../GraphUtils/testData';
 
+async function getGraphLayout(dictionary) {
+  const dotString = createDotStringFromDictionary(dictionary);
+  const layout = JSON.parse(await graphviz.layout(dotString, 'json', 'dot'));
+  return calculateGraphLayout(dictionary, layout);
+}
+
 test('renders nodes and edges in graph', async () => {
   const { dictionary } = buildTestData();
-  const layout = await calculateGraphLayout(dictionary);
+  const layout = await getGraphLayout(dictionary);
   const props = {
     nodes: layout.nodes,
     edges: layout.edges,
@@ -26,7 +34,7 @@ test('renders nodes and edges in graph', async () => {
 
 test('hovers and clicks nodes, and updates svg element', async () => {
   const { dictionary } = buildTestData();
-  const layout = await calculateGraphLayout(dictionary);
+  const layout = await getGraphLayout(dictionary);
 
   const onHoverNode = jest.fn();
   const onCancelHoverNode = jest.fn();

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -193,7 +193,7 @@ describe('Get GQL filter from filter object from', () => {
 
 describe('Get query info objects for aggregation options data', () => {
   const anchorConfig = {
-    fieldName: 'a',
+    field: 'a',
     tabs: ['t1'],
     options: ['a0', 'a1'],
   };

--- a/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.test.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.test.jsx
@@ -12,6 +12,7 @@ const tableConfig = {
   fields: ['foo', 'bar', 'fizz.buzz'],
   linkFields: ['bar'],
   ordered: false,
+  filterInfo: {},
 };
 const rawData = [
   { foo: 0, bar: 'a', fizz: { buzz: true } },

--- a/src/Login/Login.test.jsx
+++ b/src/Login/Login.test.jsx
@@ -31,6 +31,10 @@ const testProps = {
   data: components.login,
 };
 
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
 test('lists login providers', () => {
   const { container } = render(
     <MemoryRouter>

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -71,6 +71,7 @@ export class SessionMonitor {
         // Allow Fence to log out the user.
         // If we don't refresh, Fence will mark them as inactive.
         this.logoutUser();
+        return;
       }
     }
 

--- a/src/Submission/MapDataModel.test.jsx
+++ b/src/Submission/MapDataModel.test.jsx
@@ -1,3 +1,5 @@
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MapDataModel, {
@@ -5,6 +7,9 @@ import MapDataModel, {
   isValidSubmission,
 } from './MapDataModel';
 import * as testData from './__test__/data.json';
+import reducers from '../reducers';
+
+const testReduxStore = createStore(reducers, {});
 
 const projects = {
   test: { name: 'test', counts: [], charts: [], code: 'test' },
@@ -32,16 +37,18 @@ const dictionary = {
 
 test('renders', () => {
   const { container } = render(
-    <MemoryRouter>
-      <MapDataModel
-        filesToMap={testData.records}
-        projects={projects}
-        dictionary={dictionary}
-        nodeTypes={['aligned_reads_index']}
-        getProjectsList={() => {}}
-        submitFiles={() => {}}
-      />
-    </MemoryRouter>
+    <Provider store={testReduxStore}>
+      <MemoryRouter>
+        <MapDataModel
+          filesToMap={testData.records}
+          projects={projects}
+          dictionary={dictionary}
+          nodeTypes={['aligned_reads_index']}
+          getProjectsList={() => {}}
+          submitFiles={() => {}}
+        />
+      </MemoryRouter>
+    </Provider>
   );
   expect(container.firstElementChild).toHaveClass('map-data-model');
 });

--- a/src/Submission/SubmissionHeader.test.jsx
+++ b/src/Submission/SubmissionHeader.test.jsx
@@ -1,12 +1,15 @@
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import SubmissionHeader from './SubmissionHeader';
 
 test('renders', () => {
   const { container } = render(
-    <SubmissionHeader
-      username='testuser@gmail.com'
-      fetchUnmappedFileStats={() => {}}
-    />
+    <MemoryRouter>
+      <SubmissionHeader
+        username='testuser@gmail.com'
+        fetchUnmappedFileStats={() => {}}
+      />
+    </MemoryRouter>
   );
   expect(container.firstElementChild).toHaveClass('submission-header');
 });

--- a/src/Submission/SubmitTSV.test.jsx
+++ b/src/Submission/SubmitTSV.test.jsx
@@ -1,23 +1,30 @@
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 import * as testData from './__test__/data.json';
+import reducers from '../reducers';
 import SubmitTSV from './SubmitTSV';
 
 const testProjName = 'bogusProject';
+const testReduxStore = createStore(reducers, {});
 
 test('hides the "submit" button when data is not available', () => {
   const { container } = render(
-    <SubmitTSV
-      project={testProjName}
-      submission={{
-        file: '',
-        submit_result: '',
-        submit_status: 200,
-      }}
-      onUploadClick={() => {}}
-      onSubmitClick={() => {}}
-      onFileChange={() => {}}
-      onFinish={() => {}}
-    />
+    <Provider store={testReduxStore}>
+      <SubmitTSV
+        project={testProjName}
+        submission={{
+          file: '',
+          submit_result: '',
+          submit_status: 200,
+          submit_total: 0,
+        }}
+        onUploadClick={() => {}}
+        onSubmitClick={() => {}}
+        onFileChange={() => {}}
+        onFinish={() => {}}
+      />
+    </Provider>
   );
   expect(
     container.querySelector('label[id="cd-submit-tsv__upload-button"]')
@@ -32,18 +39,21 @@ test('hides the "submit" button when data is not available', () => {
 
 test('shows a "submit" button when a tsv or json file has been uploaded', () => {
   const { container } = render(
-    <SubmitTSV
-      project={testProjName}
-      submission={{
-        file: JSON.stringify({ type: 'whatever', submitter_id: 'frickjack' }),
-        submit_result: '',
-        submit_status: 200,
-      }}
-      onUploadClick={() => {}}
-      onSubmitClick={() => {}}
-      onFileChange={() => {}}
-      onFinish={() => {}}
-    />
+    <Provider store={testReduxStore}>
+      <SubmitTSV
+        project={testProjName}
+        submission={{
+          file: JSON.stringify({ type: 'whatever', submitter_id: 'frickjack' }),
+          submit_result: '',
+          submit_status: 200,
+          submit_total: 0,
+        }}
+        onUploadClick={() => {}}
+        onSubmitClick={() => {}}
+        onFileChange={() => {}}
+        onFinish={() => {}}
+      />
+    </Provider>
   );
 
   const submitElement = container.querySelector(
@@ -58,21 +68,26 @@ test('shows a "submit" button when a tsv or json file has been uploaded', () => 
 
 test('shows a submit result when appropriate', () => {
   const { container } = render(
-    <SubmitTSV
-      project={testProjName}
-      submission={{
-        file: JSON.stringify({ type: 'whatever', submitter_id: 'frickjack' }),
-        submit_result: {
-          message: 'submission ok',
-          entities: [{ type: 'frickjack' }],
-        },
-        submit_status: 200,
-      }}
-      onUploadClick={() => {}}
-      onSubmitClick={() => {}}
-      onFileChange={() => {}}
-      onFinish={() => {}}
-    />
+    <Provider store={testReduxStore}>
+      <SubmitTSV
+        project={testProjName}
+        submission={{
+          file: JSON.stringify({ type: 'whatever', submitter_id: 'frickjack' }),
+          submit_counter: 0,
+          submit_result: {
+            message: 'submission ok',
+            entities: [{ type: 'frickjack' }],
+          },
+          submit_result_string: '',
+          submit_status: 200,
+          submit_total: 0,
+        }}
+        onUploadClick={() => {}}
+        onSubmitClick={() => {}}
+        onFileChange={() => {}}
+        onFinish={() => {}}
+      />
+    </Provider>
   );
   expect(
     container.querySelector('label[id="cd-submit-tsv__upload-button"]')
@@ -107,14 +122,22 @@ test('correctly handles utf-8 files, without corrupting multi-byte special chara
   }
 
   const { container } = render(
-    <SubmitTSV
-      project={testProjName}
-      submission={{ file: '', submit_result: '', submit_status: 200 }}
-      onUploadClick={onUploadClick}
-      onSubmitClick={() => {}}
-      onFileChange={() => {}}
-      onFinish={() => {}}
-    />
+    <Provider store={testReduxStore}>
+      <SubmitTSV
+        project={testProjName}
+        submission={{
+          file: '',
+          submit_counter: 0,
+          submit_result: '',
+          submit_status: 200,
+          submit_total: 0,
+        }}
+        onUploadClick={onUploadClick}
+        onSubmitClick={() => {}}
+        onFileChange={() => {}}
+        onFinish={() => {}}
+      />
+    </Provider>
   );
 
   // 1. Find the file upload button and upload our JSON file with non-ascii characters.

--- a/src/components/tables/ProjectTable.test.jsx
+++ b/src/components/tables/ProjectTable.test.jsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import ProjectTable from './ProjectTable';
 
@@ -12,7 +13,9 @@ const summaryFields = ['a', 'b', 'c', 'd'];
 
 test('renders', () => {
   const { container } = render(
-    <ProjectTable projectList={projectList} summaryFields={summaryFields} />
+    <MemoryRouter>
+      <ProjectTable projectList={projectList} summaryFields={summaryFields} />
+    </MemoryRouter>
   );
 
   // summary totals row


### PR DESCRIPTION
This PR fixes failing unit tests in preparation for version 1.4.0. Most of these failures are due to refactoring efforts that didn't change the observable component behaviors rather than actual breakages.

Omitted in this PR is the tests for `<QueryNode>` (`src/QueryNode/QueryNode.test.js`). `<QueryNode>` has undergone significant changes that make the existing tests completely obsolete. Writing tests for the component will take some time and is pushed to the next release cycle as the component currently shows no bugs/unexpected behaviors.