### PR TITLE
Show abbreviated User Agreement UI to returning users PEDS-114

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -43,7 +43,10 @@ function AgreementForm({ isSubmitting, onAgree }) {
   const [error, setError] = useState(/** @type {Error | null} */ (null));
   if (error) throw error;
   function handleAgree() {
-    onAgree().catch(setError);
+    onAgree().catch((err) => {
+      console.error(err); // eslint-disable-line no-console
+      setError(err);
+    });
   }
 
   const fullname = useSelector(fullnameSelector);

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -14,16 +14,6 @@ const pcdcStatisticalManualLink = (
     <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
   </a>
 );
-const statisticalConsiderationVidoeLink = (
-  <a
-    href='https://youtu.be/d_x8taJ-lP8'
-    target='_black'
-    rel='noopener noreferrer'
-  >
-    Watch this video
-    <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
-  </a>
-);
 
 const checkItems = [
   <>
@@ -65,8 +55,16 @@ function AgreementForm({ onAgree }) {
         All users of the Kaplan-Meier survival analysis tool are required to
         review the {pcdcStatisticalManualLink}. The manual outlines principles
         for responsible data exploration and sets forth policies users must
-        agree to abide by. {statisticalConsiderationVidoeLink} for a summary of
-        important statistical considerations.
+        agree to abide by.{' '}
+        <a
+          href='https://youtu.be/d_x8taJ-lP8'
+          target='_black'
+          rel='noopener noreferrer'
+        >
+          Watch this video
+          <i className='g3-icon g3-icon--external-link g3-icon--sm g3-icon-color__gray' />
+        </a>{' '}
+        for a summary of important statistical considerations.
       </p>
       <p>I, {fullname}, agree that:</p>
       <ul>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -99,7 +99,7 @@ function AgreementForm({ isSubmitting, onAgree }) {
       <div className='explorer-survival-analysis__button-group'>
         <Button
           buttonType='primary'
-          label='I Agree'
+          label='Agree'
           enabled={Object.values(checkStatus).every(Boolean) && !isSubmitting}
           onClick={handleAgree}
         />

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -90,7 +90,10 @@ function ProtectedContent({
     const isUserRegistered =
       currentState.user.authz !== undefined &&
       Object.keys(currentState.user.authz).length > 0;
-    const hasDocsToReview = currentState.user.docs_to_be_reviewed?.length > 0;
+    const hasDocsToReview =
+      currentState.user.docs_to_be_reviewed?.filter(
+        ({ type }) => type !== 'survival-user-agreement'
+      ).length > 0;
     const hasAccess = isUserRegistered && !hasDocsToReview;
 
     return location.pathname === '/' || hasAccess

--- a/src/UserPopup/index.jsx
+++ b/src/UserPopup/index.jsx
@@ -38,7 +38,10 @@ function updateDocsToReview(reviewStatus) {
 /** @param {{ user: import('../types').UserState }} state */
 function userPopupSelector({ user }) {
   const isRegistered = user.authz?.['/portal']?.length > 0;
-  const docsToBeReviewed = user.docs_to_be_reviewed ?? [];
+  const docsToBeReviewed =
+    user.docs_to_be_reviewed.filter(
+      ({ type }) => type !== 'survival-user-agreement'
+    ) ?? [];
   return {
     docsToBeReviewed,
     shouldRegister: !isRegistered,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,7 +23,11 @@ export type UserAuthz = {
 };
 
 export type User = {
-  additional_info: Object;
+  additional_info: {
+    firstName?: string;
+    lastName?: string;
+    institution?: string;
+  };
   authz: UserAuthz;
   azp: any;
   certificates_uploaded: any[];


### PR DESCRIPTION
Ticket: [PEDS-114](https://pcdc.atlassian.net/browse/PEDS-114)

This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/372 and implements an abbreviated user agreement UI for returning users. This is handled by using a document of `"survival-user-agreement"` type, which will be present in the `docs_to_be_reviewed` list for all first-time users of the survival analysis tool.

Because agreeing to the terms now involves sending a request to `/user/documents` endpoint, the PR also includes error handling for failed request.

See the following screenshot of the abbreviated UI:

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/22449454/164550526-eddbde11-ad36-4629-a84e-65ebb6702e9e.png">

And see the following screenshot of the error UI:

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/22449454/164551226-d4005dbc-f650-4ee1-9cba-e284855d8a89.png">
