### PR TITLE
Display survival error message PEDS-726

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -32,6 +32,16 @@
   margin: 1rem auto;
 }
 
+.explorer-survival-analysis__error-message {
+  margin-bottom: 1rem;
+  text-align: initial;
+}
+
+.explorer-survival-analysis__error-message > pre {
+  background: var(--g3-color__bg-cloud);
+  padding: 0.5rem;
+}
+
 .explorer-survival-analysis__control-form {
   margin: 12px;
   min-height: 300px;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/index.jsx
@@ -22,6 +22,7 @@ function ExplorerSurvivalAnalysis() {
   const [endTime, setEndTime] = useState(undefined);
 
   const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState(null);
   /** @type {UserInputSubmitHandler} */
   const handleSubmit = ({
     timeInterval,
@@ -30,14 +31,15 @@ function ExplorerSurvivalAnalysis() {
     efsFlag,
     usedFilterSets,
   }) => {
+    setError(null);
     setIsUpdating(true);
     setTimeInterval(timeInterval);
     setStartTime(startTime);
     setEndTime(endTime);
 
-    refershResult({ efsFlag, usedFilterSets }).finally(() =>
-      setIsUpdating(false)
-    );
+    refershResult({ efsFlag, usedFilterSets })
+      .catch(setError)
+      .finally(() => setIsUpdating(false));
   };
 
   const { survivalAnalysisConfig: config } = useExplorerConfig().current;
@@ -61,6 +63,13 @@ function ExplorerSurvivalAnalysis() {
                 fallback={
                   <div className='explorer-survival-analysis__error'>
                     <h1>Error obtaining survival analysis result...</h1>
+                    {error?.message ? (
+                      <p className='explorer-survival-analysis__error-message'>
+                        <pre>
+                          <strong>Error message:</strong> {error.message}
+                        </pre>
+                      </p>
+                    ) : null}
                     <p>
                       Please retry by clicking {'"Apply"'} button or refreshing
                       the page. If the problem persists, please contact the

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -106,7 +106,10 @@ export default function useSurvivalAnalysisResult() {
     if (body.filterSets.length > 0)
       return fetchResult(body)
         .then((data) => setResult({ ...cache, ...data }))
-        .catch(() => setResult(null));
+        .catch((e) => {
+          setResult(null);
+          throw e;
+        });
 
     setResult(cache);
     return Promise.resolve();

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -76,6 +76,7 @@ export default function useSurvivalAnalysisResult() {
       method: 'POST',
       body: JSON.stringify({ ...body, explorerId, result: config.result }),
     }).then(({ response, data, status }) => {
+      if (status === 404) throw data;
       if (status !== 200) throw response.statusText;
       return data;
     });


### PR DESCRIPTION
Ticket: [PEDS-726](https://pcdc.atlassian.net/browse/PEDS-726)

This PR adds server-provided error message to the `<ErrorBoundary>` fallback element in `<ExplorerSurvivalAnalysis>`. This is implemented to support the survival analysis tool to inform users when their attempt fails due to missing survival data for the select cohort.

 See the following screenshot:

![image](https://user-images.githubusercontent.com/22449454/166070207-77492c67-fd8b-4406-9731-1bc06dafa71a.png)
