### PR TITLE
Patch release 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.10",

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -20,8 +20,15 @@ function convertToFilterSetDTO({ filter: filters, ...rest }) {
  * @param {ExplorerFilterSetDTO} filterSetDTO
  * @returns {ExplorerFilterSet}
  */
-function convertFromFilterSetDTO({ filters: filter, ...rest }) {
-  return { filter, ...rest };
+function convertFromFilterSetDTO({ filters, ...rest }) {
+  return {
+    filter:
+      '__combineMode' in filters
+        ? filters
+        : // backward compat for old filter sets missing __combineMode value
+          { __combineMode: 'AND', ...filters },
+    ...rest,
+  };
 }
 
 /**


### PR DESCRIPTION
This PR bumps the project version to 1.5.2.

The PR includes a fix for crashing data explorer page due to the missing `__combineMode` value in the filter for filter sets created using the older versions of the portal  (i.e. before v1.5). The current portal version (v1.5) has added the support for the top-level "OR" combine mode (https://github.com/chicagopcdc/data-portal/pull/371) and now expects the filter object to always have a top-level `__combineMode` value (`"AND" | "OR"`). To comply with this expectation, the fix checks for each filter set filter on fetching data and sets its `__combineMode` value to `"AND"` if missing. 