### PR TITLE
Improve visual cue for Explorer page active tabs PEDS-729

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
+++ b/src/GuppyDataExplorer/ExplorerFilter/ExplorerFilter.css
@@ -46,6 +46,10 @@
   cursor: pointer;
 }
 
+.explorer-filter__combine-mode > label.active {
+  border-color: var(--pcdc-color__secondary);
+}
+
 .explorer-filter__combine-mode > label.active,
 .explorer-filter__combine-mode > label:hover {
   background-color: var(--g3-color__white);

--- a/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
+++ b/src/GuppyDataExplorer/ExplorerVisualization/ExplorerVisualization.css
@@ -58,6 +58,10 @@
   margin-right: 0;
 }
 
+.explorer-visualization__view-group > button.active {
+  border-color: var(--pcdc-color__secondary);
+}
+
 .explorer-visualization__view-group > button.active,
 .explorer-visualization__view-group > button:hover {
   background-color: var(--g3-color__white);

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.css
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.css
@@ -25,6 +25,10 @@
   padding: 4px 12px;
 }
 
+.g3-filter-group__tab--selected {
+  border-color: var(--pcdc-color__secondary);
+}
+
 .g3-filter-group__tab--selected,
 .g3-filter-group__tab:hover {
   background-color: var(--g3-color__white);


### PR DESCRIPTION
Ticket: [PEDS-729](https://pcdc.atlassian.net/browse/PEDS-729)

This PR improves the visual distinction for active tabs/buttons on the Explorer page. The change is applied to active combine mode label, active filter tab button, and active view group button.

See the before/after comparison below:

_Before:_
<img width="550" alt="image" src="https://user-images.githubusercontent.com/22449454/169118608-efefd14f-cb1c-4945-8b72-44c89bd8ad7a.png">

_After:_
<img width="550" alt="image" src="https://user-images.githubusercontent.com/22449454/169118672-b129a5ae-d96e-49c3-be20-b6d59046d3c6.png">
