### PR TITLE
Fix double fetching data on filter change PEDS-739

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -490,8 +490,7 @@ function GuppyWrapper({
       ...filter,
     });
     const mergedFilter = mergeFilters(userFilter, adminAppliedPreFilters);
-
-    if (onFilterChange) onFilterChange(mergedFilter);
+    onFilterChange?.(mergedFilter);
   }
 
   return children({

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -492,15 +492,6 @@ function GuppyWrapper({
     const mergedFilter = mergeFilters(userFilter, adminAppliedPreFilters);
 
     if (onFilterChange) onFilterChange(mergedFilter);
-
-    controller.current.abort();
-    controller.current = new AbortController();
-    fetchAggsDataFromGuppy(mergedFilter);
-    fetchRawDataFromGuppy({
-      fields: rawDataFields,
-      filter: mergedFilter,
-      updateDataWhenReceive: true,
-    });
   }
 
   return children({


### PR DESCRIPTION
Ticket: [PEDS-739](https://pcdc.atlassian.net/browse/PEDS-739)

This PR fixes double fetching of data on filter change, introduced by https://github.com/chicagopcdc/data-portal/commit/ed6791ede78b07e1d6181324381ff52baa8f4508 in https://github.com/chicagopcdc/data-portal/pull/379.