### PR TITLE
Enable react refresh via webpack PEDS-221

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3322,9 +3322,9 @@
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.5.tgz",
-      "integrity": "sha512-RbG7h6TuP6nFFYKJwbcToA1rjC1FyPg25NR2noAZ0vKI+la01KTSRPkuVPE+U88jXv7javx2JHglUcL1MHcshQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.6.tgz",
+      "integrity": "sha512-IIWxofIYt/AbMwoeBgj+O2aAXLrlCQVg+A4a2zfpXFNHgP8o8rvi3v+oe5t787Lj+KXlKOh8BAiUp9bhuELXhg==",
       "dev": true,
       "requires": {
         "ansi-html-community": "^0.0.8",
@@ -8167,6 +8167,12 @@
               }
             }
           }
+        },
+        "react-refresh": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
+          "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+          "dev": true
         },
         "schema-utils": {
           "version": "1.0.0",
@@ -22136,9 +22142,9 @@
       }
     },
     "react-refresh": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
       "dev": true
     },
     "react-relay": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.6",
     "@storybook/addon-actions": "^6.4.22",
     "@storybook/addon-essentials": "^6.4.22",
     "@storybook/addon-links": "^6.4.22",
@@ -96,6 +97,7 @@
     "jest-environment-jsdom": "^28.0.2",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.6.2",
+    "react-refresh": "^0.13.0",
     "react-test-renderer": "^17.0.2",
     "redux-mock-store": "^1.5.4",
     "stylelint": "^14.8.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const CompressionPlugin = require('compression-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const path = require('path');
 const portalVersion = require('./package.json').version;
 
@@ -76,6 +77,9 @@ if (isProduction) {
 } else {
   // add sourcemap tools for development mode
   devtool = 'eval-source-map';
+
+  // add react-refresh to plugins for development mode
+  plugins.push(new ReactRefreshWebpackPlugin());
 }
 
 module.exports = {
@@ -117,6 +121,9 @@ module.exports = {
         exclude:
           /node_modules\/(?!(graphiql|graphql-language-service-parser)\/).*/,
         loader: 'babel-loader',
+        options: isProduction
+          ? undefined
+          : { plugins: [require.resolve('react-refresh/babel')] },
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
Ticket: [PEDS-221](https://pcdc.atlassian.net/browse/PEDS-221)

This PR enables fast refresh (a.k.a. hot module replacement or hot reloading) for React app. This allows changes to the React code to be applied without full-page reload, which is a great DX win.