### PR TITLE
Fix lingering Filter Section search input across tabs PEDS-752

### DIFF
--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -347,7 +347,7 @@ function FilterGroup({
         )}
         {tabs[tabIndex].map((section, index) => (
           <FilterSection
-            key={index}
+            key={section.title}
             disabledTooltipMessage={disabledTooltipMessage}
             expanded={expandedStatus[tabIndex][index]}
             filterStatus={filterTabStatus[index]}


### PR DESCRIPTION
Ticket: [PEDS-752](https://pcdc.atlassian.net/browse/PEDS-752)

This PR is a simple fix for the lingering search input state for `<FilterSection>` across tabs. This is caused by using simple array index as `key` for `<FilterSection>` in loop, which remains the same across filter tabs. The fix uses section title as the new `key` value.