### PR TITLE
Support displaying saved filter set info on workspace PEDS-748

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetLabel.css
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetLabel.css
@@ -1,0 +1,21 @@
+.filter-set-label h4 {
+  font-size: 0.8rem;
+}
+
+.filter-set-label h4:not(:first-of-type) {
+  margin-top: 0.5rem;
+}
+
+.filter-set-label textarea {
+  border: none;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  height: auto;
+  resize: none;
+  width: auto;
+}
+
+.filter-set-label textarea:disabled {
+  background-color: transparent;
+}

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetLabel.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetLabel.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
+import './FilterSetLabel.css';
+
+/** @param {string} value */
+function getTextareaAttrs(value) {
+  let cols = 10;
+  if (value.length > 10)
+    if (value.length < 15) cols = 15;
+    else if (value.length < 20) cols = 20;
+    else cols = 30;
+
+  const maxRows = 8;
+  let rows = 2;
+  if (value.length > 30)
+    rows = Math.min(maxRows, Math.ceil(value.length / cols) + 1);
+
+  return { cols, rows, value };
+}
+
+/**
+ * @param {Object} props
+ * @param {Object} props.filterSet
+ * @param {string} [props.filterSet.description]
+ * @param {string} [props.filterSet.name]
+ * @param {number} props.index
+ */
+function FilterSetLabel({ filterSet: { description = '', name = '' }, index }) {
+  return name === '' ? (
+    <h3>#{index}</h3>
+  ) : (
+    <Tooltip
+      arrowContent={<div className='rc-tooltip-arrow-inner' />}
+      overlayStyle={{ maxWidth: 220 }}
+      overlay={
+        <section className='filter-set-label'>
+          <h4>Name</h4>
+          <p>{name}</p>
+          {description !== '' && (
+            <>
+              <h4>Description</h4>
+              <textarea disabled {...getTextareaAttrs(description)} />
+            </>
+          )}
+        </section>
+      }
+    >
+      <h3>
+        #{index} {name}
+      </h3>
+    </Tooltip>
+  );
+}
+
+FilterSetLabel.propTypes = {
+  filterSet: PropTypes.shape({
+    description: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  index: PropTypes.number.isRequired,
+};
+
+export default FilterSetLabel;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -7,6 +7,7 @@ import { useExplorerState } from '../ExplorerStateContext';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import { createEmptyFilterSet } from '../ExplorerFilterSet/utils';
 import FilterSetActionForm from './FilterSetActionForm';
+import FilterSetLabel from './FilterSetLabel';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 import {
   checkIfFilterEmpty,
@@ -200,7 +201,6 @@ function ExplorerFilterSetWorkspace() {
       <main>
         {Object.keys(workspace.all).map((id, i) => {
           const filterSet = workspace.all[id];
-          const name = 'name' in filterSet ? filterSet.name : undefined;
           return workspace.active.id === id ? (
             <div
               className='explorer-filter-set-workspace__query explorer-filter-set-workspace__query--active'
@@ -214,9 +214,7 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Active
                 </button>
-                <h3 title={name}>
-                  #{i + 1} {name}
-                </h3>
+                <FilterSetLabel filterSet={filterSet} index={i + 1} />
               </header>
               <main>
                 {checkIfFilterEmpty(filterSet.filter) ? (
@@ -241,9 +239,7 @@ function ExplorerFilterSetWorkspace() {
                 >
                   Use
                 </button>
-                <h3 title={name}>
-                  #{i + 1} {name}
-                </h3>
+                <FilterSetLabel filterSet={filterSet} index={i + 1} />
               </header>
               <main>
                 {checkIfFilterEmpty(filterSet.filter) ? (

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -1,6 +1,12 @@
 import type { ExplorerFilter, ExplorerFilterSet } from '../types';
 
-export type UnsavedExplorerFilterSet = Pick<ExplorerFilterSet, 'filter' | 'id'>;
+export type UnsavedExplorerFilterSet = Pick<
+  ExplorerFilterSet,
+  'filter' | 'id'
+> & {
+  name?: never;
+  description?: never;
+};
 
 export type FilterSetWorkspaceState = {
   [key: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;


### PR DESCRIPTION
Ticket: [PEDS-748](https://pcdc.atlassian.net/browse/PEDS-748)

This PR implements displaying saved filter sets' name and description info on workspace.

See the following demo screen recording:

https://user-images.githubusercontent.com/22449454/170538132-86d3ccd3-8ff7-43a3-b8b2-784fe62e46a0.mov
