### PR TITLE
Fix Index page Overview section Explorer More button PEDS-740

### DIFF
--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import { createFilterInfo, isSurvivalAnalysisEnabled } from './utils';
@@ -21,7 +21,6 @@ const ExplorerConfigContext = createContext(null);
 
 export function ExplorerConfigProvider({ children }) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const location = useLocation();
 
   const explorerOptions = [];
   const explorerIds = [];
@@ -45,15 +44,8 @@ export function ExplorerConfigProvider({ children }) {
     ];
   }, []);
   useEffect(() => {
-    if (!hasValidInitialSearchParamId) {
-      setSearchParams(
-        // @ts-ignore
-        location.state?.keepSearch === true
-          ? `id=${initialExplorerId}&${location.search.slice(1)}`
-          : `id=${initialExplorerId}`,
-        { replace: true }
-      );
-    }
+    if (!hasValidInitialSearchParamId)
+      setSearchParams(`id=${initialExplorerId}`);
   }, []);
 
   const [explorerId, setExporerId] = useState(initialExplorerId);

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
 import { useExplorerConfig } from './ExplorerConfigContext';
 
 /** @typedef {import('./types').ExplorerFilter} ExplorerFilter */
@@ -21,8 +22,9 @@ export function ExplorerStateProvider({ children }) {
     current: { filterConfig, patientIdsConfig },
   } = useExplorerConfig();
 
-  /** @type {ExplorerFilter} */
-  const initialExplorerFilter = {};
+  const initialExplorerFilter =
+    /** @type {{ filter?: ExplorerFilter  }} */ (useLocation().state)?.filter ??
+    /** @type {ExplorerFilter} */ ({});
   const [explorerFilter, setExplorerFilter] = useState(initialExplorerFilter);
 
   /** @type {string[]} */

--- a/src/Index/IndexOverview.jsx
+++ b/src/Index/IndexOverview.jsx
@@ -72,14 +72,17 @@ function IndexOverview({ overviewCounts }) {
   ];
 
   const navigate = useNavigate();
-  const explorerLocation =
-    consortium.value === 'total'
-      ? { pathname: '/explorer' }
-      : {
-          pathname: '/explorer',
-          search: `filter={"consortium":{"selectedValues":["${consortium.value}"]}}`,
-          state: { keepSearch: true },
-        };
+  /** @type {[to: string, options?: import('react-router').NavigateOptions]} */
+  const navigateParams = ['/explorer'];
+  if (consortium.value !== 'total')
+    navigateParams.push({
+      state: {
+        filter: {
+          __combineMode: 'AND',
+          consortium: { selectedValues: [consortium.value] },
+        },
+      },
+    });
 
   const [isDataLoaded, setIsDataLoaded] = useState(false);
   useEffect(() => {
@@ -106,7 +109,7 @@ function IndexOverview({ overviewCounts }) {
             <Button
               label='Explore more'
               buttonType='primary'
-              onClick={() => navigate(explorerLocation)}
+              onClick={() => navigate(...navigateParams)}
             />
           )}
         </div>
@@ -132,7 +135,7 @@ function IndexOverview({ overviewCounts }) {
           <Button
             label='Explore more'
             buttonType='primary'
-            onClick={() => navigate(explorerLocation)}
+            onClick={() => navigate(...navigateParams)}
           />
         </div>
       )}


### PR DESCRIPTION
Ticket: [PEDS-740](https://pcdc.atlassian.net/browse/PEDS-740)

This PR fixes the broken "Explore More" button for the Overview section of the Index page. The bug was introduced by https://github.com/chicagopcdc/data-portal/pull/389 which removed handling `?filter` URL search parameter without changing the "Explore More" button's implementation accordingly.