### PR TITLE
Use separate button/handler to close filter in <QueryDisplay>

### DIFF
--- a/.storybook/stories/QueryDisplay.jsx
+++ b/.storybook/stories/QueryDisplay.jsx
@@ -32,22 +32,59 @@ storiesOf('QueryDisplay', module)
     <QueryDisplay filter={simpleFilter} filterInfo={filterInfo} />
   ))
   .add('Simple with action', () => (
-    <QueryDisplay
-      filter={simpleFilter}
-      filterInfo={filterInfo}
-      onClickCombineMode={action('clickCombineMode')}
-      onClickFilter={action('clickFilter')}
-    />
+    <>
+      <div style={{ marginBottom: '1rem' }}>
+        <p>
+          Handle click <code>combineMode</code> and click <code>filter</code>:
+        </p>
+        <QueryDisplay
+          filter={simpleFilter}
+          filterInfo={filterInfo}
+          onClickCombineMode={action('clickCombineMode')}
+          onClickFilter={action('clickFilter')}
+        />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <p>
+          Handle click <code>combineMode</code> and close <code>filter</code>:
+        </p>
+        <QueryDisplay
+          filter={simpleFilter}
+          filterInfo={filterInfo}
+          onClickCombineMode={action('clickCombineMode')}
+          onCloseFilter={action('closeFilter')}
+        />
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <p>
+          Handle click <code>combineMode</code> and click/close{' '}
+          <code>filter</code>:
+        </p>
+        <QueryDisplay
+          filter={simpleFilter}
+          filterInfo={filterInfo}
+          onClickCombineMode={action('clickCombineMode')}
+          onClickFilter={action('clickFilter')}
+          onCloseFilter={action('closeFilter')}
+        />
+      </div>
+    </>
   ))
   .add('Complex', () => (
     <QueryDisplay filter={complexFilter} filterInfo={filterInfo} />
   ))
-
   .add('Complex with action', () => (
-    <QueryDisplay
-      filter={complexFilter}
-      filterInfo={filterInfo}
-      onClickCombineMode={action('clickCombineMode')}
-      onClickFilter={action('clickFilter')}
-    />
+    <div>
+      <p>
+        Handle click <code>combineMode</code> and click/close{' '}
+        <code>filter</code>:
+      </p>
+      <QueryDisplay
+        filter={complexFilter}
+        filterInfo={filterInfo}
+        onClickCombineMode={action('clickCombineMode')}
+        onClickFilter={action('clickFilter')}
+        onCloseFilter={action('closeFilter')}
+      />
+    </div>
   ));

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -17,7 +17,7 @@ function ExplorerQueryController({ filter }) {
     updateFilters({ ...filter, __combineMode: newCombineMode });
   }
   /** @type {import('../../components/QueryDisplay').ClickFilterHandler} */
