### PR TITLE
Update user agreement UI for survival analysis tool (again) PEDS-114

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -3,19 +3,16 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import Button from '../../gen3-ui-component/components/Button';
 
-// The following resources are currently works in progress
-const statisticalManualHref = '/';
-const statisticalCondiserationVideoHref = 'https://youtu.be/d_x8taJ-lP8';
-
 const pcdcStatisticalManualLink = (
-  <a href={statisticalManualHref} target='_black' rel='noopener noreferrer'>
+  // this resource is currently a work in progress
+  <a href='/' target='_black' rel='noopener noreferrer'>
     PCDC Statistical Manual
     <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
   </a>
 );
 const statisticalConsiderationVidoeLink = (
   <a
-    href={statisticalCondiserationVideoHref}
+    href='https://youtu.be/d_x8taJ-lP8'
     target='_black'
     rel='noopener noreferrer'
   >

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -5,11 +5,21 @@ import Button from '../../gen3-ui-component/components/Button';
 
 // The following resources are currently works in progress
 const statisticalManualHref = '/';
-const summaryVideoHref = '/';
+const statisticalCondiserationVideoHref = 'https://youtu.be/d_x8taJ-lP8';
 
 const pcdcStatisticalManualLink = (
   <a href={statisticalManualHref} target='_black' rel='noopener noreferrer'>
     PCDC Statistical Manual
+    <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
+  </a>
+);
+const statisticalConsiderationVidoeLink = (
+  <a
+    href={statisticalCondiserationVideoHref}
+    target='_black'
+    rel='noopener noreferrer'
+  >
+    Watch this video
     <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
   </a>
 );
@@ -57,13 +67,9 @@ function UserAgreement({ onAgree }) {
         All users of the Kaplan-Meier survival analysis tool are required to
         review the {pcdcStatisticalManualLink}. The manual outlines principles
         for responsible data exploration and sets forth policies users must
-        agree to abide by. A summary of important statistical considerations is
-        below:
+        agree to abide by. {statisticalConsiderationVidoeLink} for a summary of
+        important statistical considerations.
       </p>
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video controls>
-        <source src={summaryVideoHref} type='video/mp4' />
-      </video>
       <p>I, {fullname}, agree that:</p>
       <ul>
         {checkItems.map((item, i) => (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -4,8 +4,11 @@ import { useSelector } from 'react-redux';
 import Button from '../../gen3-ui-component/components/Button';
 
 const pcdcStatisticalManualLink = (
-  // this resource is currently a work in progress
-  <a href='/' target='_black' rel='noopener noreferrer'>
+  <a
+    href='https://commons.cri.uchicago.edu/wp-content/uploads/2022/04/PCDC-Analytics-Tool-Documentation-Statistical-Manual.pdf'
+    target='_black'
+    rel='noopener noreferrer'
+  >
     PCDC Statistical Manual
     <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
   </a>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -15,17 +15,16 @@ const pcdcStatisticalManualLink = (
 );
 
 const checkItems = [
-  <>I have read and understand the {pcdcStatisticalManualLink}.</>,
   <>
-    I will abide by the principles and policies set forth in the{' '}
-    {pcdcStatisticalManualLink}.
+    I have read the {pcdcStatisticalManualLink} and agree to abide by the
+    principles and policies set forth in the manual.
   </>,
-  'My activity on PCDC web-based analytics tools will be recorded and audited to assess the effectiveness of the pilot and to investigate possible misuse or abuse.',
-  'PCDC may contact me to investigate cases of suspected abuse or misuse of web-based analytics tools. I will promptly respond to inquiries regarding my use of the tools.',
-  'I will not violate PCDC policies or terms of use.',
+  'My activity on the PCDC Data Portal will be logged and audited to assess the effectiveness of the pilot and to investigate possible misuse or abuse.',
+  'PCDC staff may contact me to investigate cases of suspected abuse or misuse of web-based analytics tools. I will promptly respond to inquiries regarding my use of the tools.',
+  'I will not violate the PCDC Terms of Use or Acceptable Use Policy.',
   'I will not engage in p-hacking or other forms of statistical misuse.',
   'I will not reproduce or distribute results generated using web-based analytics tools.',
-  'I will follow a hypothesis-driven approach when performing analyses and maintain a hypothesis record, which may be audited.',
+  'I will follow a hypothesis-driven approach when performing analyses and maintain a hypothesis record.',
 ];
 
 function fullnameSelector(state) {
@@ -49,16 +48,17 @@ function UserAgreement({ onAgree }) {
   return (
     <div className='explorer-survival-analysis__user-agreement'>
       <p>
-        The PCDC has partnered with consortia to pilot web-based analytics
-        tools. Due to the potential for statistical misuse and abuse with use of
-        the tools, safeguards have been implemented to facilitate responsible
-        data exploration.
+        The PCDC is piloting a Kaplan-Meier survival analysis tool. Due to the
+        potential for statistical misuse and abuse with use of the tool,
+        safeguards have been implemented to facilitate responsible data
+        exploration.
       </p>
       <p>
-        All users of analytics tools are required to review the{' '}
-        {pcdcStatisticalManualLink}. The manual outlines principles for
-        responsible data exploration and sets forth policies users must agree to
-        abide by. A summary video is included below:
+        All users of the Kaplan-Meier survival analysis tool are required to
+        review the {pcdcStatisticalManualLink}. The manual outlines principles
+        for responsible data exploration and sets forth policies users must
+        agree to abide by. A summary of important statistical considerations is
+        below:
       </p>
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video controls>


### PR DESCRIPTION
Ticket: [PEDS-114](https://pcdc.atlassian.net/browse/PEDS-114)

This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/336 and adds the following changes to the user agreement UI:

* Updated text
* Added a hyperlink to statistical manual
* Added a hyperlink to the video resource (instead of directly embedding video)

See the following screenshot:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/22449454/164319044-3748e260-4f57-4ff8-87cb-3912ee3e7e88.png">