### PR TITLE
Abandon search parameters for explorer state PEDS-734

### DIFF
--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -13,8 +13,6 @@ import { createFilterInfo, isSurvivalAnalysisEnabled } from './utils';
  * @property {number} explorerId
  * @property {{ label: string; value: string }[]} explorerOptions
  * @property {() => void} handleBrowserNavigationForConfig
- * @property {boolean} shouldUpdateState
- * @property {(v: boolean) => void} setShouldUpdateState
  * @property {(id: number) => void} updateExplorerId
  */
 
@@ -46,7 +44,6 @@ export function ExplorerConfigProvider({ children }) {
       hasSearchParamId && isSearchParamIdValid,
     ];
   }, []);
-  const [shouldUpdateState, setShouldUpdateState] = useState(false);
   useEffect(() => {
     if (!hasValidInitialSearchParamId) {
       setSearchParams(
@@ -56,7 +53,6 @@ export function ExplorerConfigProvider({ children }) {
           : `id=${initialExplorerId}`,
         { replace: true }
       );
-      setShouldUpdateState(true);
     }
   }, []);
 
@@ -105,11 +101,9 @@ export function ExplorerConfigProvider({ children }) {
       explorerId,
       explorerOptions,
       handleBrowserNavigationForConfig,
-      shouldUpdateState,
-      setShouldUpdateState,
       updateExplorerId,
     }),
-    [config, explorerId, explorerOptions, shouldUpdateState]
+    [config, explorerId, explorerOptions]
   );
 
   return (

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -8,7 +8,6 @@ import { useExplorerConfig } from './ExplorerConfigContext';
  * @typedef {Object} ExplorerStateContext
  * @property {ExplorerFilter} explorerFilter
  * @property {string[]} patientIds
- * @property {() => void} handleBrowserNavigationForState
  * @property {(filter: ExplorerFilter) => void} handleFilterChange
  * @property {() => void} handleFilterClear
  * @property {(patientIds: string[]) => void} handlePatientIdsChange
@@ -72,7 +71,6 @@ export function ExplorerStateProvider({ children }) {
     () => ({
       explorerFilter,
       patientIds,
-      handleBrowserNavigationForState() {},
       handleFilterChange,
       handleFilterClear,
       handlePatientIdsChange,

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -1,16 +1,6 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import ReactDOM from 'react-dom';
+import { createContext, useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useExplorerConfig } from './ExplorerConfigContext';
-import { extractExplorerStateFromURL } from './utils';
 
 /** @typedef {import('./types').ExplorerFilter} ExplorerFilter */
 
@@ -28,71 +18,17 @@ import { extractExplorerStateFromURL } from './utils';
 const ExplorerStateContext = createContext(null);
 
 export function ExplorerStateProvider({ children }) {
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const {
     current: { filterConfig, patientIdsConfig },
-    shouldUpdateState,
-    setShouldUpdateState,
   } = useExplorerConfig();
 
-  const initialState = useMemo(
-    () =>
-      extractExplorerStateFromURL(searchParams, filterConfig, patientIdsConfig),
-    []
-  );
-  const [explorerFilter, setExplorerFilter] = useState(
-    initialState.explorerFilter
-  );
-  const [patientIds, setPatientIds] = useState(initialState.patientIds);
-  useEffect(() => {
-    if (shouldUpdateState) {
-      const newState = extractExplorerStateFromURL(
-        searchParams,
-        filterConfig,
-        patientIdsConfig
-      );
-      setExplorerFilter(newState.explorerFilter);
-      setPatientIds(newState.patientIds);
-      setShouldUpdateState(false);
-    }
-  }, [shouldUpdateState]);
+  /** @type {ExplorerFilter} */
+  const initialExplorerFilter = {};
+  const [explorerFilter, setExplorerFilter] = useState(initialExplorerFilter);
 
-  const isBrowserNavigation = useRef(false);
-  useEffect(() => {
-    if (isBrowserNavigation.current) {
-      isBrowserNavigation.current = false;
-      return;
-    }
-    const newSearchParams = new URLSearchParams(searchParams.toString());
-    newSearchParams.delete('filter');
-    newSearchParams.delete('patientIds');
-
-    if (explorerFilter && Object.keys(explorerFilter).length > 0)
-      newSearchParams.set('filter', JSON.stringify(explorerFilter));
-
-    if (patientIds?.length > 0)
-      newSearchParams.set('patientIds', patientIds.join(','));
-
-    if (searchParams.toString() !== newSearchParams.toString())
-      navigate(`?${decodeURIComponent(newSearchParams.toString())}`, {
-        state: { scrollY: window.scrollY },
-      });
-  }, [explorerFilter, patientIds]);
-
-  function handleBrowserNavigationForState() {
-    isBrowserNavigation.current = true;
-    const newState = extractExplorerStateFromURL(
-      new URL(document.URL).searchParams,
-      filterConfig,
-      patientIdsConfig
-    );
-    // batch to avoid double-triggering useEffect() above
-    ReactDOM.unstable_batchedUpdates(() => {
-      setExplorerFilter(newState.explorerFilter);
-      setPatientIds(newState.patientIds);
-    });
-  }
+  /** @type {string[]} */
+  const initielPatientIds = patientIdsConfig?.filter ? [] : undefined;
+  const [patientIds, setPatientIds] = useState(initielPatientIds);
 
   function handleFilterChange(/** @type {ExplorerFilter} */ filter) {
     let newFilter = /** @type {ExplorerFilter} */ ({});
@@ -136,7 +72,7 @@ export function ExplorerStateProvider({ children }) {
     () => ({
       explorerFilter,
       patientIds,
-      handleBrowserNavigationForState,
+      handleBrowserNavigationForState() {},
       handleFilterChange,
       handleFilterClear,
       handlePatientIdsChange,

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -44,19 +44,11 @@ function ExplorerDashboard({ dataVersion, portalVersion }) {
     explorerId,
     handleBrowserNavigationForConfig,
   } = useExplorerConfig();
-  const {
-    explorerFilter,
-    patientIds,
-    handleBrowserNavigationForState,
-    handleFilterChange,
-  } = useExplorerState();
+  const { explorerFilter, patientIds, handleFilterChange } = useExplorerState();
   useEffect(() => {
     window.addEventListener('popstate', handleBrowserNavigationForConfig);
-    window.addEventListener('popstate', handleBrowserNavigationForState);
-    return () => {
+    return () =>
       window.removeEventListener('popstate', handleBrowserNavigationForConfig);
-      window.removeEventListener('popstate', handleBrowserNavigationForState);
-    };
   }, []);
 
   return (


### PR DESCRIPTION
Ticket: [PEDS-734](https://pcdc.atlassian.net/browse/PEDS-734)

This PR stops the support for syncing filter & patient ids explorer state with URL. **This is a breaking change** since the URLs with encoded filter & patient ids information will no longer work as expected. To clarify, the "sync" was already partly undermined by the introduction of "multi query" feature (https://github.com/chicagopcdc/data-portal/pull/388) and other planned features will further undermine it. 

To compensate for the UX regression by the current PR, there will be a follow-up PR to store the explorer state in the browser session storage.