### PR TITLE
Use <QueryDisplay> component PEDS-701

### DIFF
--- a/.storybook/stories/QueryDisplay.jsx
+++ b/.storybook/stories/QueryDisplay.jsx
@@ -29,6 +29,9 @@ const filterInfo = {
 
 storiesOf('QueryDisplay', module)
   .add('Simple', () => (
+    <QueryDisplay filter={simpleFilter} filterInfo={filterInfo} />
+  ))
+  .add('Simple with action', () => (
     <QueryDisplay
       filter={simpleFilter}
       filterInfo={filterInfo}
@@ -36,6 +39,10 @@ storiesOf('QueryDisplay', module)
     />
   ))
   .add('Complex', () => (
+    <QueryDisplay filter={complexFilter} filterInfo={filterInfo} />
+  ))
+
+  .add('Complex with action', () => (
     <QueryDisplay
       filter={complexFilter}
       filterInfo={filterInfo}

--- a/.storybook/stories/QueryDisplay.jsx
+++ b/.storybook/stories/QueryDisplay.jsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import QueryDisplay from '@src/components/QueryDisplay';
 
 const simpleFilter = {
@@ -28,8 +29,16 @@ const filterInfo = {
 
 storiesOf('QueryDisplay', module)
   .add('Simple', () => (
-    <QueryDisplay filter={simpleFilter} filterInfo={filterInfo} />
+    <QueryDisplay
+      filter={simpleFilter}
+      filterInfo={filterInfo}
+      onAction={action('action')}
+    />
   ))
   .add('Complex', () => (
-    <QueryDisplay filter={complexFilter} filterInfo={filterInfo} />
+    <QueryDisplay
+      filter={complexFilter}
+      filterInfo={filterInfo}
+      onAction={action('action')}
+    />
   ));

--- a/.storybook/stories/QueryDisplay.jsx
+++ b/.storybook/stories/QueryDisplay.jsx
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { storiesOf } from '@storybook/react';
+import QueryDisplay from '@src/components/QueryDisplay';
+
+const simpleFilter = {
+  __combineMode: 'AND',
+  foo: { selectedValues: ['x', 'y'] },
+  bar: { lowerBound: 0, upperBound: 1 },
+};
+
+const complexFilter = {
+  __combineMode: 'OR',
+  foo: { selectedValues: ['x', 'y'] },
+  'lorem:ipsum': {
+    filter: {
+      bar: { lowerBound: 0, upperBound: 1 },
+      baz: { selectedValues: ['hello', 'world'] },
+    },
+  },
+};
+
+const filterInfo = {
+  foo: { label: 'Foo' },
+  bar: { label: 'Bar' },
+  baz: { label: 'Baz' },
+  lorem: { label: 'Lorem' },
+};
+
+storiesOf('QueryDisplay', module)
+  .add('Simple', () => (
+    <QueryDisplay filter={simpleFilter} filterInfo={filterInfo} />
+  ))
+  .add('Complex', () => (
+    <QueryDisplay filter={complexFilter} filterInfo={filterInfo} />
+  ));

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -7,7 +7,7 @@ import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
 import { fetchWithCreds } from '../../actions';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
-import FilterSetFilterDisplay from '../ExplorerFilterSet/FilterSetFilterDisplay';
+import FilterSetQueryDisplay from '../ExplorerFilterSet/FilterSetQueryDisplay';
 import './ExplorerExploreExternalButton.css';
 
 /** @typedef {import('../types').ExplorerFilters} ExplorerFilters */
@@ -82,7 +82,7 @@ function ExplorerExploreExternalButton({ filter }) {
                   />
                 }
               />
-              <FilterSetFilterDisplay filters={filter} />
+              <FilterSetQueryDisplay filters={filter} />
             </form>
             <div>
               <Button

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -1,98 +1,13 @@
 import PropTypes from 'prop-types';
 import { useEffect, useRef, useState } from 'react';
-import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
+import QueryDisplay from '../../components/QueryDisplay';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import './ExplorerFilterDisplay.css';
 
-/**
- * @param {Object} props
- * @param {import('../types').ExplorerFilters} props.filter
- * @param {'AND' | 'OR'} [props.combineMode]
- */
-export function FilterDisplay({ filter, combineMode }) {
-  const filterInfo = useExplorerConfig().current.filterConfig.info;
-  const filterElements = /** @type {JSX.Element[]} */ ([]);
-  const { __combineMode, ...__filter } = filter;
-  for (const [key, value] of Object.entries(__filter))
-    if ('filter' in value) {
-      const [anchorKey, anchorValue] = key.split(':');
-      filterElements.push(
-        <span key={key} className='pill anchor'>
-          <span className='token field'>
-            With <code>{filterInfo[anchorKey].label}</code> of{' '}
-            <code>{`"${anchorValue}"`}</code>
-          </span>
-          <span className='token'>
-            ({' '}
-            <FilterDisplay filter={value.filter} combineMode={__combineMode} />{' '}
-            )
-          </span>
-        </span>
-      );
-    } else if ('selectedValues' in value) {
-      filterElements.push(
-        <span key={key} className='pill'>
-          <span className='token'>
-            <code>{filterInfo[key].label}</code>{' '}
-            {value.selectedValues.length > 1 ? 'is any of ' : 'is '}
-          </span>
-          <span className='token'>
-            {value.selectedValues.length > 1 ? (
-              <Tooltip
-                arrowContent={<div className='rc-tooltip-arrow-inner' />}
-                overlay={value.selectedValues.map((v) => `"${v}"`).join(', ')}
-                placement='bottom'
-                trigger={['hover', 'focus']}
-              >
-                <span>
-                  <code>{`"${value.selectedValues[0]}"`}</code>, ...
-                </span>
-              </Tooltip>
-            ) : (
-              <code>{`"${value.selectedValues[0]}"`}</code>
-            )}
-          </span>
-        </span>
-      );
-    } else {
-      filterElements.push(
-        <span key={key} className='pill'>
-          <span className='token'>
-            <code>{filterInfo[key].label}</code> is between
-          </span>
-          <span className='token'>
-            <code>
-              ({value.lowerBound}, {value.upperBound})
-            </code>
-          </span>
-        </span>
-      );
-    }
-
-  return (
-    <span className='filter-display'>
-      {filterElements.map((filterElement, i) => (
-        <>
-          {filterElement}
-          {i < filterElements.length - 1 && (
-            <span className='pill'>
-              {combineMode ?? __combineMode ?? 'AND'}
-            </span>
-          )}
-        </>
-      ))}
-    </span>
-  );
-}
-
-FilterDisplay.propTypes = {
-  filter: PropTypes.any,
-  combineMode: PropTypes.oneOf(['AND', 'OR']),
-};
-
 /** @param {{ filter: import('../types').ExplorerFilters }} props */
 function ExplorerFilterDisplay({ filter }) {
+  const filterInfo = useExplorerConfig().current.filterConfig.info;
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const ref = useRef(null);
@@ -124,7 +39,7 @@ function ExplorerFilterDisplay({ filter }) {
             />
           </button>
           <h4>Filters in Use:</h4>
-          <FilterDisplay filter={filter} />
+          <QueryDisplay filter={filter} filterInfo={filterInfo} />
         </>
       ) : (
         <h4>← Try Filters to explore data</h4>

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -88,6 +88,7 @@ export function FilterDisplay({ filter, combineMode }) {
 
 FilterDisplay.propTypes = {
   filter: PropTypes.any,
+  combineMode: PropTypes.oneOf(['AND', 'OR']),
 };
 
 /** @param {{ filter: import('../types').ExplorerFilters }} props */
@@ -132,6 +133,8 @@ function ExplorerFilterDisplay({ filter }) {
   );
 }
 
-ExplorerFilterDisplay.propTypes = FilterDisplay.propTypes;
+ExplorerFilterDisplay.propTypes = {
+  filter: PropTypes.any,
+};
 
 export default ExplorerFilterDisplay;

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetActionComponents.jsx
@@ -6,7 +6,7 @@ import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
 import { defaultFilterSet as survivalDefaultFilterSet } from '../ExplorerSurvivalAnalysis/ControlForm';
-import FilterSetFilterDisplay from './FilterSetFilterDisplay';
+import FilterSetQueryDisplay from './FilterSetQueryDisplay';
 import './ExplorerFilterSet.css';
 
 /** @typedef {import('./types').ExplorerFilters} ExplorerFilters */
@@ -105,7 +105,7 @@ function FilterSetOpenForm({
             />
           }
         />
-        <FilterSetFilterDisplay filters={selected.value.filters} />
+        <FilterSetQueryDisplay filters={selected.value.filters} />
       </form>
       <div>
         <FilterSetButton
@@ -217,7 +217,7 @@ function FilterSetCreateForm({
             />
           }
         />
-        <FilterSetFilterDisplay filters={currentFilters} />
+        <FilterSetQueryDisplay filters={currentFilters} />
       </form>
       <div>
         <FilterSetButton
@@ -333,9 +333,9 @@ function FilterSetUpdateForm({
             />
           }
         />
-        <FilterSetFilterDisplay filters={filterSet.filters} />
+        <FilterSetQueryDisplay filters={filterSet.filters} />
         {isFiltersChanged && (
-          <FilterSetFilterDisplay
+          <FilterSetQueryDisplay
             filters={currentFilters}
             title='Filters (changed)'
           />

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetFilterDisplay.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
-import { FilterDisplay } from '../ExplorerFilterDisplay';
+import QueryDisplay from '../../components/QueryDisplay';
+import { useExplorerConfig } from '../ExplorerConfigContext';
 import './FilterSetFilterDisplay.css';
 
 /**
@@ -8,13 +9,14 @@ import './FilterSetFilterDisplay.css';
  * @param {string} [props.title]
  */
 function FilterSetFilterDisplay({ filters, title = 'Filters' }) {
+  const filterInfo = useExplorerConfig().current.filterConfig.info;
   return (
     <div className='filter-set-filter-display'>
       {Object.keys(filters).length > 0 ? (
         <>
           <header>{title}</header>
           <main>
-            <FilterDisplay filter={filters} />
+            <QueryDisplay filter={filters} filterInfo={filterInfo} />
           </main>
         </>
       ) : (

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.css
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.css
@@ -1,13 +1,13 @@
-.filter-set-filter-display {
+.filter-set-query-display {
   margin: 1rem;
   min-height: 6.5rem;
 }
 
-.filter-set-filter-display header {
+.filter-set-query-display header {
   margin-bottom: 0.25rem;
 }
 
-.filter-set-filter-display main {
+.filter-set-query-display main {
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 12px;

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.jsx
@@ -1,17 +1,17 @@
 import PropTypes from 'prop-types';
 import QueryDisplay from '../../components/QueryDisplay';
 import { useExplorerConfig } from '../ExplorerConfigContext';
-import './FilterSetFilterDisplay.css';
+import './FilterSetQueryDisplay.css';
 
 /**
  * @param {Object} props
  * @param {import('../types').ExplorerFilters} props.filters
  * @param {string} [props.title]
  */
-function FilterSetFilterDisplay({ filters, title = 'Filters' }) {
+function FilterSetQueryDisplay({ filters, title = 'Filters' }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   return (
-    <div className='filter-set-filter-display'>
+    <div className='filter-set-query-display'>
       {Object.keys(filters).length > 0 ? (
         <>
           <header>{title}</header>
@@ -28,9 +28,9 @@ function FilterSetFilterDisplay({ filters, title = 'Filters' }) {
   );
 }
 
-FilterSetFilterDisplay.propTypes = {
+FilterSetQueryDisplay.propTypes = {
   filters: PropTypes.any,
   title: PropTypes.string,
 };
 
-export default FilterSetFilterDisplay;
+export default FilterSetQueryDisplay;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import SimpleInputField from '../../components/SimpleInputField';
-import FilterSetFilterDisplay from '../ExplorerFilterSet/FilterSetFilterDisplay';
+import FilterSetQueryDisplay from '../ExplorerFilterSet/FilterSetQueryDisplay';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
 
@@ -62,7 +62,7 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
               />
             }
           />
-          <FilterSetFilterDisplay filters={filterSet.filters} />
+          <FilterSetQueryDisplay filters={filterSet.filters} />
         </>
       ) : null}
     </div>

--- a/src/components/QueryDisplay.css
+++ b/src/components/QueryDisplay.css
@@ -7,6 +7,10 @@
   line-height: 2rem;
 }
 
+.query-display .pill[role='button'] {
+  cursor: pointer;
+}
+
 /* Tablet width and less */
 @media screen and (max-width: 820px) {
   .query-display .pill {

--- a/src/components/QueryDisplay.css
+++ b/src/components/QueryDisplay.css
@@ -1,0 +1,34 @@
+.query-display .pill {
+  background-color: var(--g3-color__bg-cloud);
+  border: 1px solid var(--g3-color__lightgray);
+  border-radius: 4px;
+  padding: 4px;
+  margin: 2px;
+  line-height: 2rem;
+}
+
+/* Tablet width and less */
+@media screen and (max-width: 820px) {
+  .query-display .pill {
+    font-size: 12px;
+  }
+}
+
+.query-display .pill.anchor {
+  padding: 8px 4px;
+  line-height: 2.2rem;
+}
+
+.query-display .pill > * {
+  border-right: 1px solid var(--g3-color__lightgray);
+  padding: 2px 4px;
+  margin: 0 2px;
+}
+
+.query-display .pill > *:last-child {
+  border-right: none;
+}
+
+.query-display .pill code {
+  background-color: inherit;
+}

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -8,6 +8,37 @@ import './QueryDisplay.css';
 
 /**
  * @param {Object} props
+ * @param {string} [props.className]
+ * @param {React.ReactNode} props.children
+ * @param {string} [props.filterKey]
+ * @param {React.EventHandler<any>} [props.onClick]
+ */
+function QueryPill({ className = 'pill', children, filterKey, onClick }) {
+  return typeof onClick === 'function' ? (
+    <span
+      className={className}
+      role='button'
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={onClick}
+      filter-key={filterKey}
+    >
+      {children}
+    </span>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+QueryPill.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  filterKey: PropTypes.element,
+  onClick: PropTypes.func,
+};
+
+/**
+ * @param {Object} props
  * @param {[anchorKey: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
  * @param {import('../GuppyComponents/types').FilterState} props.filter
@@ -46,7 +77,7 @@ function QueryDisplay({
     if ('filter' in value) {
       const [anchorKey, anchorValue] = key.split(':');
       filterElements.push(
-        <span key={key} className='pill anchor'>
+        <QueryPill key={key} className='pill anchor'>
           <span className='token field'>
             With <code>{filterInfo[anchorKey].label}</code> of{' '}
             <code>{`"${anchorValue}"`}</code>
@@ -62,19 +93,11 @@ function QueryDisplay({
             />{' '}
             )
           </span>
-        </span>
+        </QueryPill>
       );
     } else if ('selectedValues' in value) {
       filterElements.push(
-        <span
-          key={key}
-          className='pill'
-          role='button'
-          tabIndex={0}
-          onClick={handleClickFilter}
-          onKeyDown={handleClickFilter}
-          filter-key={key}
-        >
+        <QueryPill key={key} onClick={handleClickFilter} filterKey={key}>
           <span className='token'>
             <code>{filterInfo[key].label}</code>{' '}
             {value.selectedValues.length > 1 ? 'is any of ' : 'is '}
@@ -95,19 +118,11 @@ function QueryDisplay({
               <code>{`"${value.selectedValues[0]}"`}</code>
             )}
           </span>
-        </span>
+        </QueryPill>
       );
     } else {
       filterElements.push(
-        <span
-          key={key}
-          className='pill'
-          role='button'
-          tabIndex={0}
-          onClick={handleClickFilter}
-          onKeyDown={handleClickFilter}
-          filter-key={key}
-        >
+        <QueryPill key={key} onClick={handleClickFilter} filterKey={key}>
           <span className='token'>
             <code>{filterInfo[key].label}</code> is between
           </span>
@@ -116,7 +131,7 @@ function QueryDisplay({
               ({value.lowerBound}, {value.upperBound})
             </code>
           </span>
-        </span>
+        </QueryPill>
       );
     }
 
@@ -126,15 +141,9 @@ function QueryDisplay({
         <>
           {filterElement}
           {i < filterElements.length - 1 && (
-            <span
-              className='pill'
-              role='button'
-              tabIndex={0}
-              onClick={handleClickCombineMode}
-              onKeyDown={handleClickCombineMode}
-            >
+            <QueryPill onClick={handleClickCombineMode}>
               {queryCombineMode}
-            </span>
+            </QueryPill>
           )}
         </>
       ))}

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -1,0 +1,101 @@
+import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
+import 'rc-tooltip/assets/bootstrap_white.css';
+import './QueryDisplay.css';
+
+/**
+ * @param {Object} props
+ * @param {import('../GuppyComponents/types').FilterState} props.filter
+ * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
+ * @param {'AND' | 'OR'} [props.combineMode]
+ */
+function QueryDisplay({ filter, filterInfo, combineMode }) {
+  const filterElements = /** @type {JSX.Element[]} */ ([]);
+  const { __combineMode, ...__filter } = filter;
+  for (const [key, value] of Object.entries(__filter))
+    if ('filter' in value) {
+      const [anchorKey, anchorValue] = key.split(':');
+      filterElements.push(
+        <span key={key} className='pill anchor'>
+          <span className='token field'>
+            With <code>{filterInfo[anchorKey].label}</code> of{' '}
+            <code>{`"${anchorValue}"`}</code>
+          </span>
+          <span className='token'>
+            ({' '}
+            <QueryDisplay
+              filter={value.filter}
+              combineMode={__combineMode}
+              filterInfo={filterInfo}
+            />{' '}
+            )
+          </span>
+        </span>
+      );
+    } else if ('selectedValues' in value) {
+      filterElements.push(
+        <span key={key} className='pill'>
+          <span className='token'>
+            <code>{filterInfo[key].label}</code>{' '}
+            {value.selectedValues.length > 1 ? 'is any of ' : 'is '}
+          </span>
+          <span className='token'>
+            {value.selectedValues.length > 1 ? (
+              <Tooltip
+                arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                overlay={value.selectedValues.map((v) => `"${v}"`).join(', ')}
+                placement='bottom'
+                trigger={['hover', 'focus']}
+              >
+                <span>
+                  <code>{`"${value.selectedValues[0]}"`}</code>, ...
+                </span>
+              </Tooltip>
+            ) : (
+              <code>{`"${value.selectedValues[0]}"`}</code>
+            )}
+          </span>
+        </span>
+      );
+    } else {
+      filterElements.push(
+        <span key={key} className='pill'>
+          <span className='token'>
+            <code>{filterInfo[key].label}</code> is between
+          </span>
+          <span className='token'>
+            <code>
+              ({value.lowerBound}, {value.upperBound})
+            </code>
+          </span>
+        </span>
+      );
+    }
+
+  return (
+    <span className='query-display'>
+      {filterElements.map((filterElement, i) => (
+        <>
+          {filterElement}
+          {i < filterElements.length - 1 && (
+            <span className='pill'>
+              {combineMode ?? __combineMode ?? 'AND'}
+            </span>
+          )}
+        </>
+      ))}
+    </span>
+  );
+}
+
+QueryDisplay.propTypes = {
+  filter: PropTypes.any,
+  filterInfo: PropTypes.objectOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+    })
+  ),
+  combineMode: PropTypes.oneOf(['AND', 'OR']),
+};
+
+export default QueryDisplay;

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -156,7 +156,7 @@ function QueryDisplay({
 }
 
 QueryDisplay.propTypes = {
-  anchorInfo: PropTypes.string,
+  anchorInfo: PropTypes.arrayOf(PropTypes.string),
   combineMode: PropTypes.oneOf(['AND', 'OR']),
   filter: PropTypes.any.isRequired,
   filterInfo: PropTypes.objectOf(

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -33,7 +33,7 @@ function QueryPill({ className = 'pill', children, filterKey, onClick }) {
 QueryPill.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
-  filterKey: PropTypes.element,
+  filterKey: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
@@ -142,14 +143,14 @@ function QueryDisplay({
   return (
     <span className='query-display'>
       {filterElements.map((filterElement, i) => (
-        <>
+        <Fragment key={i}>
           {filterElement}
           {i < filterElements.length - 1 && (
             <QueryPill onClick={handleClickCombineMode}>
               {queryCombineMode}
             </QueryPill>
           )}
-        </>
+        </Fragment>
       ))}
     </span>
   );

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -56,22 +56,26 @@ function QueryDisplay({
   const { __combineMode, ...__filter } = filter;
   const queryCombineMode = combineMode ?? __combineMode ?? 'AND';
 
-  function handleClickCombineMode() {
-    onAction({
-      type: 'clickCombineMode',
-      payload: queryCombineMode,
-    });
-  }
-  function handleClickFilter(/** @type {React.SyntheticEvent} */ e) {
-    onAction({
-      type: 'clickFilter',
-      payload: {
-        filterKey: e.currentTarget.attributes.getNamedItem('filter-key').value,
-        anchorKey: anchorInfo?.[0],
-        anchorValue: anchorInfo?.[1],
-      },
-    });
-  }
+  const [handleClickCombineMode, handleClickFilter] =
+    typeof onAction === 'function'
+      ? [
+          () =>
+            onAction({
+              type: 'clickCombineMode',
+              payload: queryCombineMode,
+            }),
+          (/** @type {React.SyntheticEvent} */ e) =>
+            onAction({
+              type: 'clickFilter',
+              payload: {
+                filterKey:
+                  e.currentTarget.attributes.getNamedItem('filter-key').value,
+                anchorKey: anchorInfo?.[0],
+                anchorValue: anchorInfo?.[1],
+              },
+            }),
+        ]
+      : [];
 
   for (const [key, value] of Object.entries(__filter))
     if ('filter' in value) {

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -8,12 +8,19 @@ import './QueryDisplay.css';
 
 /**
  * @param {Object} props
+ * @param {[anchorKey: string, anchorValue: string]} [props.anchorInfo]
+ * @param {'AND' | 'OR'} [props.combineMode]
  * @param {import('../GuppyComponents/types').FilterState} props.filter
  * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
- * @param {'AND' | 'OR'} [props.combineMode]
  * @param {(action: QueryDisplayAction) => void} [props.onAction]
  */
-function QueryDisplay({ filter, filterInfo, combineMode, onAction }) {
+function QueryDisplay({
+  anchorInfo,
+  combineMode,
+  filter,
+  filterInfo,
+  onAction,
+}) {
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   const { __combineMode, ...__filter } = filter;
   const queryCombineMode = combineMode ?? __combineMode ?? 'AND';
@@ -27,7 +34,11 @@ function QueryDisplay({ filter, filterInfo, combineMode, onAction }) {
   function handleClickFilter(/** @type {React.SyntheticEvent} */ e) {
     onAction({
       type: 'clickFilter',
-      payload: e.currentTarget.attributes.getNamedItem('filter-key').value,
+      payload: {
+        filterKey: e.currentTarget.attributes.getNamedItem('filter-key').value,
+        anchorKey: anchorInfo?.[0],
+        anchorValue: anchorInfo?.[1],
+      },
     });
   }
 
@@ -43,6 +54,7 @@ function QueryDisplay({ filter, filterInfo, combineMode, onAction }) {
           <span className='token'>
             ({' '}
             <QueryDisplay
+              anchorInfo={[anchorKey, anchorValue]}
               filter={value.filter}
               filterInfo={filterInfo}
               combineMode={__combineMode}
@@ -131,13 +143,14 @@ function QueryDisplay({ filter, filterInfo, combineMode, onAction }) {
 }
 
 QueryDisplay.propTypes = {
+  anchorInfo: PropTypes.string,
+  combineMode: PropTypes.oneOf(['AND', 'OR']),
   filter: PropTypes.any.isRequired,
   filterInfo: PropTypes.objectOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
     })
   ),
-  combineMode: PropTypes.oneOf(['AND', 'OR']),
   onAction: PropTypes.func,
 };
 


### PR DESCRIPTION
Ticket: [PEDS-701](https://pcdc.atlassian.net/browse/PEDS-701)

This PR replaces `<FilterDisplay>` component with new `<QueryDisplay>` component that is 1) not coupled with explorer context (i.e. now expects`filterInfo` prop; this facilitates UI testing on storybook) and 2) capable of handling actions via optional `onAction` prop.

The following two action types are supported:

1. `"clickCombineMode"` action returns the current `combineMode` value of type `"AND" | '"OR"` as payload.
2. `"clickFilter"` action returns an object of type `{ filterKey: string; anchorKey?: string; anchorVale?: string }` as payload.

If `onAction` prop is not provided, `<QueryDisplay>` acts like `<FilterDisplay>` (i.e. read-only).