### PR TITLE
Use sessionStorage for GraphiQL PEDS-741

### DIFF
--- a/src/GraphQLEditor/GqlEditor.jsx
+++ b/src/GraphQLEditor/GqlEditor.jsx
@@ -114,6 +114,7 @@ function GqlEditor({ guppySchema, schema }) {
         variables={parameters.variables}
         onEditQuery={editQuery}
         onEditVariables={editVariables}
+        storage={window.sessionStorage}
       />
     </div>
   );


### PR DESCRIPTION
Ticket: [PEDS-741](https://pcdc.atlassian.net/browse/PEDS-741)

This PR switches from the default `localStorage` to `sessionStorage` to persist `<GraphiQL>` query string to match the explorer query state's behavior (https://github.com/chicagopcdc/data-portal/pull/391).