### PR TITLE
Support loading saved filter sets to workspace PEDS-704

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/ExplorerFilterSetWorkspace.css
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/ExplorerFilterSetWorkspace.css
@@ -64,16 +64,30 @@
 
 .explorer-filter-set-workplace__query > header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  min-width: 5rem;
+  align-items: center;
+}
+
+.explorer-filter-set-workplace__query > header::after {
+  border: 0.5px solid var(--g3-color__lightgray);
+  content: '';
+  margin: 0 0.5rem;
+  height: 1rem;
+}
+
+.explorer-filter-set-workplace__query > header > button {
+  width: 3rem;
+  text-align: center;
 }
 
 .explorer-filter-set-workplace__query > header > h3 {
-  font-size: 1rem;
+  font-size: 0.8rem;
   line-height: 1rem;
   padding: 0.25rem;
   color: inherit;
+  max-width: 6rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .explorer-filter-set-workplace__query--active {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -14,6 +14,20 @@ function ExplorerFilterSetWorkspace() {
   const { handleFilterChange } = useExplorerState();
   const workspace = useFilterSetWorkspace();
 
+  function handleCreate() {
+    workspace.create(handleFilterChange);
+  }
+  function handleDuplicate() {
+    workspace.duplicate(handleFilterChange);
+  }
+  function handleRemove() {
+    workspace.remove(handleFilterChange);
+  }
+  /** @param {string} id */
+  function handleUse(id) {
+    workspace.use(id, handleFilterChange);
+  }
+
   /** @type {import('../../components/FilterDisplay').ClickCombineModeHandler} */
   function handleClickCombineMode(payload) {
     handleFilterChange(
@@ -46,7 +60,7 @@ function ExplorerFilterSetWorkspace() {
         <button
           className='explorer-filter-set-workplace__action-button'
           type='button'
-          onClick={() => workspace.create(handleFilterChange)}
+          onClick={handleCreate}
           disabled={disableNew}
           title={
             disableNew
@@ -59,7 +73,7 @@ function ExplorerFilterSetWorkspace() {
         <button
           className='explorer-filter-set-workplace__action-button'
           type='button'
-          onClick={() => workspace.duplicate(handleFilterChange)}
+          onClick={handleDuplicate}
           disabled={checkIfFilterEmpty(workspace.active.filter)}
         >
           Duplicate
@@ -67,7 +81,7 @@ function ExplorerFilterSetWorkspace() {
         <button
           className='explorer-filter-set-workplace__action-button'
           type='button'
-          onClick={() => workspace.remove(handleFilterChange)}
+          onClick={handleRemove}
           disabled={workspace.size < 2}
         >
           Remove
@@ -110,7 +124,7 @@ function ExplorerFilterSetWorkspace() {
                 <button
                   className='explorer-filter-set-workplace__action-button'
                   type='button'
-                  onClick={() => workspace.use(id, handleFilterChange)}
+                  onClick={() => handleUse(id)}
                 >
                   Use
                 </button>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -35,7 +35,9 @@ function ExplorerFilterSetWorkspace() {
     }
   }
 
-  const disableNew = Object.values(workspace.all).some(checkIfFilterEmpty);
+  const disableNew = Object.values(workspace.all).some(({ filter }) =>
+    checkIfFilterEmpty(filter)
+  );
 
   return (
     <div className='explorer-filter-set-workplace'>
@@ -73,7 +75,7 @@ function ExplorerFilterSetWorkspace() {
       </header>
       <main>
         {Object.keys(workspace.all).map((id, i) => {
-          const _filter = workspace.all[id];
+          const _filter = workspace.all[id].filter;
           return workspace.active.id === id ? (
             <div
               className='explorer-filter-set-workplace__query explorer-filter-set-workplace__query--active'

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -26,6 +26,10 @@ function ExplorerFilterSetWorkspace() {
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   useEffect(() => {
+    const activeFilterSetId = workspace.all[workspace.active.id].id;
+    if (activeFilterSetId !== undefined) filterSets.use(activeFilterSetId);
+  }, []);
+  useEffect(() => {
     if (filterSets.active?.id !== undefined)
       workspace.load(filterSets.active, true);
   }, [filterSets.active]);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -32,11 +32,15 @@ function ExplorerFilterSetWorkspace() {
     setShowActionForm(undefined);
   }
 
+  function updateFilterSet(updated) {
+    filterSets.use(updated.id);
+    handleFilterChange(updated.filter);
+  }
   function handleCreate() {
-    workspace.create(({ filter }) => handleFilterChange(filter));
+    workspace.create(updateFilterSet);
   }
   function handleDuplicate() {
-    workspace.duplicate(({ filter }) => handleFilterChange(filter));
+    workspace.duplicate(updateFilterSet);
   }
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {
@@ -45,14 +49,11 @@ function ExplorerFilterSetWorkspace() {
     closeActionForm();
   }
   function handleRemove() {
-    workspace.remove(({ filter }) => handleFilterChange(filter));
+    workspace.remove(updateFilterSet);
   }
   /** @param {string} id */
   function handleUse(id) {
-    workspace.use(id, (used) => {
-      filterSets.use(used.id);
-      handleFilterChange(used.filter);
-    });
+    workspace.use(id, updateFilterSet);
   }
 
   /** @type {import('../../components/FilterDisplay').ClickCombineModeHandler} */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -89,7 +89,8 @@ function ExplorerFilterSetWorkspace() {
       </header>
       <main>
         {Object.keys(workspace.all).map((id, i) => {
-          const _filter = workspace.all[id].filter;
+          const filterSet = workspace.all[id];
+          const name = `#${i + 1}`;
           return workspace.active.id === id ? (
             <div
               className='explorer-filter-set-workplace__query explorer-filter-set-workplace__query--active'
@@ -103,14 +104,14 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Active
                 </button>
-                <h3>{`#${i + 1}`}</h3>
+                <h3>{name}</h3>
               </header>
               <main>
-                {checkIfFilterEmpty(_filter) ? (
+                {checkIfFilterEmpty(filterSet.filter) ? (
                   <h4>Try Filters to explore data</h4>
                 ) : (
                   <FilterDisplay
-                    filter={_filter}
+                    filter={filterSet.filter}
                     filterInfo={filterInfo}
                     onClickCombineMode={handleClickCombineMode}
                     onCloseFilter={handleCloseFilter}
@@ -128,13 +129,16 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Use
                 </button>
-                <h3>{`#${i + 1}`}</h3>
+                <h3>{name}</h3>
               </header>
               <main>
-                {checkIfFilterEmpty(_filter) ? (
+                {checkIfFilterEmpty(filterSet.filter) ? (
                   <h4>Try Filters to explore data</h4>
                 ) : (
-                  <FilterDisplay filter={_filter} filterInfo={filterInfo} />
+                  <FilterDisplay
+                    filter={filterSet.filter}
+                    filterInfo={filterInfo}
+                  />
                 )}
               </main>
             </div>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -118,7 +118,9 @@ function ExplorerFilterSetWorkspace() {
           className='explorer-filter-set-workplace__action-button'
           type='button'
           onClick={handleDuplicate}
-          disabled={checkIfFilterEmpty(workspace.active.filterSet.filter)}
+          disabled={checkIfFilterEmpty(
+            (workspace.active.filterSet ?? emptyFilterSet).filter
+          )}
         >
           Duplicate
         </button>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FilterDisplay from '../../components/FilterDisplay';
 import SimplePopup from '../../components/SimplePopup';
 import { useExplorerConfig } from '../ExplorerConfigContext';
@@ -24,6 +24,10 @@ function ExplorerFilterSetWorkspace() {
   const { handleFilterChange } = useExplorerState();
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
+  useEffect(() => {
+    if (filterSets.active?.id !== undefined)
+      workspace.load(filterSets.active, true);
+  }, [filterSets.active]);
 
   const [showActionForm, setShowActionForm] = useState(
     /** @type {WorkspaceActionType} */ (undefined)

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -9,6 +9,7 @@ import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 import {
   checkIfFilterEmpty,
+  findFilterSetIdInWorkspaceState,
   pluckFromAnchorFilter,
   pluckFromFilter,
 } from './utils';
@@ -48,10 +49,14 @@ function ExplorerFilterSetWorkspace() {
   }
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {
-    filterSets.use(loaded.id);
-    const shouldOverwrite = checkIfFilterEmpty(workspace.active.filter);
-    workspace.load(loaded, shouldOverwrite);
-    closeActionForm();
+    const foundId = findFilterSetIdInWorkspaceState(loaded.id, workspace.all);
+    if (foundId !== undefined) {
+      workspace.use(foundId, closeActionForm);
+    } else {
+      filterSets.use(loaded.id);
+      const shouldOverwrite = checkIfFilterEmpty(workspace.active.filter);
+      workspace.load(loaded, shouldOverwrite, closeActionForm);
+    }
   }
   function handleRemove() {
     workspace.remove(updateFilterSet);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -125,7 +125,7 @@ function ExplorerFilterSetWorkspace() {
       <main>
         {Object.keys(workspace.all).map((id, i) => {
           const filterSet = workspace.all[id];
-          const name = `#${i + 1}`;
+          const name = 'name' in filterSet ? filterSet.name : undefined;
           return workspace.active.id === id ? (
             <div
               className='explorer-filter-set-workplace__query explorer-filter-set-workplace__query--active'
@@ -139,7 +139,9 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Active
                 </button>
-                <h3>{name}</h3>
+                <h3 title={name}>
+                  #{i + 1} {name}
+                </h3>
               </header>
               <main>
                 {checkIfFilterEmpty(filterSet.filter) ? (
@@ -164,7 +166,9 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Use
                 </button>
-                <h3>{name}</h3>
+                <h3 title={name}>
+                  #{i + 1} {name}
+                </h3>
               </header>
               <main>
                 {checkIfFilterEmpty(filterSet.filter) ? (

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -26,7 +26,7 @@ function ExplorerFilterSetWorkspace() {
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   useEffect(() => {
-    const activeFilterSetId = workspace.all[workspace.active.id].id;
+    const activeFilterSetId = workspace.active.filterSet.id;
     if (activeFilterSetId !== undefined) filterSets.use(activeFilterSetId);
   }, []);
   useEffect(() => {
@@ -58,7 +58,9 @@ function ExplorerFilterSetWorkspace() {
       workspace.use(foundId, closeActionForm);
     } else {
       filterSets.use(loaded.id);
-      const shouldOverwrite = checkIfFilterEmpty(workspace.active.filter);
+      const shouldOverwrite = checkIfFilterEmpty(
+        workspace.active.filterSet.filter
+      );
       workspace.load(loaded, shouldOverwrite, closeActionForm);
     }
   }
@@ -74,7 +76,7 @@ function ExplorerFilterSetWorkspace() {
   function handleClickCombineMode(payload) {
     handleFilterChange(
       /** @type {import('../types').ExplorerFilter} */ ({
-        ...workspace.active.filter,
+        ...workspace.active.filterSet.filter,
         __combineMode: payload === 'AND' ? 'OR' : 'AND',
       })
     );
@@ -82,7 +84,7 @@ function ExplorerFilterSetWorkspace() {
   /** @type {import('../../components/FilterDisplay').ClickFilterHandler} */
   function handleCloseFilter(payload) {
     const { field, anchorField, anchorValue } = payload;
-    const { filter } = workspace.active;
+    const { filter } = workspace.active.filterSet;
     if (anchorField !== undefined && anchorValue !== undefined) {
       const anchor = `${anchorField}:${anchorValue}`;
       handleFilterChange(pluckFromAnchorFilter({ anchor, field, filter }));
@@ -116,7 +118,7 @@ function ExplorerFilterSetWorkspace() {
           className='explorer-filter-set-workplace__action-button'
           type='button'
           onClick={handleDuplicate}
-          disabled={checkIfFilterEmpty(workspace.active.filter)}
+          disabled={checkIfFilterEmpty(workspace.active.filterSet.filter)}
         >
           Duplicate
         </button>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -55,14 +55,15 @@ function ExplorerFilterSetWorkspace() {
   function handleLoad(loaded) {
     const foundId = findFilterSetIdInWorkspaceState(loaded.id, workspace.all);
     if (foundId !== undefined) {
-      workspace.use(foundId, closeActionForm);
+      workspace.use(foundId, updateFilterSet);
     } else {
       filterSets.use(loaded.id);
       const shouldOverwrite = checkIfFilterEmpty(
         workspace.active.filterSet.filter
       );
-      workspace.load(loaded, shouldOverwrite, closeActionForm);
+      workspace.load(loaded, shouldOverwrite, updateFilterSet);
     }
+    closeActionForm();
   }
   function handleRemove() {
     workspace.remove(updateFilterSet);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -49,7 +49,7 @@ function ExplorerFilterSetWorkspace() {
     workspace.create(updateFilterSet);
   }
   function handleDuplicate() {
-    workspace.duplicate(updateFilterSet);
+    workspace.duplicate(({ id }) => filterSets.use(id));
   }
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -15,17 +15,17 @@ function ExplorerFilterSetWorkspace() {
   const workspace = useFilterSetWorkspace();
 
   function handleCreate() {
-    workspace.create(handleFilterChange);
+    workspace.create(({ filter }) => handleFilterChange(filter));
   }
   function handleDuplicate() {
-    workspace.duplicate(handleFilterChange);
+    workspace.duplicate(({ filter }) => handleFilterChange(filter));
   }
   function handleRemove() {
-    workspace.remove(handleFilterChange);
+    workspace.remove(({ filter }) => handleFilterChange(filter));
   }
   /** @param {string} id */
   function handleUse(id) {
-    workspace.use(id, handleFilterChange);
+    workspace.use(id, ({ filter }) => handleFilterChange(filter));
   }
 
   /** @type {import('../../components/FilterDisplay').ClickCombineModeHandler} */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/index.jsx
@@ -49,7 +49,8 @@ function ExplorerFilterSetWorkspace() {
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {
     filterSets.use(loaded.id);
-    workspace.load(loaded);
+    const shouldOverwrite = checkIfFilterEmpty(workspace.active.filter);
+    workspace.load(loaded, shouldOverwrite);
     closeActionForm();
   }
   function handleRemove() {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
@@ -26,6 +26,14 @@ type FilterSetWorkspaceDuplicateAction = {
   };
 };
 
+type FilterSetWorkspaceLoadAction = {
+  type: 'LOAD';
+  payload: {
+    filterSet: ExplorerFilterSet;
+    callback?: FilterSetWorkspaceActionCallback;
+  };
+};
+
 type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
@@ -46,5 +54,6 @@ type FilterSetWorkspaceUpdateAction = {
 export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction
+  | FilterSetWorkspaceLoadAction
   | FilterSetWorkspaceRemoveAction
   | FilterSetWorkspaceUpdateAction;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
@@ -6,9 +6,9 @@ export type FilterSetWorkspaceState = {
   [key: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
 };
 
-type FilterSetWorkspaceActionCallback = (args: {
+export type FilterSetWorkspaceActionCallback = (args: {
   id: string;
-  filter: ExplorerFilter;
+  filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
 }) => void;
 
 type FilterSetWorkspaceCreactAction = {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
@@ -1,6 +1,10 @@
-import type { ExplorerFilter } from '../types';
+import type { ExplorerFilter, ExplorerFilterSet } from '../types';
 
-export type FilterSetWorkspaceState = { [key: string]: ExplorerFilter };
+export type UnsavedExplorerFilterSet = Pick<ExplorerFilterSet, 'filter'>;
+
+export type FilterSetWorkspaceState = {
+  [key: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
+};
 
 type FilterSetWorkspaceActionCallback = (args: {
   id: string;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
@@ -29,6 +29,7 @@ type FilterSetWorkspaceDuplicateAction = {
 type FilterSetWorkspaceLoadAction = {
   type: 'LOAD';
   payload: {
+    id?: string;
     filterSet: ExplorerFilterSet;
     callback?: FilterSetWorkspaceActionCallback;
   };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/types.ts
@@ -1,6 +1,6 @@
 import type { ExplorerFilter, ExplorerFilterSet } from '../types';
 
-export type UnsavedExplorerFilterSet = Pick<ExplorerFilterSet, 'filter'>;
+export type UnsavedExplorerFilterSet = Pick<ExplorerFilterSet, 'filter' | 'id'>;
 
 export type FilterSetWorkspaceState = {
   [key: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -24,24 +24,24 @@ function reducer(state, action) {
 
       payload.callback?.({ filter, id });
 
-      return { ...state, [id]: filter };
+      return { ...state, [id]: { filter } };
     }
     case 'REMOVE': {
       const newState = cloneDeep(state);
       delete newState[payload.id];
 
-      const [id, filter] = Object.entries(newState)[0];
+      const [id, { filter }] = Object.entries(newState)[0];
       payload.callback?.({ filter, id });
 
       return newState;
     }
     case 'DUPLICATE': {
       const id = crypto.randomUUID();
-      const filter = cloneDeep(state[payload.id]);
+      const filter = cloneDeep(state[payload.id].filter);
 
       payload.callback?.({ filter, id });
 
-      return { ...state, [id]: filter };
+      return { ...state, [id]: { filter } };
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
@@ -49,7 +49,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filter, id });
 
-      return { ...state, [id]: filter };
+      return { ...state, [id]: { filter } };
     }
     default:
       return state;
@@ -62,9 +62,9 @@ export default function useFilterSetWorkspace() {
     const wsState = initializeWorkspaceState(explorerFilter);
 
     // sync filter UI with non-empty initial filter
-    const filters = Object.values(wsState);
-    if (filters.length > 1 || !checkIfFilterEmpty(filters[0]))
-      handleFilterChange(filters[0]);
+    const values = Object.values(wsState);
+    if (values.length > 1 || !checkIfFilterEmpty(values[0].filter))
+      handleFilterChange(values[0].filter);
 
     return wsState;
   }, []);
@@ -137,12 +137,12 @@ export default function useFilterSetWorkspace() {
    */
   function use(newId, callback) {
     setId(newId);
-    callback?.(wsState[newId]);
+    callback?.(wsState[newId].filter);
   }
 
   return useMemo(
     () => ({
-      active: { id, filter: wsState[id] },
+      active: { id, filter: wsState[id].filter },
       all: wsState,
       size: Object.keys(wsState).length,
       create,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -22,6 +22,7 @@ import {
 /**
  * @param {FilterSetWorkspaceState} state
  * @param {FilterSetWorkspaceAction} action
+ * @returns {FilterSetWorkspaceState}
  */
 function reducer(state, action) {
   const { type, payload } = action;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
 /** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
 
@@ -34,6 +35,14 @@ function reducer(state, action) {
       payload.callback?.({ filter, id });
 
       return newState;
+    }
+    case 'LOAD': {
+      const id = crypto.randomUUID();
+      const filterSet = cloneDeep(payload.filterSet);
+
+      payload.callback?.({ filter: filterSet.filter, id });
+
+      return { ...state, [id]: filterSet };
     }
     case 'DUPLICATE': {
       const id = crypto.randomUUID();
@@ -98,6 +107,23 @@ export default function useFilterSetWorkspace() {
     });
   }
 
+  /**
+   * @param {ExplorerFilterSet} filterSet
+   * @param {(filter: ExplorerFilter) => void} [callback]
+   */
+  function load(filterSet, callback) {
+    dispatch({
+      type: 'LOAD',
+      payload: {
+        filterSet,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filter);
+        },
+      },
+    });
+  }
+
   /** @param {(filter: ExplorerFilter) => void} [callback] */
   function remove(callback) {
     dispatch({
@@ -147,6 +173,7 @@ export default function useFilterSetWorkspace() {
       size: Object.keys(wsState).length,
       create,
       duplicate,
+      load,
       remove,
       update,
       use,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -76,15 +76,15 @@ function reducer(state, action) {
 
 export default function useFilterSetWorkspace() {
   const { explorerFilter, handleFilterChange } = useExplorerState();
-  const initialWsState = useMemo(() => {
-    const wsState = initializeWorkspaceState(explorerFilter);
-
-    // sync filter UI with non-empty initial filter
-    const values = Object.values(wsState);
+  const initialWsState = useMemo(
+    () => initializeWorkspaceState(explorerFilter),
+    []
+  );
+  useEffect(() => {
+    // sync filter UI with non-empty initial workspace filter
+    const values = Object.values(initialWsState);
     if (values.length > 1 || !checkIfFilterEmpty(values[0].filter))
       handleFilterChange(values[0].filter);
-
-    return wsState;
   }, []);
   const [id, setId] = useState(Object.keys(initialWsState)[0]);
   const [wsState, dispatch] = useReducer(reducer, initialWsState);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -62,7 +62,7 @@ function reducer(state, action) {
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
-      const filterSet = { filter: cloneDeep(newFilter) };
+      const filterSet = { ...state[id], filter: cloneDeep(newFilter) };
 
       payload.callback?.({ filterSet, id });
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -45,7 +45,7 @@ function reducer(state, action) {
       return newState;
     }
     case 'LOAD': {
-      const id = crypto.randomUUID();
+      const id = payload.id ?? crypto.randomUUID();
       const filterSet = cloneDeep(payload.filterSet);
 
       payload.callback?.({ filterSet, id });
@@ -117,12 +117,14 @@ export default function useFilterSetWorkspace() {
 
   /**
    * @param {ExplorerFilterSet} filterSet
+   * @param {boolean} [shouldOverwrite]
    * @param {FilterSetWorkspaceMethodCallback} [callback]
    */
-  function load(filterSet, callback) {
+  function load(filterSet, shouldOverwrite, callback) {
     dispatch({
       type: 'LOAD',
       payload: {
+        id: shouldOverwrite ? id : undefined,
         filterSet,
         callback(args) {
           setId(args.id);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/useFilterSetWorkspace.js
@@ -179,7 +179,7 @@ export default function useFilterSetWorkspace() {
 
   return useMemo(
     () => ({
-      active: { id, filter: wsState[id].filter },
+      active: { id, filterSet: wsState[id] },
       all: wsState,
       size: Object.keys(wsState).length,
       create,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/utils.js
@@ -49,7 +49,7 @@ export function retrieveWorkspaceState() {
     return JSON.parse(str);
   } catch (e) {
     if (e.message !== 'No stored query') console.error(e);
-    return { [crypto.randomUUID()]: {} };
+    return { [crypto.randomUUID()]: { filter: {} } };
   }
 }
 
@@ -57,7 +57,7 @@ export function retrieveWorkspaceState() {
 export function initializeWorkspaceState(filter) {
   return checkIfFilterEmpty(filter)
     ? retrieveWorkspaceState()
-    : { [crypto.randomUUID()]: filter };
+    : { [crypto.randomUUID()]: { filter } };
 }
 
 /** @param {FilterSetWorkspaceState} state */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkplace/utils.js
@@ -1,4 +1,5 @@
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
 
 /**
@@ -66,4 +67,15 @@ export function storeWorkspaceState(state) {
     workspaceStateSessionStorageKey,
     JSON.stringify(state)
   );
+}
+
+/**
+ * @param {number} filterSetId
+ * @param {FilterSetWorkspaceState} state
+ */
+export function findFilterSetIdInWorkspaceState(filterSetId, state) {
+  for (const [id, filterSet] of Object.entries(state))
+    if ('id' in filterSet && filterSet.id === filterSetId) return id;
+
+  return undefined;
 }


### PR DESCRIPTION
Ticket: [PEDS-704](https://pcdc.atlassian.net/browse/PEDS-704)

This PR implements the "load" feature for `<ExplorerFilterSetWorkspace>` that supports loading existing saved filter sets directly to workspace.

The "load" feature for workspace works as follows:

* Loading is enabled only if at least one saved filter set is available
* Loading a saved filter set uses the current active workspace filter set if its filter is empty; otherwise, it creates and uses a new workspace filter set
* Loaded saved filter set will display its name
  * Long names will be truncated, but hovering over a truncated name will show the full name via `"title"` attribute 
* Loading a saved filter set that is already loaded to the workspace will simply use the corresponding workspace filter set (making it "active"); this avoids loading the same saved filter set multiple times
* Duplicating a loaded saved filter set only duplicates the filter content, not the filter set as a whole

See the following demo screen recording:

https://user-images.githubusercontent.com/22449454/170089603-decaff56-426b-4138-add1-04a623669a75.mov

\*
\*
\*

**NB:** There are a few known sub-optimal behaviors on mixing the original filter set UI (located on the sidebar) and the new workspace UI for using saved filter sets. These are left intact as the workspace UI is currently planned to replace the original filter set UI.

If it is later decided to keep them both, the following behaviors (and potentially more) will have to be addressed:

* loading the same saved filter set multiple times is still possible via the filter set section on the sidebar.
* clicking "New" in the old filter set UI when a saved filter set is loaded and active in workspace UI doesn't clear the filter set information in the workspace as it should.
