### PR TITLE
Patch release 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.10",

--- a/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/FilterSetQueryDisplay.jsx
@@ -12,7 +12,7 @@ function FilterSetQueryDisplay({ filter, title = 'Filters' }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   return (
     <div className='filter-set-query-display'>
-      {Object.keys(filter).length > 0 ? (
+      {Object.keys(filter ?? {}).length > 0 ? (
         <>
           <header>{title}</header>
           <main>

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -4,8 +4,25 @@ import { fetchWithCreds } from '../actions';
 import { useExplorerConfig } from './ExplorerConfigContext';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('./types').ExplorerFilterSetDTO} ExplorerFilterSetDTO */
 
 const FILTER_SET_URL = '/amanuensis/filter-sets';
+
+/**
+ * @param {ExplorerFilterSet} filterSet
+ * @returns {ExplorerFilterSetDTO}
+ */
+function convertToFilterSetDTO({ filter: filters, ...rest }) {
+  return { filters, ...rest };
+}
+
+/**
+ * @param {ExplorerFilterSetDTO} filterSetDTO
+ * @returns {ExplorerFilterSet}
+ */
+function convertFromFilterSetDTO({ filters: filter, ...rest }) {
+  return { filter, ...rest };
+}
 
 /**
  * @param {number} explorerId
@@ -24,7 +41,7 @@ function fetchFilterSets(explorerId) {
       !Array.isArray(data.filter_sets)
     )
       throw new Error('Error: Incorrect Response Data');
-    return data.filter_sets;
+    return data.filter_sets.map(convertFromFilterSetDTO);
   });
 }
 
@@ -37,7 +54,7 @@ export function createFilterSet(explorerId, filterSet) {
   return fetchWithCreds({
     path: `${FILTER_SET_URL}?explorerId=${explorerId}`,
     method: 'POST',
-    body: JSON.stringify(filterSet),
+    body: JSON.stringify(convertToFilterSetDTO(filterSet)),
   }).then(({ response, data, status }) => {
     if (status !== 200) throw response.statusText;
     return data;
@@ -66,7 +83,7 @@ export function updateFilterSet(explorerId, filterSet) {
   return fetchWithCreds({
     path: `${FILTER_SET_URL}/${id}?explorerId=${explorerId}`,
     method: 'PUT',
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(convertToFilterSetDTO(requestBody)),
   }).then(({ response, status }) => {
     if (status !== 200) throw response.statusText;
   });

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -104,3 +104,11 @@ export type ExplorerFilterSet = {
   id?: number;
   name: string;
 };
+
+export type ExplorerFilterSetDTO = {
+  description: string;
+  explorerId?: number;
+  filters: ExplorerFilter;
+  id?: number;
+  name: string;
+};


### PR DESCRIPTION
This PR bumps the project version to 1.5.1.

The PR includes the fix for crashing data explorer page due to the mismatch between data structures for the portal and `/filter-set` service API for filter value. This was introduced by a recent refactoring effort to keep naming for relevant variables more consistent throughout the portal codebase (https://github.com/chicagopcdc/data-portal/pull/379), specifically by this commit: https://github.com/chicagopcdc/data-portal/commit/e274f6778cf623445fc69627cc78765702005f25.

The PR also includes a smaller fix for unhandled missing `filter` value (`null` or `undefined` instead of `{}`) in `<FilterSetQueryDisplay>` (although this really shouldn't happen in normal circumstances).