-  function handleClickFilter(payload) {
+  function handleCloseFilter(payload) {
     const { field, anchorField, anchorValue } = payload;
     if (anchorField !== undefined && anchorValue !== undefined) {
       const anchor = `${anchorField}:${anchorValue}`;
@@ -65,7 +65,7 @@ function ExplorerQueryController({ filter }) {
             filter={filter}
             filterInfo={filterInfo}
             onClickCombineMode={handleClickCombineMode}
-            onClickFilter={handleClickFilter}
+            onCloseFilter={handleCloseFilter}
           />
         </>
       ) : (

--- a/src/components/QueryDisplay.css
+++ b/src/components/QueryDisplay.css
@@ -1,16 +1,38 @@
-.query-display .pill {
+.query-display .pill-container {
+  display: inline-block;
   background-color: var(--g3-color__bg-cloud);
   border: 1px solid var(--g3-color__lightgray);
   border-radius: 4px;
-  padding: 4px;
+  padding: 1px 4px;
   margin: 2px;
-  line-height: 1rem;
-  letter-spacing: normal;
+}
+
+.query-display button {
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
   color: inherit;
   height: inherit;
   width: inherit;
-  display: inline-block;
   vertical-align: baseline;
+  font-size: inherit;
+}
+
+.query-display .pill {
+  letter-spacing: normal;
+}
+
+.query-display .close {
+  border-left: 1px solid var(--g3-color__lightgray);
+  border-radius: 0;
+  padding: 0 4px;
+  height: 100%;
+}
+
+.query-display .pill-container > .close > i {
+  background-color: var(--g3-color__gray);
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 /* Tablet width and less */
@@ -18,11 +40,6 @@
   .query-display .pill {
     font-size: 12px;
   }
-}
-
-.query-display .pill.anchor {
-  padding: 1px 4px;
-  line-height: 1rem;
 }
 
 .query-display .pill > * {

--- a/src/components/QueryDisplay.jsx
+++ b/src/components/QueryDisplay.jsx
@@ -19,19 +19,40 @@ import './QueryDisplay.css';
  * @param {React.ReactNode} props.children
  * @param {string} [props.filterKey]
  * @param {React.EventHandler<any>} [props.onClick]
+ * @param {React.EventHandler<any>} [props.onClose]
  */
-function QueryPill({ className = 'pill', children, filterKey, onClick }) {
-  return typeof onClick === 'function' ? (
-    <button
-      className={className}
-      type='button'
-      onClick={onClick}
-      filter-key={filterKey}
-    >
-      {children}
-    </button>
-  ) : (
-    <span className={className}>{children}</span>
+function QueryPill({
+  className = 'pill',
+  children,
+  filterKey,
+  onClick,
+  onClose,
+}) {
+  return (
+    <div className='pill-container'>
+      {typeof onClick === 'function' ? (
+        <button
+          className={className}
+          type='button'
+          onClick={onClick}
+          filter-key={filterKey}
+        >
+          {children}
+        </button>
+      ) : (
+        <span className={className}>{children}</span>
+      )}
+      {typeof onClose === 'function' ? (
+        <button
+          className='pill close'
+          type='button'
+          onClick={onClose}
+          filter-key={filterKey}
+        >
+          <i className='g3-icon g3-icon--cross g3-icon--sm' />
+        </button>
+      ) : null}
+    </div>
   );
 }
 
@@ -40,6 +61,7 @@ QueryPill.propTypes = {
   children: PropTypes.node.isRequired,
   filterKey: PropTypes.string,
   onClick: PropTypes.func,
+  onClose: PropTypes.func,
 };
 
 /**
@@ -50,6 +72,7 @@ QueryPill.propTypes = {
  * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]
+ * @param {ClickFilterHandler} [props.onCloseFilter]
  */
 function QueryDisplay({
   anchorInfo,
@@ -58,6 +81,7 @@ function QueryDisplay({
   filterInfo,
   onClickCombineMode,
   onClickFilter,
+  onCloseFilter,
 }) {
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   const { __combineMode, ...__filter } = filter;
@@ -71,6 +95,16 @@ function QueryDisplay({
     typeof onClickFilter === 'function'
       ? (/** @type {React.SyntheticEvent} */ e) => {
           onClickFilter({
+            field: e.currentTarget.attributes.getNamedItem('filter-key').value,
+            anchorField: anchorInfo?.[0],
+            anchorValue: anchorInfo?.[1],
+          });
+        }
+      : undefined;
+  const handleCloseFilter =
+    typeof onCloseFilter === 'function'
+      ? (/** @type {React.SyntheticEvent} */ e) => {
+          onCloseFilter({
             field: e.currentTarget.attributes.getNamedItem('filter-key').value,
             anchorField: anchorInfo?.[0],
             anchorValue: anchorInfo?.[1],
@@ -96,6 +130,7 @@ function QueryDisplay({
               combineMode={__combineMode}
               onClickCombineMode={onClickCombineMode}
               onClickFilter={onClickFilter}
+              onCloseFilter={onCloseFilter}
             />{' '}
             )
           </span>
@@ -103,7 +138,12 @@ function QueryDisplay({
       );
     } else if ('selectedValues' in value) {
       filterElements.push(
-        <QueryPill key={key} onClick={handleClickFilter} filterKey={key}>
+        <QueryPill
+          key={key}
+          onClick={handleClickFilter}
+          onClose={handleCloseFilter}
+          filterKey={key}
+        >
           <span className='token'>
             <code>{filterInfo[key].label}</code>{' '}
             {value.selectedValues.length > 1 ? 'is any of ' : 'is '}
@@ -128,7 +168,12 @@ function QueryDisplay({
       );
     } else {
       filterElements.push(
-        <QueryPill key={key} onClick={handleClickFilter} filterKey={key}>
+        <QueryPill
+          key={key}
+          onClick={handleClickFilter}
+          onClose={handleCloseFilter}
+          filterKey={key}
+        >
           <span className='token'>
             <code>{filterInfo[key].label}</code> is between
           </span>
@@ -168,6 +213,7 @@ QueryDisplay.propTypes = {
   ),
   onClickCombineMode: PropTypes.func,
   onClickFilter: PropTypes.func,
+  onCloseFilter: PropTypes.func,
 };
 
 export default QueryDisplay;


### PR DESCRIPTION
This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/376 and https://github.com/chicagopcdc/data-portal/pull/377 and implements separate handler prop (`onCloseFilter`) & button to close filter pill. This change is meant to fix potentially confusing UX where a user clicks individual filter pills on `<QueryDisplay>` without any intention to remove it from the query. 

See the following screenshot image (with a "close" button focused):

<img width="954" alt="image" src="https://user-images.githubusercontent.com/22449454/165550922-f1b329ac-d30a-466c-af09-dda01b88dd6f.png">


`onCloseFilter` parameter is the object of type `{ field: string; anchorField?: string; anchorValue?: string }` (just like `onClickFilter`).


