### PR TITLE
Update data requests download data UX PEDS-724

### DIFF
--- a/src/DataRequests/DataDownloadButton.jsx
+++ b/src/DataRequests/DataDownloadButton.jsx
@@ -1,21 +1,27 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import Button from '../gen3-ui-component/components/Button';
 
 /** @param {{ project: import('./index.jsx').DataRequestProject }} props */
 function DataDownloadButton({ project }) {
+  const [isLoading, setIsLoading] = useState(false);
+  function handleClick() {
+    setIsLoading(true);
+    fetch(`/amanuensis/download-urls/${project.id}`)
+      .then((res) => res.json())
+      .then((data) =>
+        window.open(data.download_url, '_blank', 'noopener, noreferrer')
+      )
+      .finally(() => setIsLoading(false));
+  }
   return (
     <Button
       buttonType='primary'
       enabled={project.status === 'Data Delivered' && project.has_access}
-      onClick={() =>
-        fetch(`/amanuensis/download-urls/${project.id}`)
-          .then((res) => res.json())
-          .then((data) =>
-            window.open(data.download_url, '_blank', 'noopener, noreferrer')
-          )
-      }
+      onClick={handleClick}
       label='Download Data'
       rightIcon='download'
+      isPending={isLoading}
     />
   );
 }

--- a/src/DataRequests/DataDownloadButton.jsx
+++ b/src/DataRequests/DataDownloadButton.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import Button from '../gen3-ui-component/components/Button';
+
+/** @param {{ project: import('./index.jsx').DataRequestProject }} props */
+function DataDownloadButton({ project }) {
+  return (
+    <Button
+      buttonType='primary'
+      enabled={project.status === 'Data Delivered' && project.has_access}
+      onClick={() =>
+        fetch(`/amanuensis/download-urls/${project.id}`)
+          .then((res) => res.json())
+          .then((data) =>
+            window.open(data.download_url, '_blank', 'noopener, noreferrer')
+          )
+      }
+      label='Download Data'
+      rightIcon='download'
+    />
+  );
+}
+
+DataDownloadButton.propTypes = {
+  project: PropTypes.shape({
+    has_access: PropTypes.bool,
+    id: PropTypes.number,
+    status: PropTypes.oneOf([
+      'Approved',
+      'Rejected',
+      'In Review',
+      'Data Delivered',
+    ]),
+  }),
+};
+
+export default DataDownloadButton;

