### PR TITLE
Support saving filter set on workspace PEDS-705

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import { createEmptyFilterSet } from '../ExplorerFilterSet/utils';
+import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
+import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
+
+/** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
+
+const emptyFilterSet = createEmptyFilterSet();
+
+/**
+ * @param {Object} prop
+ * @param {FilterSetWorkspaceAction['type']} prop.actionType
+ * @param {object} prop.handlers
+ * @param {() => void} prop.handlers.close
+ * @param {(loaded: ExplorerFilterSet) => void} prop.handlers.load
+ */
+function FilterSetActionForm({ actionType, handlers }) {
+  const filterSets = useExplorerFilterSets();
+  switch (actionType) {
+    case 'LOAD':
+      return (
+        <FilterSetOpenForm
+          currentFilterSet={filterSets.active ?? emptyFilterSet}
+          filterSets={filterSets.all}
+          onAction={handlers.load}
+          onClose={handlers.close}
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+FilterSetActionForm.propTypes = {
+  actionType: PropTypes.oneOf(['LOAD']),
+  handlers: PropTypes.shape({
+    close: PropTypes.func,
+    load: PropTypes.func,
+  }),
+};
+
+export default FilterSetActionForm;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
 import { createEmptyFilterSet } from '../ExplorerFilterSet/utils';
+import FilterSetCreateForm from '../ExplorerFilterSetForms/FilterSetCreateForm';
 import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
+import FilterSetUpdateForm from '../ExplorerFilterSetForms/FilterSetUpdateForm';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
+import useFilterSetWorkspace from './useFilterSetWorkspace';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
@@ -14,9 +17,11 @@ const emptyFilterSet = createEmptyFilterSet();
  * @param {object} prop.handlers
  * @param {() => void} prop.handlers.close
  * @param {(loaded: ExplorerFilterSet) => void} prop.handlers.load
+ * @param {(saved: ExplorerFilterSet) => void} prop.handlers.save
  */
 function FilterSetActionForm({ actionType, handlers }) {
   const filterSets = useExplorerFilterSets();
+  const workspace = useFilterSetWorkspace();
   switch (actionType) {
     case 'LOAD':
       return (
@@ -27,16 +32,37 @@ function FilterSetActionForm({ actionType, handlers }) {
           onClose={handlers.close}
         />
       );
+    case 'SAVE':
+      return filterSets.active === undefined ? (
+        <FilterSetCreateForm
+          currentFilter={workspace.active.filterSet.filter}
+          currentFilterSet={emptyFilterSet}
+          filterSets={filterSets.all}
+          onAction={handlers.save}
+          onClose={handlers.close}
+          isFiltersChanged={false}
+        />
+      ) : (
+        <FilterSetUpdateForm
+          currentFilter={workspace.active.filterSet.filter}
+          currentFilterSet={filterSets.active}
+          filterSets={filterSets.all}
+          onAction={handlers.save}
+          onClose={handlers.close}
+          isFiltersChanged={false}
+        />
+      );
     default:
       return null;
   }
 }
 
 FilterSetActionForm.propTypes = {
-  actionType: PropTypes.oneOf(['LOAD']),
+  actionType: PropTypes.oneOf(['LOAD', 'SAVE']),
   handlers: PropTypes.shape({
     close: PropTypes.func,
     load: PropTypes.func,
+    save: PropTypes.func,
   }),
 };
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -6,7 +6,7 @@ import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerState } from '../ExplorerStateContext';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import { createEmptyFilterSet } from '../ExplorerFilterSet/utils';
-import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
+import FilterSetActionForm from './FilterSetActionForm';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 import {
   checkIfFilterEmpty,
@@ -236,14 +236,13 @@ function ExplorerFilterSetWorkspace() {
       </main>
       {showActionForm !== undefined && (
         <SimplePopup>
-          {showActionForm === 'LOAD' && (
-            <FilterSetOpenForm
-              currentFilterSet={filterSets.active ?? emptyFilterSet}
-              filterSets={filterSets.all}
-              onAction={handleLoad}
-              onClose={closeActionForm}
-            />
-          )}
+          <FilterSetActionForm
+            actionType={showActionForm}
+            handlers={{
+              close: closeActionForm,
+              load: handleLoad,
+            }}
+          />
         </SimplePopup>
       )}
     </div>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -66,6 +66,21 @@ function ExplorerFilterSetWorkspace() {
     }
     closeActionForm();
   }
+  /** @param {ExplorerFilterSet} saved */
+  async function handleSave(saved) {
+    try {
+      let filterSet = saved;
+      if (saved.id === undefined) filterSet = await filterSets.create(saved);
+      else await filterSets.update(saved);
+
+      filterSets.use(filterSet.id);
+      await filterSets.refresh();
+
+      workspace.load(filterSet, true);
+    } finally {
+      closeActionForm();
+    }
+  }
   function handleRemove() {
     workspace.remove(updateFilterSet);
   }
@@ -164,6 +179,16 @@ function ExplorerFilterSetWorkspace() {
             <button
               className='explorer-filter-set-workspace__action-button'
               type='button'
+              onClick={() => setShowActionForm('SAVE')}
+              disabled={checkIfFilterEmpty(
+                (workspace.active.filterSet ?? emptyFilterSet).filter
+              )}
+            >
+              Save
+            </button>
+            <button
+              className='explorer-filter-set-workspace__action-button'
+              type='button'
               onClick={handleRemove}
               disabled={workspace.size < 2}
             >
@@ -241,6 +266,7 @@ function ExplorerFilterSetWorkspace() {
             handlers={{
               close: closeActionForm,
               load: handleLoad,
+              save: handleSave,
             }}
           />
         </SimplePopup>

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -35,6 +35,15 @@ type FilterSetWorkspaceLoadAction = {
   };
 };
 
+type FilterSetWorkspaceSaveAction = {
+  type: 'SAVE';
+  payload: {
+    id: string;
+    filterSet: ExplorerFilterSet;
+    callback?: FilterSetWorkspaceActionCallback;
+  };
+};
+
 type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
@@ -56,5 +65,6 @@ export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction
   | FilterSetWorkspaceLoadAction
+  | FilterSetWorkspaceSaveAction
   | FilterSetWorkspaceRemoveAction
   | FilterSetWorkspaceUpdateAction;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -53,6 +53,13 @@ function reducer(state, action) {
 
       return { ...state, [id]: filterSet };
     }
+    case 'SAVE': {
+      const { filterSet, id } = payload;
+
+      payload.callback?.({ filterSet, id });
+
+      return { ...state, [id]: filterSet };
+    }
     case 'DUPLICATE': {
       const id = crypto.randomUUID();
       const filterSet = { filter: cloneDeep(state[payload.id].filter) };
@@ -135,6 +142,24 @@ export default function useFilterSetWorkspace() {
     });
   }
 
+  /**
+   * @param {ExplorerFilterSet} filterSet
+   * @param {FilterSetWorkspaceMethodCallback} [callback]
+   */
+  function save(filterSet, callback) {
+    dispatch({
+      type: 'SAVE',
+      payload: {
+        id,
+        filterSet,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filterSet);
+        },
+      },
+    });
+  }
+
   /** @param {FilterSetWorkspaceMethodCallback} [callback] */
   function remove(callback) {
     dispatch({
@@ -185,6 +210,7 @@ export default function useFilterSetWorkspace() {
       create,
       duplicate,
       load,
+      save,
       remove,
       update,
       use,


### PR DESCRIPTION
Ticket: [PEDS-705](https://pcdc.atlassian.net/browse/PEDS-705)

This PR implements the "save" feature for `<ExplorerFilterSetWorkspace>` that supports saving the active filter set on workspace.

The "save" feature for workspace works as follows:

* Saving is enabled only if the filter for the active workspace filter is _not_ empty
* Saving an unsaved filter set will create a new saved filter set
* Saving an already existing saved filter set will update the saved filter set.
 
See the following demo screen recording:


https://user-images.githubusercontent.com/22449454/170368451-c553c70c-5733-44f4-a8e2-26c9af2e15ae.mov

