### PR TITLE
Persist explorer query state PEDS-735

### DIFF
--- a/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerQueryController/index.jsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import QueryDisplay from '../../components/QueryDisplay';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerState } from '../ExplorerStateContext';
@@ -11,18 +9,16 @@ import {
 } from './utils';
 import './ExplorerQueryController.css';
 
-/** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
-
-/** @param {{ filter: ExplorerFilter }} props */
-function ExplorerQueryController({ filter }) {
+function ExplorerQueryController() {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
   const { handleFilterChange } = useExplorerState();
+  const queryState = useQueryState();
 
   /** @type {import('../../components/QueryDisplay').ClickCombineModeHandler} */
   function handleClickCombineMode(payload) {
     handleFilterChange(
-      /** @type {ExplorerFilter} */ ({
-        ...filter,
+      /** @type {import('../types').ExplorerFilter} */ ({
+        ...queryState.current.filter,
         __combineMode: payload === 'AND' ? 'OR' : 'AND',
       })
     );
@@ -30,6 +26,7 @@ function ExplorerQueryController({ filter }) {
   /** @type {import('../../components/QueryDisplay').ClickFilterHandler} */
   function handleCloseFilter(payload) {
     const { field, anchorField, anchorValue } = payload;
+    const { filter } = queryState.current;
     if (anchorField !== undefined && anchorValue !== undefined) {
       const anchor = `${anchorField}:${anchorValue}`;
       handleFilterChange(pluckFromAnchorFilter({ anchor, field, filter }));
@@ -37,11 +34,6 @@ function ExplorerQueryController({ filter }) {
       handleFilterChange(pluckFromFilter({ field, filter }));
     }
   }
-
-  const queryState = useQueryState(filter);
-  useEffect(() => {
-    queryState.update(filter);
-  }, [filter]);
 
   const disableNew = Object.values(queryState.all).some(checkIfFilterEmpty);
 
@@ -135,9 +127,5 @@ function ExplorerQueryController({ filter }) {
     </div>
   );
 }
-
-ExplorerQueryController.propTypes = {
-  filter: PropTypes.any,
-};
 
 export default ExplorerQueryController;

--- a/src/GuppyDataExplorer/ExplorerQueryController/types.ts
+++ b/src/GuppyDataExplorer/ExplorerQueryController/types.ts
@@ -1,5 +1,7 @@
 import type { ExplorerFilter } from '../types';
 
+export type QueryState = { [key: string]: ExplorerFilter };
+
 export type QueryStateActionCallback = (args: {
   id: string;
   filter: ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
@@ -1,5 +1,6 @@
-import { useMemo, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import cloneDeep from 'lodash.clonedeep';
+import { useExplorerState } from '../ExplorerStateContext';
 
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 /** @typedef {import('./types').QueryState} QueryState */
@@ -51,10 +52,10 @@ function reducer(state, action) {
   }
 }
 
-/** @param {ExplorerFilter} initialFilter */
-export default function useQueryState(initialFilter) {
+export default function useQueryState() {
+  const { explorerFilter } = useExplorerState();
   const [id, setId] = useState(crypto.randomUUID());
-  const [state, dispatch] = useReducer(reducer, { [id]: initialFilter });
+  const [state, dispatch] = useReducer(reducer, { [id]: explorerFilter });
 
   /** @param {(filter: ExplorerFilter) => void} [callback] */
   function create(callback) {
@@ -113,6 +114,8 @@ export default function useQueryState(initialFilter) {
       },
     });
   }
+
+  useEffect(() => update(explorerFilter), [explorerFilter]);
 
   /**
    * @param {string} newId

--- a/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
@@ -130,7 +130,6 @@ export default function useQueryState() {
       },
     });
   }
-
   useEffect(() => update(explorerFilter), [explorerFilter]);
 
   /**

--- a/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/useQueryState.js
@@ -2,11 +2,12 @@ import { useMemo, useReducer, useState } from 'react';
 import cloneDeep from 'lodash.clonedeep';
 
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import('./types').QueryState} QueryState */
 /** @typedef {import('./types').QueryStateAction} QueryStateAction */
 /** @typedef {import('./types').QueryStateActionCallback} QueryStateActionCallback */
 
 /**
- * @param {{ [id: string]: ExplorerFilter }} state
+ * @param {QueryState} state
  * @param {QueryStateAction} action
  */
 function reducer(state, action) {

--- a/src/GuppyDataExplorer/ExplorerQueryController/utils.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/utils.js
@@ -1,4 +1,5 @@
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import('./types').QueryState} QueryState */
 
 /**
  * @param {Object} args
@@ -36,4 +37,30 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
 export function checkIfFilterEmpty(filter) {
   const { __combineMode, ..._filter } = filter;
   return Object.keys(_filter).length === 0;
+}
+
+const queryStateLocalStorageKey = 'explorer:queryState';
+
+/** @returns {QueryState} */
+export function retrieveQueryState() {
+  try {
+    const str = window.localStorage.getItem(queryStateLocalStorageKey);
+    if (str === null) throw new Error('No stored query');
+    return JSON.parse(str);
+  } catch (e) {
+    if (e.message !== 'No stored query') console.error(e);
+    return { [crypto.randomUUID()]: {} };
+  }
+}
+
+/** @param {ExplorerFilter} filter */
+export function getInitialQueryState(filter) {
+  return checkIfFilterEmpty(filter)
+    ? retrieveQueryState()
+    : { [crypto.randomUUID()]: filter };
+}
+
+/** @param {QueryState} state */
+export function storeQueryState(state) {
+  window.localStorage.setItem(queryStateLocalStorageKey, JSON.stringify(state));
 }

--- a/src/GuppyDataExplorer/ExplorerQueryController/utils.js
+++ b/src/GuppyDataExplorer/ExplorerQueryController/utils.js
@@ -39,12 +39,12 @@ export function checkIfFilterEmpty(filter) {
   return Object.keys(_filter).length === 0;
 }
 
-const queryStateLocalStorageKey = 'explorer:queryState';
+const queryStateSessionStorageKey = 'explorer:queryState';
 
 /** @returns {QueryState} */
 export function retrieveQueryState() {
   try {
-    const str = window.localStorage.getItem(queryStateLocalStorageKey);
+    const str = window.sessionStorage.getItem(queryStateSessionStorageKey);
     if (str === null) throw new Error('No stored query');
     return JSON.parse(str);
   } catch (e) {
@@ -62,5 +62,8 @@ export function getInitialQueryState(filter) {
 
 /** @param {QueryState} state */
 export function storeQueryState(state) {
-  window.localStorage.setItem(queryStateLocalStorageKey, JSON.stringify(state));
+  window.sessionStorage.setItem(
+    queryStateSessionStorageKey,
+    JSON.stringify(state)
+  );
 }


### PR DESCRIPTION
Ticket: [PEDS-735](https://pcdc.atlassian.net/browse/PEDS-735)

This PR implements persisting the latest explorer query state using `sessionStorage`. This is a follow-up to https://github.com/chicagopcdc/data-portal/pull/389.

See the following demo screen recording:

https://user-images.githubusercontent.com/22449454/168864365-77413d11-aaed-48a9-a342-f7dfb1bf0e2c.mov



 