--- a/src/DataRequests/DataDownloadButton.jsx
+++ b/src/DataRequests/DataDownloadButton.jsx
@@ -5,24 +5,37 @@ import Button from '../gen3-ui-component/components/Button';
 /** @param {{ project: import('./index.jsx').DataRequestProject }} props */
 function DataDownloadButton({ project }) {
   const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
   function handleClick() {
+    if (isError) setIsError(false);
     setIsLoading(true);
     fetch(`/amanuensis/download-urls/${project.id}`)
       .then((res) => res.json())
       .then((data) =>
         window.open(data.download_url, '_blank', 'noopener, noreferrer')
       )
+      .catch((err) => {
+        setIsError(true);
+        throw err;
+      })
       .finally(() => setIsLoading(false));
   }
   return (
-    <Button
-      buttonType='primary'
-      enabled={project.status === 'Data Delivered' && project.has_access}
-      onClick={handleClick}
-      label='Download Data'
-      rightIcon='download'
-      isPending={isLoading}
-    />
+    <div className='download-button'>
+      <Button
+        buttonType='primary'
+        enabled={project.status === 'Data Delivered' && project.has_access}
+        onClick={handleClick}
+        label='Download Data'
+        rightIcon='download'
+        isPending={isLoading}
+      />
+      {isError && (
+        <p className='download-button__error-message'>
+          Something went wrong! Try again.
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -35,3 +35,13 @@
 .data-requests__error > h2 {
   display: block !important;
 }
+
+.data-requests .download-button {
+  min-width: 240px;
+}
+
+.data-requests .download-button__error-message {
+  color: red;
+  font-size: 0.8rem;
+  font-style: italic;
+}

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -13,7 +13,8 @@
   color: inherit;
 }
 
-.data-requests__status-approved {
+.data-requests__status-approved,
+.data-requests__status-data-delivered {
   color: var(--pcdc-color__primary);
 }
 

--- a/src/DataRequests/DataRequestsTable.jsx
+++ b/src/DataRequests/DataRequestsTable.jsx
@@ -59,7 +59,7 @@ function parseTableData(projects, showApprovedOnly, userId) {
       project.has_access ? (
         <Button
           buttonType='primary'
-          enabled={project.status === 'Approved' && project.has_access}
+          enabled={project.status === 'Data Delivered' && project.has_access}
           onClick={() =>
             fetch(`/amanuensis/download-urls/${project.id}`)
               .then((res) => res.json())

--- a/src/DataRequests/DataRequestsTable.jsx
+++ b/src/DataRequests/DataRequestsTable.jsx
@@ -5,6 +5,7 @@ import Spinner from '../components/Spinner';
 import Table from '../components/tables/base/Table';
 import Button from '../gen3-ui-component/components/Button';
 import { formatLocalTime } from '../utils';
+import DataDownloadButton from './DataDownloadButton';
 import './DataRequests.css';
 
 /** @typedef {import('../types').UserState} UserState */
@@ -57,21 +58,7 @@ function parseTableData({ projects, showApprovedOnly, userId }) {
       >
         {project.status}
       </span>,
-      project.has_access ? (
-        <Button
-          buttonType='primary'
-          enabled={project.status === 'Data Delivered' && project.has_access}
-          onClick={() =>
-            fetch(`/amanuensis/download-urls/${project.id}`)
-              .then((res) => res.json())
-              .then((data) =>
-                window.open(data.download_url, '_blank', 'noopener, noreferrer')
-              )
-          }
-          label='Download Data'
-          rightIcon='download'
-        />
-      ) : null,
+      project.has_access ? <DataDownloadButton project={project} /> : null,
     ]);
 }
 

--- a/src/DataRequests/DataRequestsTable.jsx
+++ b/src/DataRequests/DataRequestsTable.jsx
@@ -34,11 +34,12 @@ function parseResearcherInfo(researcher) {
 }
 
 /**
- * @param {DataRequestProject[]} projects
- * @param {boolean} showApprovedOnly
- * @param {UserState['user_id']} userId
+ * @param {Object} args
+ * @param {DataRequestProject[]} args.projects
+ * @param {boolean} args.showApprovedOnly
+ * @param {UserState['user_id']} args.userId
  */
-function parseTableData(projects, showApprovedOnly, userId) {
+function parseTableData({ projects, showApprovedOnly, userId }) {
   return projects
     ?.filter((project) => !showApprovedOnly || project.status === 'Approved')
     .map((project) => [
@@ -89,7 +90,7 @@ function DataRequestsTable({ className = '', isLoading, projects }) {
   const userId = useSelector(userIdSelector);
   const [showApprovedOnly, setShowApprovedOnly] = useState(false);
   const tableData = useMemo(
-    () => parseTableData(projects, showApprovedOnly, userId),
+    () => parseTableData({ projects, showApprovedOnly, userId }),
     [projects, showApprovedOnly, userId]
   );
   return (

--- a/src/DataRequests/index.jsx
+++ b/src/DataRequests/index.jsx
@@ -17,7 +17,7 @@ import './DataRequests.css';
  * @typedef {Object} DataRequestProject
  * @property {number} id
  * @property {string} name
- * @property {'Approved' | 'Rejected' | 'In Review'} status
+ * @property {'Approved' | 'Rejected' | 'In Review' | 'Data Delivered'} status
  * @property {string | null} submitted_at timestamp
  * @property {string | null} completed_at timestamp
  * @property {ResearcherInfo} researcher


### PR DESCRIPTION
Ticket: [PEDS-724](https://pcdc.atlassian.net/browse/PEDS-724)

This PR makes the following two updates to the data download UX for Data Requests page:

1. Changes the condition for enabling "Download Data" button, from project status "Approved" to "Data Delivered"
2. Handles loading and error state for downloading data. See the following screen recording for demo:

https://user-images.githubusercontent.com/22449454/167946506-7c26cef6-e4fe-432d-8b32-cf1e41633476.mov


