### PR TITLE
Support multiple queries in explorer PEDS-702

### DIFF
--- a/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
+++ b/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
@@ -28,11 +28,6 @@
   background-color: var(--g3-color__bg-coal);
 }
 
-.explorer-query-controller__collapse {
-  max-height: 90px;
-  overflow-x: scroll;
-}
-
 .explorer-query-controller__query > h4 {
   display: inline-block;
   margin-right: 0.25rem;

--- a/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
+++ b/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
@@ -1,15 +1,18 @@
 .explorer-query-controller {
   background-color: var(--g3-color__white);
-  padding: 0.5rem 1rem;
-  margin: 0.5rem 0;
 }
 
-.explorer-query-controller__collapsed {
+.explorer-query-controller__query {
+  padding: 0.5rem 1rem;
+  margin: 0.25rem;
+}
+
+.explorer-query-controller__query--collapsed {
   max-height: 5.5rem;
   overflow-y: scroll;
 }
 
-.explorer-query-controller > button {
+.explorer-query-controller__query > button {
   background-color: inherit;
   border: none;
   height: 1rem;
@@ -17,11 +20,11 @@
   margin-right: 0.25rem;
 }
 
-.explorer-query-controller > button:disabled {
+.explorer-query-controller__query > button:disabled {
   cursor: not-allowed;
 }
 
-.explorer-query-controller > button > i {
+.explorer-query-controller__query > button > i {
   background-color: var(--g3-color__bg-coal);
 }
 
@@ -30,7 +33,7 @@
   overflow-x: scroll;
 }
 
-.explorer-query-controller > h4 {
+.explorer-query-controller__query > h4 {
   display: inline-block;
   margin-right: 0.25rem;
 }

--- a/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
+++ b/src/GuppyDataExplorer/ExplorerQueryController/ExplorerQueryController.css
@@ -1,31 +1,66 @@
 .explorer-query-controller {
   background-color: var(--g3-color__white);
-}
-
-.explorer-query-controller__query {
   padding: 0.5rem 1rem;
-  margin: 0.25rem;
 }
 
-.explorer-query-controller__query--collapsed {
-  max-height: 5.5rem;
+.explorer-query-controller > main {
+  margin-top: 1rem;
+  max-height: 12rem;
   overflow-y: scroll;
 }
 
-.explorer-query-controller__query > button {
+.explorer-query-controller button {
   background-color: inherit;
   border: none;
-  height: 1rem;
-  width: 1rem;
-  margin-right: 0.25rem;
+  height: initial;
+  width: initial;
 }
 
-.explorer-query-controller__query > button:disabled {
+.explorer-query-controller button:disabled {
   cursor: not-allowed;
 }
 
-.explorer-query-controller__query > button > i {
-  background-color: var(--g3-color__bg-coal);
+.explorer-query-controller button.explorer-query-controller__action-button {
+  margin-right: 0.25rem;
+  padding: 0.25rem;
+}
+
+.explorer-query-controller
+  button.explorer-query-controller__action-button:hover:not(:disabled) {
+  background-color: var(--g3-color__silver);
+}
+
+.explorer-query-controller__query {
+  display: flex;
+  padding: 0.25rem;
+  background-color: var(--g3-color__bg-cloud);
+}
+
+.explorer-query-controller__query > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  min-width: 5rem;
+}
+
+.explorer-query-controller__query > header > h3 {
+  font-size: 1rem;
+  line-height: 1rem;
+  padding: 0.25rem;
+  color: inherit;
+}
+
+.explorer-query-controller__query--active {
+  background-color: transparent;
+  border: 1px solid var(--g3-color__lime);
+  border-left-width: 0.25rem;
+  padding-left: 0;
+}
+
+.explorer-query-controller__query--active
+  button.explorer-query-controller__action-button {
+  color: var(--g3-color__lime);
+  cursor: initial;
 }
 
 .explorer-query-controller__query > h4 {

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -43,6 +43,8 @@ function ExplorerQueryController({ filter }) {
     queryState.update(filter);
   }, [filter]);
 
+  const disableNew = Object.values(queryState.all).some(checkIfFilterEmpty);
+
   return (
     <div className='explorer-query-controller'>
       <header>
@@ -50,7 +52,8 @@ function ExplorerQueryController({ filter }) {
           className='explorer-query-controller__action-button'
           type='button'
           onClick={() => queryState.create(handleFilterChange)}
-          disabled={Object.values(queryState.all).some(checkIfFilterEmpty)}
+          disabled={disableNew}
+          title={disableNew && 'No new query if queries without filter exist'}
         >
           New
         </button>

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -6,7 +6,9 @@ import { useExplorerState } from '../ExplorerStateContext';
 import { pluckFromAnchorFilter, pluckFromFilter } from './utils';
 import './ExplorerQueryController.css';
 
-/** @param {{ filter: import('../types').ExplorerFilter }} props */
+/** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
+
+/** @param {{ filter: ExplorerFilter }} props */
 function ExplorerQueryController({ filter }) {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const { handleFilterChange } = useExplorerState();
@@ -14,7 +16,7 @@ function ExplorerQueryController({ filter }) {
   /** @type {import('../../components/QueryDisplay').ClickCombineModeHandler} */
   function handleClickCombineMode(payload) {
     handleFilterChange(
-      /** @type {import('../types').ExplorerFilter} */ ({
+      /** @type {ExplorerFilter} */ ({
         ...filter,
         __combineMode: payload === 'AND' ? 'OR' : 'AND',
       })

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -47,36 +47,38 @@ function ExplorerQueryController({ filter }) {
   const hasFilter =
     Object.keys(pluckFromFilter({ field: '__combineMode', filter })).length > 0;
   return (
-    <div
-      ref={ref}
-      className={`explorer-query-controller ${
-        isCollapsed ? 'explorer-query-controller__collapsed' : ''
-      }`.trim()}
-    >
-      {hasFilter ? (
-        <>
-          <button
-            type='button'
-            onClick={() => setIsCollapsed((s) => !s)}
-            disabled={isCollapsed && !isOverflowing}
-          >
-            <i
-              className={`g3-icon g3-icon--sm g3-icon--chevron-${
-                isCollapsed ? 'right' : 'down'
-              }`}
+    <div className='explorer-query-controller'>
+      <div
+        ref={ref}
+        className={`explorer-query-controller__query ${
+          isCollapsed ? 'explorer-query-controller__query--collapsed' : ''
+        }`.trim()}
+      >
+        {hasFilter ? (
+          <>
+            <button
+              type='button'
+              onClick={() => setIsCollapsed((s) => !s)}
+              disabled={isCollapsed && !isOverflowing}
+            >
+              <i
+                className={`g3-icon g3-icon--sm g3-icon--chevron-${
+                  isCollapsed ? 'right' : 'down'
+                }`}
+              />
+            </button>
+            <h4>Filters in Use:</h4>
+            <QueryDisplay
+              filter={filter}
+              filterInfo={filterInfo}
+              onClickCombineMode={handleClickCombineMode}
+              onCloseFilter={handleCloseFilter}
             />
-          </button>
-          <h4>Filters in Use:</h4>
-          <QueryDisplay
-            filter={filter}
-            filterInfo={filterInfo}
-            onClickCombineMode={handleClickCombineMode}
-            onCloseFilter={handleCloseFilter}
-          />
-        </>
-      ) : (
-        <h4>← Try Filters to explore data</h4>
-      )}
+          </>
+        ) : (
+          <h4>← Try Filters to explore data</h4>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -78,7 +78,10 @@ function ExplorerQueryController({ filter }) {
         {Object.keys(queryState.all).map((id, i) => {
           const queryFilter = queryState.all[id];
           return queryState.current.id === id ? (
-            <div className='explorer-query-controller__query explorer-query-controller__query--active'>
+            <div
+              className='explorer-query-controller__query explorer-query-controller__query--active'
+              key={id}
+            >
               <header>
                 <button
                   className='explorer-query-controller__action-button'
@@ -103,7 +106,7 @@ function ExplorerQueryController({ filter }) {
               </main>
             </div>
           ) : (
-            <div className='explorer-query-controller__query'>
+            <div className='explorer-query-controller__query' key={id}>
               <header>
                 <button
                   className='explorer-query-controller__action-button'

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -1,9 +1,14 @@
 import PropTypes from 'prop-types';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import QueryDisplay from '../../components/QueryDisplay';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerState } from '../ExplorerStateContext';
-import { pluckFromAnchorFilter, pluckFromFilter } from './utils';
+import useQueryState from './useQueryState';
+import {
+  checkIfFilterEmpty,
+  pluckFromAnchorFilter,
+  pluckFromFilter,
+} from './utils';
 import './ExplorerQueryController.css';
 
 /** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
@@ -33,52 +38,90 @@ function ExplorerQueryController({ filter }) {
     }
   }
 
-  const [isCollapsed, setIsCollapsed] = useState(true);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-  const ref = useRef(null);
+  const queryState = useQueryState(filter);
   useEffect(() => {
-    if (ref.current?.offsetHeight < ref.current?.scrollHeight) {
-      if (!isOverflowing) setIsOverflowing(true);
-    } else if (isOverflowing) {
-      setIsOverflowing(false);
-    }
-  });
+    queryState.update(filter);
+  }, [filter]);
 
-  const hasFilter =
-    Object.keys(pluckFromFilter({ field: '__combineMode', filter })).length > 0;
   return (
     <div className='explorer-query-controller'>
-      <div
-        ref={ref}
-        className={`explorer-query-controller__query ${
-          isCollapsed ? 'explorer-query-controller__query--collapsed' : ''
-        }`.trim()}
-      >
-        {hasFilter ? (
-          <>
-            <button
-              type='button'
-              onClick={() => setIsCollapsed((s) => !s)}
-              disabled={isCollapsed && !isOverflowing}
-            >
-              <i
-                className={`g3-icon g3-icon--sm g3-icon--chevron-${
-                  isCollapsed ? 'right' : 'down'
-                }`}
-              />
-            </button>
-            <h4>Filters in Use:</h4>
-            <QueryDisplay
-              filter={filter}
-              filterInfo={filterInfo}
-              onClickCombineMode={handleClickCombineMode}
-              onCloseFilter={handleCloseFilter}
-            />
-          </>
-        ) : (
-          <h4>← Try Filters to explore data</h4>
-        )}
-      </div>
+      <header>
+        <button
+          className='explorer-query-controller__action-button'
+          type='button'
+          onClick={() => queryState.create(handleFilterChange)}
+          disabled={Object.values(queryState.all).some(checkIfFilterEmpty)}
+        >
+          New
+        </button>
+        <button
+          className='explorer-query-controller__action-button'
+          type='button'
+          onClick={() => queryState.duplicate(handleFilterChange)}
+          disabled={checkIfFilterEmpty(queryState.current.filter)}
+        >
+          Duplicate
+        </button>
+        <button
+          className='explorer-query-controller__action-button'
+          type='button'
+          onClick={() => queryState.remove(handleFilterChange)}
+          disabled={queryState.size < 2}
+        >
+          Remove
+        </button>
+      </header>
+      <main>
+        {Object.keys(queryState.all).map((id, i) => {
+          const queryFilter = queryState.all[id];
+          return queryState.current.id === id ? (
+            <div className='explorer-query-controller__query explorer-query-controller__query--active'>
+              <header>
+                <button
+                  className='explorer-query-controller__action-button'
+                  type='button'
+                  disabled
+                >
+                  Active
+                </button>
+                <h3>{`#${i + 1}`}</h3>
+              </header>
+              <main>
+                {checkIfFilterEmpty(queryFilter) ? (
+                  <h4>Try Filters to explore data</h4>
+                ) : (
+                  <QueryDisplay
+                    filter={queryFilter}
+                    filterInfo={filterInfo}
+                    onClickCombineMode={handleClickCombineMode}
+                    onCloseFilter={handleCloseFilter}
+                  />
+                )}
+              </main>
+            </div>
+          ) : (
+            <div className='explorer-query-controller__query'>
+              <header>
+                <button
+                  className='explorer-query-controller__action-button'
+                  type='button'
+                  onClick={() => queryState.use(id, handleFilterChange)}
+                >
+                  Use
+                </button>
+                <h3>{`#${i + 1}`}</h3>
+              </header>
+              <main>
+                {checkIfFilterEmpty(queryFilter) ? (
+                  <h4>Try Filters to explore data</h4>
+                ) : (
+                  <QueryDisplay filter={queryFilter} filterInfo={filterInfo} />
+                )}
+              </main>
+            </div>
+          );
+        })}
+      </main>
     </div>
   );
 }

--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -53,7 +53,11 @@ function ExplorerQueryController({ filter }) {
           type='button'
           onClick={() => queryState.create(handleFilterChange)}
           disabled={disableNew}
-          title={disableNew && 'No new query if queries without filter exist'}
+          title={
+            disableNew
+              ? 'No new query if queries without filter exist'
+              : undefined
+          }
         >
           New
         </button>

--- a/src/GuppyDataExplorer/ExplorerQueryController/types.ts
+++ b/src/GuppyDataExplorer/ExplorerQueryController/types.ts
@@ -1,0 +1,44 @@
+import type { ExplorerFilter } from '../types';
+
+export type QueryStateActionCallback = (args: {
+  id: string;
+  filter: ExplorerFilter;
+}) => void;
+
+type QueryStateCreactAction = {
+  type: 'CREATE';
+  payload: {
+    callback?: QueryStateActionCallback;
+  };
+};
+
+type QueryStateDuplicateAction = {
+  type: 'DUPLICATE';
+  payload: {
+    id: string;
+    callback?: QueryStateActionCallback;
+  };
+};
+
+type QueryStateRemoveAction = {
+  type: 'REMOVE';
+  payload: {
+    id: string;
+    callback?: QueryStateActionCallback;
+  };
+};
+
+type QueryStateUpdateAction = {
+  type: 'UPDATE';
+  payload: {
+    id: string;
+    filter: ExplorerFilter;
+    callback?: QueryStateActionCallback;
+  };
+};
+
+export type QueryStateAction =
+  | QueryStateCreactAction
+  | QueryStateDuplicateAction
+  | QueryStateRemoveAction
+  | QueryStateUpdateAction;

--- a/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
@@ -1,0 +1,140 @@
+import { useMemo, useReducer, useState } from 'react';
+import cloneDeep from 'lodash.clonedeep';
+
+/** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import('./types').QueryStateAction} QueryStateAction */
+/** @typedef {import('./types').QueryStateActionCallback} QueryStateActionCallback */
+
+/**
+ * @param {{ [id: string]: ExplorerFilter }} state
+ * @param {QueryStateAction} action
+ */
+function reducer(state, action) {
+  const { type, payload } = action;
+  switch (type) {
+    case 'CREATE': {
+      const id = crypto.randomUUID();
+      const filter = /** @type {ExplorerFilter} */ ({});
+
+      payload.callback?.({ filter, id });
+
+      return { ...state, [id]: filter };
+    }
+    case 'REMOVE': {
+      const newState = cloneDeep(state);
+      delete newState[payload.id];
+
+      const [id, filter] = Object.entries(newState)[0];
+      payload.callback?.({ filter, id });
+
+      return newState;
+    }
+    case 'DUPLICATE': {
+      const id = crypto.randomUUID();
+      const filter = cloneDeep(state[payload.id]);
+
+      payload.callback?.({ filter, id });
+
+      return { ...state, [id]: filter };
+    }
+    case 'UPDATE': {
+      const { id, filter: newFilter } = payload;
+      const filter = cloneDeep(newFilter);
+
+      payload.callback?.({ filter, id });
+
+      return { ...state, [id]: filter };
+    }
+    default:
+      return state;
+  }
+}
+
+/** @param {ExplorerFilter} initialFilter */
+export default function useQueryState(initialFilter) {
+  const [id, setId] = useState(crypto.randomUUID());
+  const initialState = { [id]: initialFilter };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const size = Object.keys(state).length;
+
+  /** @param {(filter: ExplorerFilter) => void} [callback] */
+  function create(callback) {
+    dispatch({
+      type: 'CREATE',
+      payload: {
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filter);
+        },
+      },
+    });
+  }
+  /** @param {(filter: ExplorerFilter) => void} [callback] */
+  function duplicate(callback) {
+    dispatch({
+      type: 'DUPLICATE',
+      payload: {
+        id,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filter);
+        },
+      },
+    });
+  }
+
+  /** @param {(filter: ExplorerFilter) => void} [callback] */
+  function remove(callback) {
+    dispatch({
+      type: 'REMOVE',
+      payload: {
+        id,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filter);
+        },
+      },
+    });
+  }
+
+  /**
+   * @param {ExplorerFilter} newFilter
+   * @param {(filter: ExplorerFilter) => void} [callback]
+   */
+  function update(newFilter, callback) {
+    dispatch({
+      type: 'UPDATE',
+      payload: {
+        id,
+        filter: newFilter,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filter);
+        },
+      },
+    });
+  }
+
+  /**
+   * @param {string} newId
+   * @param {(filter: ExplorerFilter) => void} callback
+   */
+  function use(newId, callback) {
+    setId(newId);
+    callback?.(state[newId]);
+  }
+
+  return useMemo(
+    () => ({
+      all: state,
+      current: { id, filter: state[id] },
+      size,
+      create,
+      duplicate,
+      remove,
+      update,
+      use,
+    }),
+    [id, state]
+  );
+}

--- a/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
@@ -53,9 +53,7 @@ function reducer(state, action) {
 /** @param {ExplorerFilter} initialFilter */
 export default function useQueryState(initialFilter) {
   const [id, setId] = useState(crypto.randomUUID());
-  const initialState = { [id]: initialFilter };
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const size = Object.keys(state).length;
+  const [state, dispatch] = useReducer(reducer, { [id]: initialFilter });
 
   /** @param {(filter: ExplorerFilter) => void} [callback] */
   function create(callback) {
@@ -128,7 +126,7 @@ export default function useQueryState(initialFilter) {
     () => ({
       all: state,
       current: { id, filter: state[id] },
-      size,
+      size: Object.keys(state).length,
       create,
       duplicate,
       remove,

--- a/src/GuppyDataExplorer/ExplorerQueryController/utils.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/utils.js
@@ -31,3 +31,9 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
 
   return /** @type {ExplorerFilter} */ (newFilter);
 }
+
+/** @param {ExplorerFilter} filter */
+export function checkIfFilterEmpty(filter) {
+  const { __combineMode, ..._filter } = filter;
+  return Object.keys(_filter).length === 0;
+}


### PR DESCRIPTION
Ticket: [PEDS-702](https://pcdc.atlassian.net/browse/PEDS-702)

This PR implements support for multiple "queries" on the explorer via the "query controller" UI component. With this, a user can add/duplicate/remove/switch between queries where each query is a combination of filters. 

The following is a detailed explanation on each user action:

* `New`: Creates a new query without any filter. This action is enabled only if there is no existing query without any filter, i.e. all existing queries must have some filter in order to create a new query. This is to prevent users from creating multiple empty queries.
* `Duplicate`: Duplicates the currently "active" query with the same set of filter. This action is enabled only if the currently active query is not without any filter.
* `Remove`: Removes the "active" query. This action is enabled only if there are two or more queries, i.e. the only existing query cannot be removed.
* `Use`: Select the query to be the "active" query. An "active" query is visually distinct from the others and its displayed query body is made interactive.

See the short demo below:

https://user-images.githubusercontent.com/22449454/168301076-640c2fa7-eaa5-4932-a8ea-396e8934013e.mov

This PR removes a feature of the previous query controller UI, namely, an ability to expand/collapse a single query. Instead, the query controller as a whole has as set maximum height with scroll. This is to simplify the implementation of supporting multiple queries.

