### PR TITLE
Support clearing filter set(s) on workspace PEDS-750

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import Button from '../../gen3-ui-component/components/Button';
 import FilterSetCreateForm from '../ExplorerFilterSetForms/FilterSetCreateForm';
 import FilterSetDeleteForm from '../ExplorerFilterSetForms/FilterSetDeleteForm';
 import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
@@ -7,12 +8,13 @@ import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
-/** @typedef {'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
+/** @typedef {'CLEAR' | 'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
 
 /**
  * @param {Object} prop
  * @param {ActionFormType} prop.type
  * @param {Object} prop.handlers
+ * @param {() => void} prop.handlers.clear
  * @param {() => void} prop.handlers.close
  * @param {(deleted: ExplorerFilterSet) => void} prop.handlers.delete
  * @param {(loaded: ExplorerFilterSet) => void} prop.handlers.load
@@ -22,6 +24,24 @@ function FilterSetActionForm({ handlers, type }) {
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   switch (type) {
+    case 'CLEAR':
+      return (
+        <div className='explorer-filter-set-form'>
+          <h4>
+            Are you sure to clear Workspace?
+            <br />
+            All unsaved filter sets will be lost.
+          </h4>
+          <div>
+            <Button
+              buttonType='default'
+              label='Back to page'
+              onClick={handlers.close}
+            />
+            <Button label='Clear Workspace' onClick={handlers.clear} />
+          </div>
+        </div>
+      );
     case 'LOAD':
       return (
         <FilterSetOpenForm
@@ -66,12 +86,13 @@ function FilterSetActionForm({ handlers, type }) {
 
 FilterSetActionForm.propTypes = {
   handlers: PropTypes.shape({
+    clear: PropTypes.func,
     close: PropTypes.func,
     delete: PropTypes.func,
     load: PropTypes.func,
     save: PropTypes.func,
   }),
-  type: PropTypes.oneOf(['DELETE', 'LOAD', 'SAVE']),
+  type: PropTypes.oneOf(['CLEAR', 'DELETE', 'LOAD', 'SAVE']),
 };
 
 export default FilterSetActionForm;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -8,13 +8,13 @@ import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
-/** @typedef {'CLEAR' | 'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
+/** @typedef {'CLEAR-ALL' | 'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
 
 /**
  * @param {Object} prop
  * @param {ActionFormType} prop.type
  * @param {Object} prop.handlers
- * @param {() => void} prop.handlers.clear
+ * @param {() => void} prop.handlers.clearAll
  * @param {() => void} prop.handlers.close
  * @param {(deleted: ExplorerFilterSet) => void} prop.handlers.delete
  * @param {(loaded: ExplorerFilterSet) => void} prop.handlers.load
@@ -24,13 +24,13 @@ function FilterSetActionForm({ handlers, type }) {
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   switch (type) {
-    case 'CLEAR':
+    case 'CLEAR-ALL':
       return (
         <div className='explorer-filter-set-form'>
           <h4>
             Are you sure to clear Workspace?
             <br />
-            All unsaved filter sets will be lost.
+            All unsaved changes to Filter Sets will be lost.
           </h4>
           <div>
             <Button
@@ -38,7 +38,7 @@ function FilterSetActionForm({ handlers, type }) {
               label='Back to page'
               onClick={handlers.close}
             />
-            <Button label='Clear Workspace' onClick={handlers.clear} />
+            <Button label='Clear Workspace' onClick={handlers.clearAll} />
           </div>
         </div>
       );
@@ -86,13 +86,13 @@ function FilterSetActionForm({ handlers, type }) {
 
 FilterSetActionForm.propTypes = {
   handlers: PropTypes.shape({
-    clear: PropTypes.func,
+    clearAll: PropTypes.func,
     close: PropTypes.func,
     delete: PropTypes.func,
     load: PropTypes.func,
     save: PropTypes.func,
   }),
-  type: PropTypes.oneOf(['CLEAR', 'DELETE', 'LOAD', 'SAVE']),
+  type: PropTypes.oneOf(['CLEAR-ALL', 'DELETE', 'LOAD', 'SAVE']),
 };
 
 export default FilterSetActionForm;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -44,8 +44,8 @@ function ExplorerFilterSetWorkspace() {
     filterSets.use(updated.id);
     handleFilterChange(updated.filter);
   }
-  function handleClear() {
-    workspace.clear((filterSet) => {
+  function handleClearAll() {
+    workspace.clearAll((filterSet) => {
       updateFilterSet(filterSet);
       closeActionForm();
     });
@@ -225,7 +225,7 @@ function ExplorerFilterSetWorkspace() {
             <button
               className='explorer-filter-set-workspace__action-button'
               type='button'
-              onClick={() => setActionFormType('CLEAR')}
+              onClick={() => setActionFormType('CLEAR-ALL')}
               disabled={Object.keys(workspace.all).length < 2}
             >
               Clear all
@@ -312,7 +312,7 @@ function ExplorerFilterSetWorkspace() {
         <SimplePopup>
           <FilterSetActionForm
             handlers={{
-              clear: handleClear,
+              clearAll: handleClearAll,
               close: closeActionForm,
               delete: handleDelete,
               load: handleLoad,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -21,7 +21,7 @@ import './ExplorerFilterSetWorkspace.css';
 
 function ExplorerFilterSetWorkspace() {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
-  const { handleFilterChange, handleFilterClear } = useExplorerState();
+  const { handleFilterChange } = useExplorerState();
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   useEffect(() => {
@@ -43,6 +43,9 @@ function ExplorerFilterSetWorkspace() {
   function updateFilterSet(updated) {
     filterSets.use(updated.id);
     handleFilterChange(updated.filter);
+  }
+  function handleClear() {
+    workspace.clear(updateFilterSet);
   }
   function handleClearAll() {
     workspace.clearAll((filterSet) => {
@@ -215,7 +218,7 @@ function ExplorerFilterSetWorkspace() {
             <button
               className='explorer-filter-set-workspace__action-button'
               type='button'
-              onClick={handleFilterClear}
+              onClick={handleClear}
               disabled={checkIfFilterEmpty(
                 (workspace.active.filterSet ?? filterSets.empty).filter
               )}

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -44,6 +44,9 @@ function ExplorerFilterSetWorkspace() {
     filterSets.use(updated.id);
     handleFilterChange(updated.filter);
   }
+  function handleClearAll() {
+    workspace.clear(updateFilterSet);
+  }
   function handleCreate() {
     workspace.create(updateFilterSet);
   }
@@ -215,6 +218,14 @@ function ExplorerFilterSetWorkspace() {
               )}
             >
               Clear
+            </button>
+            <button
+              className='explorer-filter-set-workspace__action-button'
+              type='button'
+              onClick={handleClearAll}
+              disabled={Object.keys(workspace.all).length < 2}
+            >
+              Clear all
             </button>
             <button
               className='explorer-filter-set-workspace__action-button'

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -44,8 +44,11 @@ function ExplorerFilterSetWorkspace() {
     filterSets.use(updated.id);
     handleFilterChange(updated.filter);
   }
-  function handleClearAll() {
-    workspace.clear(updateFilterSet);
+  function handleClear() {
+    workspace.clear((filterSet) => {
+      updateFilterSet(filterSet);
+      closeActionForm();
+    });
   }
   function handleCreate() {
     workspace.create(updateFilterSet);
@@ -222,7 +225,7 @@ function ExplorerFilterSetWorkspace() {
             <button
               className='explorer-filter-set-workspace__action-button'
               type='button'
-              onClick={handleClearAll}
+              onClick={() => setActionFormType('CLEAR')}
               disabled={Object.keys(workspace.all).length < 2}
             >
               Clear all
@@ -309,6 +312,7 @@ function ExplorerFilterSetWorkspace() {
         <SimplePopup>
           <FilterSetActionForm
             handlers={{
+              clear: handleClear,
               close: closeActionForm,
               delete: handleDelete,
               load: handleLoad,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -21,7 +21,7 @@ import './ExplorerFilterSetWorkspace.css';
 
 function ExplorerFilterSetWorkspace() {
   const filterInfo = useExplorerConfig().current.filterConfig.info;
-  const { handleFilterChange } = useExplorerState();
+  const { handleFilterChange, handleFilterClear } = useExplorerState();
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
   useEffect(() => {
@@ -205,6 +205,16 @@ function ExplorerFilterSetWorkspace() {
               }
             >
               Reset
+            </button>
+            <button
+              className='explorer-filter-set-workspace__action-button'
+              type='button'
+              onClick={handleFilterClear}
+              disabled={checkIfFilterEmpty(
+                (workspace.active.filterSet ?? filterSets.empty).filter
+              )}
+            >
+              Clear
             </button>
             <button
               className='explorer-filter-set-workspace__action-button'

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -17,6 +17,14 @@ export type FilterSetWorkspaceActionCallback = (args: {
   filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
 }) => void;
 
+type FilterSetWorkspaceClearAction = {
+  type: 'CLEAR';
+  payload: {
+    id: string;
+    callback?: FilterSetWorkspaceActionCallback;
+  };
+};
+
 type FilterSetWorkspaceClearAllAction = {
   type: 'CLEAR-ALL';
   payload: {
@@ -75,6 +83,7 @@ type FilterSetWorkspaceUpdateAction = {
 };
 
 export type FilterSetWorkspaceAction =
+  | FilterSetWorkspaceClearAction
   | FilterSetWorkspaceClearAllAction
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -17,8 +17,8 @@ export type FilterSetWorkspaceActionCallback = (args: {
   filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
 }) => void;
 
-type FilterSetWorkspaceClearAction = {
-  type: 'CLEAR';
+type FilterSetWorkspaceClearAllAction = {
+  type: 'CLEAR-ALL';
   payload: {
     callback?: FilterSetWorkspaceActionCallback;
   };
@@ -75,7 +75,7 @@ type FilterSetWorkspaceUpdateAction = {
 };
 
 export type FilterSetWorkspaceAction =
-  | FilterSetWorkspaceClearAction
+  | FilterSetWorkspaceClearAllAction
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction
   | FilterSetWorkspaceLoadAction

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -17,6 +17,13 @@ export type FilterSetWorkspaceActionCallback = (args: {
   filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
 }) => void;
 
+type FilterSetWorkspaceClearAction = {
+  type: 'CLEAR';
+  payload: {
+    callback?: FilterSetWorkspaceActionCallback;
+  };
+};
+
 type FilterSetWorkspaceCreactAction = {
   type: 'CREATE';
   payload: {
@@ -68,6 +75,7 @@ type FilterSetWorkspaceUpdateAction = {
 };
 
 export type FilterSetWorkspaceAction =
+  | FilterSetWorkspaceClearAction
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction
   | FilterSetWorkspaceLoadAction

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -27,6 +27,15 @@ import {
 function reducer(state, action) {
   const { type, payload } = action;
   switch (type) {
+    case 'CLEAR': {
+      const { id } = payload;
+      /** @type {UnsavedExplorerFilterSet} */
+      const filterSet = { filter: {} };
+
+      payload.callback?.({ filterSet, id });
+
+      return { [id]: filterSet };
+    }
     case 'CLEAR-ALL': {
       const id = crypto.randomUUID();
       /** @type {UnsavedExplorerFilterSet} */
@@ -111,6 +120,19 @@ export default function useFilterSetWorkspace() {
   const [wsState, dispatch] = useReducer(reducer, initialWsState);
   useEffect(() => storeWorkspaceState(wsState), [wsState]);
 
+  /** @param {FilterSetWorkspaceMethodCallback} [callback] */
+  function clear(callback) {
+    dispatch({
+      type: 'CLEAR',
+      payload: {
+        id,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filterSet);
+        },
+      },
+    });
+  }
   /** @param {FilterSetWorkspaceMethodCallback} [callback] */
   function clearAll(callback) {
     dispatch({
@@ -233,6 +255,7 @@ export default function useFilterSetWorkspace() {
       active: { id, filterSet: wsState[id] },
       all: wsState,
       size: Object.keys(wsState).length,
+      clear,
       clearAll,
       create,
       duplicate,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -27,7 +27,7 @@ import {
 function reducer(state, action) {
   const { type, payload } = action;
   switch (type) {
-    case 'CLEAR': {
+    case 'CLEAR-ALL': {
       const id = crypto.randomUUID();
       /** @type {UnsavedExplorerFilterSet} */
       const filterSet = { filter: {} };
@@ -112,9 +112,9 @@ export default function useFilterSetWorkspace() {
   useEffect(() => storeWorkspaceState(wsState), [wsState]);
 
   /** @param {FilterSetWorkspaceMethodCallback} [callback] */
-  function clear(callback) {
+  function clearAll(callback) {
     dispatch({
-      type: 'CLEAR',
+      type: 'CLEAR-ALL',
       payload: {
         callback(args) {
           setId(args.id);
@@ -233,7 +233,7 @@ export default function useFilterSetWorkspace() {
       active: { id, filterSet: wsState[id] },
       all: wsState,
       size: Object.keys(wsState).length,
-      clear,
+      clearAll,
       create,
       duplicate,
       load,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -27,6 +27,15 @@ import {
 function reducer(state, action) {
   const { type, payload } = action;
   switch (type) {
+    case 'CLEAR': {
+      const id = crypto.randomUUID();
+      /** @type {UnsavedExplorerFilterSet} */
+      const filterSet = { filter: {} };
+
+      payload.callback?.({ filterSet, id });
+
+      return { [id]: filterSet };
+    }
     case 'CREATE': {
       const id = crypto.randomUUID();
       /** @type {UnsavedExplorerFilterSet} */
@@ -102,6 +111,18 @@ export default function useFilterSetWorkspace() {
   const [wsState, dispatch] = useReducer(reducer, initialWsState);
   useEffect(() => storeWorkspaceState(wsState), [wsState]);
 
+  /** @param {FilterSetWorkspaceMethodCallback} [callback] */
+  function clear(callback) {
+    dispatch({
+      type: 'CLEAR',
+      payload: {
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filterSet);
+        },
+      },
+    });
+  }
   /** @param {FilterSetWorkspaceMethodCallback} [callback] */
   function create(callback) {
     dispatch({
@@ -212,6 +233,7 @@ export default function useFilterSetWorkspace() {
       active: { id, filterSet: wsState[id] },
       all: wsState,
       size: Object.keys(wsState).length,
+      clear,
       create,
       duplicate,
       load,


### PR DESCRIPTION
Ticket: [PEDS-750](https://pcdc.atlassian.net/browse/PEDS-750)

This PR implements the "clear" feature for `<ExplorerFilterSetWorkspace>` that works as follows:

*  Clearing the active filter set ("Clear") is enabled only if the active workspace filter set 1) has non-empty filter value or 2) using a saved filter set
    * "Clear" only clears the filter value for an unsaved filter set
    * "Clear" replaces an active saved filter set with a new unsaved filter set with empty filter
*  Clearing the workspace ("Clear all") is enabled only if two or more filter sets are on workspace 
    * "Clear all" will ask users to confirm their choice using modal form 

See the following demo screen recording:

https://user-images.githubusercontent.com/22449454/170742260-e1dd1efe-bc06-41ae-8c6e-8480fd61f5f7.mov

