### PR TITLE
Support top-level OR combine mode for explorer filters PEDS-700

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -18,6 +18,7 @@ import {
 /**
  * @typedef {Object} ConnectedFilterProps
  * @property {object} [adminAppliedPreFilters]
+ * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {FilterState} filter
  * @property {FilterConfig} filterConfig
@@ -36,6 +37,7 @@ import {
 /** @param {ConnectedFilterProps} props */
 function ConnectedFilter({
   adminAppliedPreFilters = {},
+  anchorValue,
   className = '',
   filter,
   filterConfig,
@@ -87,6 +89,7 @@ function ConnectedFilter({
 
   return (
     <FilterGroup
+      anchorValue={anchorValue}
       className={className}
       disabledTooltipMessage={
         'This resource is currently disabled because you are exploring restricted data. You are limited to exploring cohorts of a size greater than or equal to the access limit.'
@@ -106,6 +109,7 @@ function ConnectedFilter({
 
 ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
+  anchorValue: PropTypes.string,
   className: PropTypes.string,
   filter: PropTypes.object.isRequired,
   filterConfig: PropTypes.shape({

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -246,6 +246,7 @@ function GuppyWrapper({
   /**
    * @param {Object} args
    * @param {string[]} args.fields
+   * @param {FilterState} [args.filter]
    * @param {number} [args.offset]
    * @param {number} [args.size]
    * @param {GqlSort} [args.sort]
@@ -253,6 +254,7 @@ function GuppyWrapper({
    */
   function fetchRawDataFromGuppy({
     fields,
+    filter = state.filter,
     offset,
     size,
     sort,
@@ -275,7 +277,7 @@ function GuppyWrapper({
         numericAggAsText,
         termsFields: guppyConfig.aggFields,
         missingFields: [],
-        gqlFilter: getGQLFilter(augmentFilter(state.filter)),
+        gqlFilter: getGQLFilter(augmentFilter(filter)),
         signal: controller.current.signal,
       }).then((res) => {
         if (!res || !res.data)
@@ -303,7 +305,7 @@ function GuppyWrapper({
     return queryGuppyForRawData({
       type: guppyConfig.dataType,
       fields,
-      gqlFilter: getGQLFilter(augmentFilter(state.filter)),
+      gqlFilter: getGQLFilter(augmentFilter(filter)),
       sort,
       offset,
       size,
@@ -497,6 +499,7 @@ function GuppyWrapper({
     fetchAggsDataFromGuppy(mergedFilter);
     fetchRawDataFromGuppy({
       fields: rawDataFields,
+      filter: mergedFilter,
       updateDataWhenReceive: true,
     });
   }

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -386,7 +386,7 @@ function GuppyWrapper({
       type: guppyConfig.dataType,
       fields: rawDataFields,
       sort,
-      filter: augmentFilter(state.filter),
+      gqlFilter: getGQLFilter(augmentFilter(state.filter)),
       format,
     });
   }
@@ -404,7 +404,7 @@ function GuppyWrapper({
       type: guppyConfig.dataType,
       fields: fields || rawDataFields,
       sort,
-      filter: state.filter,
+      gqlFilter: getGQLFilter(state.filter),
     });
   }
 
@@ -424,7 +424,11 @@ function GuppyWrapper({
    * @param {string[]} fields
    */
   function downloadRawDataByTypeAndFilter(type, filter, fields) {
-    return downloadDataFromGuppy({ type, fields, filter });
+    return downloadDataFromGuppy({
+      type,
+      fields,
+      gqlFilter: getGQLFilter(filter),
+    });
   }
 
   /**

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -481,7 +481,11 @@ function GuppyWrapper({
 
   /** @param {FilterState} filter */
   function handleFilterChange(filter) {
-    const mergedFilter = mergeFilters(filter, adminAppliedPreFilters);
+    const userFilter = /** @type {FilterState} */ ({
+      __combineMode: state.filter.__combineMode ?? 'AND',
+      ...filter,
+    });
+    const mergedFilter = mergeFilters(userFilter, adminAppliedPreFilters);
 
     if (onFilterChange) onFilterChange(mergedFilter);
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -673,11 +673,17 @@ export function getGQLFilter(filterState, combineMode = 'AND') {
  * @param {object} args
  * @param {string} args.type
  * @param {string[]} [args.fields]
- * @param {FilterState} [args.filter]
+ * @param {GqlFilter} [args.gqlFilter]
  * @param {GqlSort} [args.sort]
  * @param {string} [args.format]
  */
-export function downloadDataFromGuppy({ type, fields, filter, sort, format }) {
+export function downloadDataFromGuppy({
+  type,
+  fields,
+  gqlFilter,
+  sort,
+  format,
+}) {
   const JSON_FORMAT = format === 'json' || format === undefined;
   return fetch(downloadEndpoint, {
     method: 'POST',
@@ -686,7 +692,7 @@ export function downloadDataFromGuppy({ type, fields, filter, sort, format }) {
     },
     body: JSON.stringify({
       accessibility: 'accessible',
-      filter: getGQLFilter(filter),
+      filter: gqlFilter,
       type,
       fields,
       sort,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -70,7 +70,7 @@ export function queryGuppyForAggregationChartData({
       ? `query ($filter: JSON) {
         _aggregation {
           ${type} (filter: $filter, filterSelf: ${
-          Object.keys(gqlFilter)[0] === 'OR'
+          'OR' in gqlFilter && gqlFilter.OR.length > 1
         }, accessibility: all) {
             ${fields.map(buildHistogramQueryStrForField).join('\n')}
           }
@@ -300,7 +300,8 @@ export function queryGuppyForAggregationOptionsData({
     });
 
   const isFilterEmpty = gqlFilter === undefined;
-  const filterSelf = !isFilterEmpty && Object.keys(gqlFilter)[0] === 'OR';
+  const filterSelf =
+    !isFilterEmpty && 'OR' in gqlFilter && gqlFilter.OR.length > 1;
   const query = buildQueryForAggregationOptionsData({
     filterSelf,
     fieldsByGroup,
@@ -377,7 +378,7 @@ export function queryGuppyForSubAggregationData({
       ? `query ($filter: JSON, $nestedAggFields: JSON) {
         _aggregation {
             ${type} (filter: $filter, filterSelf: ${
-          Object.keys(gqlFilter)[0] === 'OR'
+          'OR' in gqlFilter && gqlFilter.OR.length > 1
         }, nestedAggFields: $nestedAggFields, accessibility: all) {
               ${nestedHistogramQueryStrForEachField(
                 mainField,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -570,23 +570,26 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
 
   for (const [filterKey, filterValues] of Object.entries(filterState)) {
     const [path, fieldName] = filterKey.split('.');
-    const simpleFilter = parseSimpleFilter(fieldName, filterValues);
 
-    if (simpleFilter !== undefined) {
-      if (!(path in nestedFilterIndices)) {
-        nestedFilterIndices[path] = nestedFilterIndex;
-        nestedFilters.push({
-          nested:
-            combineMode === 'AND'
-              ? { path, AND: [anchorFilter] }
-              : { path, OR: [anchorFilter] },
-        });
-        nestedFilterIndex += 1;
+    if (typeof filterValues !== 'string') {
+      const simpleFilter = parseSimpleFilter(fieldName, filterValues);
+
+      if (simpleFilter !== undefined) {
+        if (!(path in nestedFilterIndices)) {
+          nestedFilterIndices[path] = nestedFilterIndex;
+          nestedFilters.push({
+            nested:
+              combineMode === 'AND'
+                ? { path, AND: [anchorFilter] }
+                : { path, OR: [anchorFilter] },
+          });
+          nestedFilterIndex += 1;
+        }
+
+        nestedFilters[nestedFilterIndices[path]].nested[combineMode].push(
+          simpleFilter
+        );
       }
-
-      nestedFilters[nestedFilterIndices[path]].nested[combineMode].push(
-        simpleFilter
-      );
     }
   }
 

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -9,7 +9,8 @@ export type RangeFilter = {
 };
 
 export type SimpleFilterState = {
-  [x: string]: OptionFilter | RangeFilter;
+  [x: Exclude<string, '__combineMode'>]: OptionFilter | RangeFilter;
+  __combineMode?: 'AND' | 'OR';
 };
 
 export type AnchoredFilterState = {
@@ -17,7 +18,11 @@ export type AnchoredFilterState = {
 };
 
 export type FilterState = {
-  [x: string]: OptionFilter | RangeFilter | AnchoredFilterState;
+  [x: Exclude<string, '__combineMode'>]:
+    | OptionFilter
+    | RangeFilter
+    | AnchoredFilterState;
+  __combineMode?: 'AND' | 'OR';
 };
 
 export type GqlInFilter = {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -35,22 +35,35 @@ export type GqlRangeFilter = {
   };
 };
 
-export type GqlSimpleAndFilter = {
-  AND: GqlSimpleFilter[];
-};
+export type GqlSimpleAndFilter =
+  | {
+      AND: GqlSimpleFilter[];
+    }
+  | {
+      OR: GqlSimpleFilter[];
+    };
 
 export type GqlSimpleFilter = GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter;
 
 export type GqlNestedFilter = {
-  nested: {
-    path: string;
-    AND: GqlFilter[];
-  };
+  nested:
+    | {
+        path: string;
+        AND: GqlFilter[];
+      }
+    | {
+        path: string;
+        OR: GqlFilter[];
+      };
 };
 
-export type GqlAndFilter = {
-  AND: GqlFilter[];
-};
+export type GqlAndFilter =
+  | {
+      AND: GqlFilter[];
+    }
+  | {
+      OR: GqlFilter[];
+    };
 
 export type GqlSearchFilter = {
   search: {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -156,16 +156,14 @@ export type AggsData = {
     | SimpleAggsData;
 };
 
-export type FilterChangeHandler = (args: {
-  anchorValue?: string;
-  filter: FilterState;
-}) => void;
+export type FilterChangeHandler = (filter: FilterState) => void;
 
 export type GuppyData = {
   accessibleCount: number;
   aggsChartData: SimpleAggsData;
   aggsData: AggsData;
   allFields: string[];
+  anchorValue: string;
   filter: FilterState;
   initialTabsOptions?: SimpleAggsData;
   isLoadingAggsData: boolean;

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -50,7 +50,7 @@ export type GqlSimpleAndFilter =
 
 export type GqlSimpleFilter = GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter;
 
-export type GqlNestedFilter = {
+export type GqlNestedAnchoredFilter = {
   nested: {
     path: string;
     AND:
@@ -58,6 +58,20 @@ export type GqlNestedFilter = {
       | [GqlInFilter, { AND: GqlFilter[] } | { OR: GqlFilter[] }];
   };
 };
+
+export type GqlNestedFilter =
+  | GqlNestedAnchoredFilter
+  | {
+      nested:
+        | {
+            path: string;
+            AND: GqlFilter[];
+          }
+        | {
+            path: string;
+            OR: GqlFilter[];
+          };
+    };
 
 export type GqlAndFilter =
   | {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -51,15 +51,12 @@ export type GqlSimpleAndFilter =
 export type GqlSimpleFilter = GqlInFilter | GqlRangeFilter | GqlSimpleAndFilter;
 
 export type GqlNestedFilter = {
-  nested:
-    | {
-        path: string;
-        AND: GqlFilter[];
-      }
-    | {
-        path: string;
-        OR: GqlFilter[];
-      };
+  nested: {
+    path: string;
+    AND:
+      | [GqlInFilter]
+      | [GqlInFilter, { AND: GqlFilter[] } | { OR: GqlFilter[] }];
+  };
 };
 
 export type GqlAndFilter =

--- a/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
+++ b/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
@@ -29,3 +29,28 @@
   height: 1.5rem;
   margin-right: 10px;
 }
+
+.explorer-filter__combine-mode {
+  margin-bottom: 1rem;
+  display: flex;
+}
+
+.explorer-filter__combine-mode > label {
+  padding: 0 4px;
+  margin-left: 8px;
+  background-color: var(--g3-color__silver);
+  border: 1px solid var(--g3-color__silver);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.explorer-filter__combine-mode > label.active,
+.explorer-filter__combine-mode > label:hover {
+  background-color: var(--g3-color__white);
+}
+
+.explorer-filter__combine-mode input[type='radio'] {
+  display: none;
+}

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -37,6 +37,13 @@ function ExplorerFilter({ className = '', ...filterProps }) {
     onPatientIdsChange: handlePatientIdsChange,
   };
   const hasAppliedFilters = Object.keys(filterProps.filter).length > 0;
+  const filterCombineMode = filterProps.filter.__combineMode ?? 'AND';
+  function updateFilterCombineMode(e) {
+    filterProps.onFilterChange({
+      ...filterProps.filter,
+      __combineMode: e.target.value,
+    });
+  }
 
   return (
     <div className={className}>
@@ -51,6 +58,24 @@ function ExplorerFilter({ className = '', ...filterProps }) {
             Clear all
           </button>
         )}
+      </div>
+      <div className='explorer-filter__combine-mode'>
+        Combine filters with
+        {['AND', 'OR'].map((/** @type {'AND' | 'OR'} */ combineMode) => (
+          <label
+            key={combineMode}
+            className={filterCombineMode === combineMode ? 'active' : undefined}
+          >
+            <input
+              name='combineMode'
+              value={combineMode}
+              type='radio'
+              onChange={updateFilterCombineMode}
+              checked={filterCombineMode === combineMode}
+            />
+            {combineMode}
+          </label>
+        ))}
       </div>
       <ConnectedFilter {...connectedFilterProps} />
     </div>

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -8,6 +8,7 @@ import './ExplorerFilter.css';
 
 /**
  * @typedef {Object} ExplorerFilterProps
+ * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {GuppyData['initialTabsOptions']} [initialTabsOptions]
  * @property {GuppyData['filter']} filter
@@ -57,6 +58,7 @@ function ExplorerFilter({ className = '', ...filterProps }) {
 }
 
 ExplorerFilter.propTypes = {
+  anchorValue: PropTypes.string, // from GuppyWrapper
   className: PropTypes.string,
   filter: PropTypes.object.isRequired, // from GuppyWrapper
   initialTabsOptions: PropTypes.object, // from GuppyWrapper

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -5,8 +5,12 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import './ExplorerFilterDisplay.css';
 
-/** @param {{ filter: import('../types').ExplorerFilters }} props */
-export function FilterDisplay({ filter }) {
+/**
+ * @param {Object} props
+ * @param {import('../types').ExplorerFilters} props.filter
+ * @param {'AND' | 'OR'} [props.combineMode]
+ */
+export function FilterDisplay({ filter, combineMode }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   const { __combineMode, ...__filter } = filter;
@@ -20,7 +24,9 @@ export function FilterDisplay({ filter }) {
             <code>{`"${anchorValue}"`}</code>
           </span>
           <span className='token'>
-            ( <FilterDisplay filter={value.filter} /> )
+            ({' '}
+            <FilterDisplay filter={value.filter} combineMode={__combineMode} />{' '}
+            )
           </span>
         </span>
       );
@@ -70,7 +76,9 @@ export function FilterDisplay({ filter }) {
         <>
           {filterElement}
           {i < filterElements.length - 1 && (
-            <span className='pill'>{__combineMode ?? 'AND'}</span>
+            <span className='pill'>
+              {combineMode ?? __combineMode ?? 'AND'}
+            </span>
           )}
         </>
       ))}

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -9,7 +9,8 @@ import './ExplorerFilterDisplay.css';
 export function FilterDisplay({ filter }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const filterElements = /** @type {JSX.Element[]} */ ([]);
-  for (const [key, value] of Object.entries(filter))
+  const { __combineMode, ...__filter } = filter;
+  for (const [key, value] of Object.entries(__filter))
     if ('filter' in value) {
       const [anchorKey, anchorValue] = key.split(':');
       filterElements.push(
@@ -68,7 +69,9 @@ export function FilterDisplay({ filter }) {
       {filterElements.map((filterElement, i) => (
         <>
           {filterElement}
-          {i < filterElements.length - 1 && <span className='pill'>AND</span>}
+          {i < filterElements.length - 1 && (
+            <span className='pill'>{__combineMode ?? 'AND'}</span>
+          )}
         </>
       ))}
     </span>

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -81,7 +81,10 @@ export function ExplorerStateProvider({ children }) {
         if (searchFields?.length > 0) allSearchFields.push(...searchFields);
 
       if (allSearchFields.length === 0) {
-        newSearchParams.set('filter', JSON.stringify(filter));
+        newSearchParams.set(
+          'filter',
+          JSON.stringify({ __combineMode: filters.__combineMode, ...filter })
+        );
       } else {
         const allSearchFieldSet = new Set(allSearchFields);
         const filterWithoutSearchFields = {};
@@ -92,7 +95,10 @@ export function ExplorerStateProvider({ children }) {
         if (Object.keys(filterWithoutSearchFields).length > 0)
           newSearchParams.set(
             'filter',
-            JSON.stringify(filterWithoutSearchFields)
+            JSON.stringify({
+              __combineMode: filters.__combineMode,
+              ...filterWithoutSearchFields,
+            })
           );
       }
     }

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -81,6 +81,7 @@ function ExplorerDashboard({ dataVersion, portalVersion }) {
                 filter={data.filter}
               />
               <ExplorerFilter
+                anchorValue={data.anchorValue}
                 className='explorer__filter'
                 filter={data.filter}
                 initialTabsOptions={data.initialTabsOptions}

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -122,7 +122,9 @@ export function validateFilter(value, filterConfig) {
   const testFieldSet = new Set(allFields);
   const isAnchorFilterEnabled = filterConfig.anchor !== undefined;
   for (const [field, filterContent] of Object.entries(value)) {
-    if (isAnchorFilterEnabled && 'filter' in filterContent)
+    if (field === '__combineMode') {
+      if (!['AND', 'OR'].includes(filterContent)) return false;
+    } else if (isAnchorFilterEnabled && 'filter' in filterContent)
       for (const [anchoredField, anchoredfilterContent] of Object.entries(
         filterContent.filter
       ))

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -38,6 +38,7 @@ function findFilterElement(label) {
 
 /**
  * @typedef {Object} FilterGroupProps
+ * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {string} [disabledTooltipMessage]
  * @property {FilterConfig} filterConfig
@@ -56,6 +57,7 @@ const defaultInitialAppliedFilters = {};
 
 /** @param {FilterGroupProps} props */
 function FilterGroup({
+  anchorValue = '',
   className = '',
   disabledTooltipMessage,
   filterConfig,
@@ -83,15 +85,10 @@ function FilterGroup({
   const showPatientIdsFilter =
     patientIds !== undefined && tabTitle === 'Subject';
 
-  const [anchorValue, setAnchorValue] = useState('');
   const anchorLabel =
     filterConfig.anchor !== undefined && anchorValue !== '' && showAnchorFilter
       ? `${filterConfig.anchor.field}:${anchorValue}`
       : '';
-  function handleAnchorValueChange(value) {
-    setAnchorValue(value);
-    onAnchorValueChange(value);
-  }
 
   const [expandedStatusControl, setExpandedStatusControl] = useState(false);
   const expandedStatusText = expandedStatusControl
@@ -125,7 +122,7 @@ function FilterGroup({
 
     setFilterStatus(newFilterStatus);
     setFilterResults(newFilterResults);
-    onFilterChange({ anchorValue, filter: newFilterResults });
+    onFilterChange(newFilterResults);
   }, [initialAppliedFilters]);
 
   const filterTabStatus = showAnchorFilter
@@ -156,7 +153,7 @@ function FilterGroup({
     });
     setFilterResults(updated.filterResults);
     setFilterStatus(updated.filterStatus);
-    onFilterChange({ anchorValue, filter: updated.filterResults });
+    onFilterChange(updated.filterResults);
   }
 
   /**
@@ -189,7 +186,7 @@ function FilterGroup({
       'selectedValues' in filterValues &&
       filterValues.selectedValues.length > 0
     )
-      onFilterChange({ anchorValue, filter: updated.filterResults });
+      onFilterChange(updated.filterResults);
   }
 
   /**
@@ -208,7 +205,7 @@ function FilterGroup({
     });
     setFilterStatus(updated.filterStatus);
     setFilterResults(updated.filterResults);
-    onFilterChange({ anchorValue, filter: updated.filterResults });
+    onFilterChange(updated.filterResults);
   }
 
   /**
@@ -242,7 +239,7 @@ function FilterGroup({
     });
     setFilterStatus(updated.filterStatus);
     setFilterResults(updated.filterResults);
-    onFilterChange({ anchorValue, filter: updated.filterResults });
+    onFilterChange(updated.filterResults);
   }
 
   function toggleSections() {
@@ -337,7 +334,7 @@ function FilterGroup({
           <AnchorFilter
             anchorField={filterConfig.anchor.field}
             anchorValue={anchorValue}
-            onChange={handleAnchorValueChange}
+            onChange={onAnchorValueChange}
             options={filterConfig.anchor.options}
             optionsInUse={selectedAnchors[tabIndex]}
             tooltip={filterConfig.anchor.tooltip}
@@ -378,6 +375,7 @@ function FilterGroup({
 }
 
 FilterGroup.propTypes = {
+  anchorValue: PropTypes.string,
   className: PropTypes.string,
   disabledTooltipMessage: PropTypes.string,
   filterConfig: PropTypes.shape({

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -97,24 +97,25 @@ export function removeEmptyFilter(filterResults) {
   const newFilterResults = {};
   for (const field of Object.keys(filterResults)) {
     const filterValues = filterResults[field];
-    if ('filter' in filterValues) {
-      const newAnchoredFilterResults = removeEmptyFilter(filterValues.filter);
-      if (Object.keys(newAnchoredFilterResults).length > 0)
-        newFilterResults[field] = { filter: newAnchoredFilterResults };
-    } else {
-      const hasRangeFilter = 'lowerBound' in filterValues;
-      const hasOptionFilter =
-        'selectedValues' in filterValues &&
-        filterValues.selectedValues.length > 0;
-      // Filter settings are prefaced with two underscores, e.g., __combineMode
-      // A given config setting is still informative to Guppy even if the setting becomes empty
-      const hasConfigSetting = Object.keys(filterValues).some((x) =>
-        x.startsWith('__')
-      );
-      if (hasRangeFilter || hasOptionFilter || hasConfigSetting) {
-        newFilterResults[field] = filterValues;
+    if (typeof filterValues !== 'string')
+      if ('filter' in filterValues) {
+        const newAnchoredFilterResults = removeEmptyFilter(filterValues.filter);
+        if (Object.keys(newAnchoredFilterResults).length > 0)
+          newFilterResults[field] = { filter: newAnchoredFilterResults };
+      } else {
+        const hasRangeFilter = 'lowerBound' in filterValues;
+        const hasOptionFilter =
+          'selectedValues' in filterValues &&
+          filterValues.selectedValues.length > 0;
+        // Filter settings are prefaced with two underscores, e.g., __combineMode
+        // A given config setting is still informative to Guppy even if the setting becomes empty
+        const hasConfigSetting = Object.keys(filterValues).some((x) =>
+          x.startsWith('__')
+        );
+        if (hasRangeFilter || hasOptionFilter || hasConfigSetting) {
+          newFilterResults[field] = filterValues;
+        }
       }
-    }
   }
 
   return newFilterResults;

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -33,11 +33,12 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
       filterResultsByAnchor[`${anchorConfig.field}:${anchorValue}`] = {};
 
   for (const [filterKey, filterValues] of Object.entries(filterResults))
-    if ('filter' in filterValues) {
-      filterResultsByAnchor[filterKey] = filterValues.filter;
-    } else {
-      filterResultsByAnchor[''][filterKey] = filterValues;
-    }
+    if (typeof filterValues !== 'string')
+      if ('filter' in filterValues) {
+        filterResultsByAnchor[filterKey] = filterValues.filter;
+      } else {
+        filterResultsByAnchor[''][filterKey] = filterValues;
+      }
 
   return filterResultsByAnchor;
 }


### PR DESCRIPTION
Ticket: [PEDS-700](https://pcdc.atlassian.net/browse/PEDS-700)

This PR implements using top-level `'OR'` `combineMode` for explorer filters. This includes adding a top-level `"__combineMode"` property to explorer filter object, using the selected `combineMode` in building graphql queries, creating a simple UI element to toggle the `combineMode`, and modifying filter display component to show selected `combineMode`.

One key change in generated graphql query is that, roughly speaking, the `filterSelf` argument value is set to `true` if more than two fields are in use with top-level 'OR' combine mode. Check out the newly added [`checkFilterSelf()` helper](https://github.com/chicagopcdc/data-portal/pull/371/files#diff-26ed70145e2d4c0a182cb126f5f680f822e8c0c055e55bc8c7e17f3bdb395afdR56-R93) to view the full logic for determining the `filterSelf` value.

See the following screenshot of updated UI:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/22449454/163270605-9875f3e4-5b06-4428-bafd-0ae7c1523e98.png">
