### PR TITLE
Refactor <QueryDisplay>

### DIFF
--- a/.storybook/stories/QueryDisplay.jsx
+++ b/.storybook/stories/QueryDisplay.jsx
@@ -35,7 +35,8 @@ storiesOf('QueryDisplay', module)
     <QueryDisplay
       filter={simpleFilter}
       filterInfo={filterInfo}
-      onAction={action('action')}
+      onClickCombineMode={action('clickCombineMode')}
+      onClickFilter={action('clickFilter')}
     />
   ))
   .add('Complex', () => (
@@ -46,6 +47,7 @@ storiesOf('QueryDisplay', module)
     <QueryDisplay
       filter={complexFilter}
       filterInfo={filterInfo}
-      onAction={action('action')}
+      onClickCombineMode={action('clickCombineMode')}
+      onClickFilter={action('clickFilter')}
     />
   ));

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -11,26 +11,19 @@ function ExplorerQueryController({ filter }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const { updateFilters } = useExplorerState();
 
-  /** @param {import('../../components/QueryDisplay').QueryDisplayAction} action */
-  function handleQueryDisplayAction({ type, payload }) {
-    switch (type) {
-      case 'clickCombineMode': {
-        const newCombineMode = payload === 'AND' ? 'OR' : 'AND';
-        updateFilters({ ...filter, __combineMode: newCombineMode });
-        break;
-      }
-      case 'clickFilter': {
-        const { filterKey, anchorKey, anchorValue } = payload;
-        if (anchorKey !== undefined && anchorValue !== undefined) {
-          const anchor = `${anchorKey}:${anchorValue}`;
-          updateFilters(pluckFromAnchorFilter({ anchor, filter, filterKey }));
-        } else {
-          updateFilters(pluckFromFilter({ filter, filterKey }));
-        }
-        break;
-      }
-      default:
-        break;
+  /** @type {import('../../components/QueryDisplay').ClickCombineModeHandler} */
+  function handleClickCombineMode(payload) {
+    const newCombineMode = payload === 'AND' ? 'OR' : 'AND';
+    updateFilters({ ...filter, __combineMode: newCombineMode });
+  }
+  /** @type {import('../../components/QueryDisplay').ClickFilterHandler} */
+  function handleClickFilter(payload) {
+    const { filterKey, anchorKey, anchorValue } = payload;
+    if (anchorKey !== undefined && anchorValue !== undefined) {
+      const anchor = `${anchorKey}:${anchorValue}`;
+      updateFilters(pluckFromAnchorFilter({ anchor, filter, filterKey }));
+    } else {
+      updateFilters(pluckFromFilter({ filter, filterKey }));
     }
   }
 
@@ -72,7 +65,8 @@ function ExplorerQueryController({ filter }) {
           <QueryDisplay
             filter={filter}
             filterInfo={filterInfo}
-            onAction={handleQueryDisplayAction}
+            onClickCombineMode={handleClickCombineMode}
+            onClickFilter={handleClickFilter}
           />
         </>
       ) : (

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -18,12 +18,12 @@ function ExplorerQueryController({ filter }) {
   }
   /** @type {import('../../components/QueryDisplay').ClickFilterHandler} */
   function handleClickFilter(payload) {
-    const { filterKey, anchorKey, anchorValue } = payload;
-    if (anchorKey !== undefined && anchorValue !== undefined) {
-      const anchor = `${anchorKey}:${anchorValue}`;
-      updateFilters(pluckFromAnchorFilter({ anchor, filter, filterKey }));
+    const { field, anchorField, anchorValue } = payload;
+    if (anchorField !== undefined && anchorValue !== undefined) {
+      const anchor = `${anchorField}:${anchorValue}`;
+      updateFilters(pluckFromAnchorFilter({ anchor, field, filter }));
     } else {
-      updateFilters(pluckFromFilter({ filter, filterKey }));
+      updateFilters(pluckFromFilter({ field, filter }));
     }
   }
 
@@ -39,8 +39,7 @@ function ExplorerQueryController({ filter }) {
   });
 
   const hasFilter =
-    Object.keys(pluckFromFilter({ filter, filterKey: '__combineMode' }))
-      .length > 0;
+    Object.keys(pluckFromFilter({ field: '__combineMode', filter })).length > 0;
   return (
     <div
       ref={ref}

--- a/src/GuppyDataExplorer/ExplorerQueryController/utils.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/utils.js
@@ -1,20 +1,28 @@
-export function pluckFromFilter({ filter, filterKey }) {
+/**
+ * @param {Object} args
+ * @param {string} args.field
+ * @param {import("../types").ExplorerFilters} args.filter
+ */
+export function pluckFromFilter({ field, filter }) {
   const newFilter = {};
   for (const [key, value] of Object.entries(filter))
-    if (key !== filterKey) newFilter[key] = value;
+    if (key !== field) newFilter[key] = value;
 
   return newFilter;
 }
 
-export function pluckFromAnchorFilter({ anchor, filter, filterKey }) {
+/**
+ * @param {Object} args
+ * @param {string} args.anchor
+ * @param {string} args.field
+ * @param {import("../types").ExplorerFilters} args.filter
+ */
+export function pluckFromAnchorFilter({ anchor, field, filter }) {
   const newFilter = {};
   for (const [key, value] of Object.entries(filter))
     if (key !== anchor) newFilter[key] = value;
     else if (typeof value === 'object' && 'filter' in value) {
-      const newAnchorFilter = pluckFromFilter({
-        filter: value.filter,
-        filterKey,
-      });
+      const newAnchorFilter = pluckFromFilter({ field, filter: value.filter });
       if (Object.keys(newAnchorFilter).length > 0)
         newFilter[key] = { filter: newAnchorFilter };
     }

--- a/src/components/QueryDisplay.css
+++ b/src/components/QueryDisplay.css
@@ -4,11 +4,13 @@
   border-radius: 4px;
   padding: 4px;
   margin: 2px;
-  line-height: 2rem;
-}
-
-.query-display .pill[role='button'] {
-  cursor: pointer;
+  line-height: 1rem;
+  letter-spacing: normal;
+  color: inherit;
+  height: inherit;
+  width: inherit;
+  display: inline-block;
+  vertical-align: baseline;
 }
 
 /* Tablet width and less */
@@ -19,8 +21,8 @@
 }
 
 .query-display .pill.anchor {
-  padding: 8px 4px;
-  line-height: 2.2rem;
+  padding: 1px 4px;
+  line-height: 1rem;
 }
 
 .query-display .pill > * {

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -5,20 +5,12 @@ import 'rc-tooltip/assets/bootstrap_white.css';
 import './QueryDisplay.css';
 
 /**
- * @typedef {Object} ClickCombineModeAction
- * @property {'clickCombineMode'} type
- * @property {'AND' | 'OR'} payload
+ * @callback ClickCombineModeHandler
+ * @param {'AND' | 'OR'} payload
  */
 /**
- * @typedef {Object} ClickFilterAction
- * @property {'clickFilter'} type
- * @property {Object} payload
- * @property {string} [payload.anchorKey]
- * @property {string} [payload.anchorValue]
- * @property {string} payload.filterKey
- */
-/**
- * @typedef {ClickCombineModeAction | ClickFilterAction} QueryDisplayAction
+ * @callback ClickFilterHandler
+ * @param {{ anchorKey?: string; anchorValue?: string; filterKey: string }} payload
  */
 
 /**
@@ -58,39 +50,31 @@ QueryPill.propTypes = {
  * @param {'AND' | 'OR'} [props.combineMode]
  * @param {import('../GuppyComponents/types').FilterState} props.filter
  * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
- * @param {(action: QueryDisplayAction) => void} [props.onAction]
+ * @param {ClickCombineModeHandler} [props.onClickCombineMode]
+ * @param {ClickFilterHandler} [props.onClickFilter]
  */
 function QueryDisplay({
   anchorInfo,
   combineMode,
   filter,
   filterInfo,
-  onAction,
+  onClickCombineMode,
+  onClickFilter,
 }) {
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   const { __combineMode, ...__filter } = filter;
   const queryCombineMode = combineMode ?? __combineMode ?? 'AND';
 
-  const [handleClickCombineMode, handleClickFilter] =
-    typeof onAction === 'function'
-      ? [
-          () =>
-            onAction({
-              type: 'clickCombineMode',
-              payload: queryCombineMode,
-            }),
-          (/** @type {React.SyntheticEvent} */ e) =>
-            onAction({
-              type: 'clickFilter',
-              payload: {
-                filterKey:
-                  e.currentTarget.attributes.getNamedItem('filter-key').value,
-                anchorKey: anchorInfo?.[0],
-                anchorValue: anchorInfo?.[1],
-              },
-            }),
-        ]
-      : [];
+  function handleClickCombineMode() {
+    onClickCombineMode?.(queryCombineMode);
+  }
+  function handleClickFilter(/** @type {React.SyntheticEvent} */ e) {
+    onClickFilter?.({
+      filterKey: e.currentTarget.attributes.getNamedItem('filter-key').value,
+      anchorKey: anchorInfo?.[0],
+      anchorValue: anchorInfo?.[1],
+    });
+  }
 
   for (const [key, value] of Object.entries(__filter))
     if ('filter' in value) {
@@ -108,7 +92,8 @@ function QueryDisplay({
               filter={value.filter}
               filterInfo={filterInfo}
               combineMode={__combineMode}
-              onAction={onAction}
+              onClickCombineMode={onClickCombineMode}
+              onClickFilter={onClickFilter}
             />{' '}
             )
           </span>
@@ -179,7 +164,8 @@ QueryDisplay.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ),
-  onAction: PropTypes.func,
+  onClickCombineMode: PropTypes.func,
+  onClickFilter: PropTypes.func,
 };
 
 export default QueryDisplay;

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -22,16 +22,14 @@ import './QueryDisplay.css';
  */
 function QueryPill({ className = 'pill', children, filterKey, onClick }) {
   return typeof onClick === 'function' ? (
-    <span
+    <button
       className={className}
-      role='button'
-      tabIndex={0}
+      type='button'
       onClick={onClick}
-      onKeyDown={onClick}
       filter-key={filterKey}
     >
       {children}
-    </span>
+    </button>
   ) : (
     <span className={className}>{children}</span>
   );

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -10,7 +10,7 @@ import './QueryDisplay.css';
  */
 /**
  * @callback ClickFilterHandler
- * @param {{ anchorKey?: string; anchorValue?: string; filterKey: string }} payload
+ * @param {{ anchorField?: string; anchorValue?: string; field: string }} payload
  */
 
 /**
@@ -46,7 +46,7 @@ QueryPill.propTypes = {
 
 /**
  * @param {Object} props
- * @param {[anchorKey: string, anchorValue: string]} [props.anchorInfo]
+ * @param {[anchorField: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
  * @param {import('../GuppyComponents/types').FilterState} props.filter
  * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
@@ -70,25 +70,25 @@ function QueryDisplay({
   }
   function handleClickFilter(/** @type {React.SyntheticEvent} */ e) {
     onClickFilter?.({
-      filterKey: e.currentTarget.attributes.getNamedItem('filter-key').value,
-      anchorKey: anchorInfo?.[0],
+      field: e.currentTarget.attributes.getNamedItem('filter-key').value,
+      anchorField: anchorInfo?.[0],
       anchorValue: anchorInfo?.[1],
     });
   }
 
   for (const [key, value] of Object.entries(__filter))
     if ('filter' in value) {
-      const [anchorKey, anchorValue] = key.split(':');
+      const [anchorField, anchorValue] = key.split(':');
       filterElements.push(
         <QueryPill key={key} className='pill anchor'>
           <span className='token field'>
-            With <code>{filterInfo[anchorKey].label}</code> of{' '}
+            With <code>{filterInfo[anchorField].label}</code> of{' '}
             <code>{`"${anchorValue}"`}</code>
           </span>
           <span className='token'>
             ({' '}
             <QueryDisplay
-              anchorInfo={[anchorKey, anchorValue]}
+              anchorInfo={[anchorField, anchorValue]}
               filter={value.filter}
               filterInfo={filterInfo}
               combineMode={__combineMode}

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -65,16 +65,20 @@ function QueryDisplay({
   const { __combineMode, ...__filter } = filter;
   const queryCombineMode = combineMode ?? __combineMode ?? 'AND';
 
-  function handleClickCombineMode() {
-    onClickCombineMode?.(queryCombineMode);
-  }
-  function handleClickFilter(/** @type {React.SyntheticEvent} */ e) {
-    onClickFilter?.({
-      field: e.currentTarget.attributes.getNamedItem('filter-key').value,
-      anchorField: anchorInfo?.[0],
-      anchorValue: anchorInfo?.[1],
-    });
-  }
+  const handleClickCombineMode =
+    typeof onClickCombineMode === 'function'
+      ? () => onClickCombineMode(queryCombineMode)
+      : undefined;
+  const handleClickFilter =
+    typeof onClickFilter === 'function'
+      ? (/** @type {React.SyntheticEvent} */ e) => {
+          onClickFilter({
+            field: e.currentTarget.attributes.getNamedItem('filter-key').value,
+            anchorField: anchorInfo?.[0],
+            anchorValue: anchorInfo?.[1],
+          });
+        }
+      : undefined;
 
   for (const [key, value] of Object.entries(__filter))
     if ('filter' in value) {


### PR DESCRIPTION
This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/375 and makes the following changes to the component:

* Use `<button>` for interactive pill rather than abusing `<span>` to serve as button.
* Replace all-in-one `onAction` prop with separate `onClickCombineMode` and `onClickFilter` props
  * Modify parameter type for new callback/event-handler props
    * `onClickCombineMode` parameter is now simply the new `combineMode` value
    * `onClickFilter` parameter is now the object of type `{ field: string; anchorField?: string; anchorValue?: string }`

