### PR TITLE
Refactor workspace reducer

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -71,7 +71,7 @@ function ExplorerFilterSetWorkspace() {
   }
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {
-    const foundId = findFilterSetIdInWorkspaceState(loaded.id, workspace.all);
+    const foundId = findFilterSetIdInWorkspaceState(loaded.id, workspace);
     if (foundId !== undefined) {
       workspace.use(foundId, updateFilterSet);
     } else {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -40,45 +40,39 @@ function ExplorerFilterSetWorkspace() {
     setActionFormType(undefined);
   }
 
-  function updateFilterSet(updated) {
-    filterSets.use(updated.id);
-    handleFilterChange(updated.filter);
-  }
   function handleClear() {
-    workspace.clear(updateFilterSet);
+    workspace.clear();
   }
   function handleClearAll() {
-    workspace.clearAll((filterSet) => {
-      updateFilterSet(filterSet);
-      closeActionForm();
-    });
+    workspace.clearAll();
+    closeActionForm();
   }
   function handleCreate() {
-    workspace.create(updateFilterSet);
+    workspace.create();
   }
   /** @param {ExplorerFilterSet} deleted */
   async function handleDelete(deleted) {
     try {
       await filterSets.delete(deleted);
       await filterSets.refresh();
-      workspace.remove(updateFilterSet);
+      workspace.remove();
     } finally {
       closeActionForm();
     }
   }
   function handleDuplicate() {
-    workspace.duplicate(({ id }) => filterSets.use(id));
+    workspace.duplicate();
   }
   /** @param {ExplorerFilterSet} loaded */
   function handleLoad(loaded) {
     const foundId = findFilterSetIdInWorkspaceState(loaded.id, workspace);
     if (foundId !== undefined) {
-      workspace.use(foundId, updateFilterSet);
+      workspace.use(foundId);
     } else {
       const shouldOverwrite = checkIfFilterEmpty(
         workspace.active.filterSet.filter
       );
-      workspace.load(loaded, shouldOverwrite, updateFilterSet);
+      workspace.load(loaded, shouldOverwrite);
     }
     closeActionForm();
   }
@@ -90,7 +84,7 @@ function ExplorerFilterSetWorkspace() {
       else await filterSets.update(saved);
 
       await filterSets.refresh();
-      workspace.load(filterSet, true, updateFilterSet);
+      workspace.load(filterSet, true);
     } finally {
       closeActionForm();
     }
@@ -99,11 +93,11 @@ function ExplorerFilterSetWorkspace() {
     handleFilterChange(filterSets.active.filter);
   }
   function handleRemove() {
-    workspace.remove(updateFilterSet);
+    workspace.remove();
   }
   /** @param {string} id */
   function handleUse(id) {
-    workspace.use(id, updateFilterSet);
+    workspace.use(id);
   }
 
   /** @type {import('../../components/FilterDisplay').ClickCombineModeHandler} */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -12,6 +12,7 @@ export type FilterSetWorkspaceState = {
   all: {
     [id: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
   };
+  size: number;
 };
 
 export type FilterSetWorkspaceActionCallback = (args: {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -28,6 +28,7 @@ type FilterSetWorkspaceClearAction = {
 type FilterSetWorkspaceClearAllAction = {
   type: 'CLEAR-ALL';
   payload: {
+    id: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
 };
@@ -35,6 +36,7 @@ type FilterSetWorkspaceClearAllAction = {
 type FilterSetWorkspaceCreactAction = {
   type: 'CREATE';
   payload: {
+    id: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
 };
@@ -43,6 +45,7 @@ type FilterSetWorkspaceDuplicateAction = {
   type: 'DUPLICATE';
   payload: {
     id: string;
+    newId: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
 };
@@ -69,6 +72,7 @@ type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
     id: string;
+    newId: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
 };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -26,16 +26,13 @@ export type FilterSetWorkspaceActionCallback = (args: {
 
 type FilterSetWorkspaceClearAction = {
   type: 'CLEAR';
-  payload: {
-    callback?: FilterSetWorkspaceActionCallback;
-  };
+  payload: undefined;
 };
 
 type FilterSetWorkspaceClearAllAction = {
   type: 'CLEAR-ALL';
   payload: {
     id: string;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -43,7 +40,6 @@ type FilterSetWorkspaceCreactAction = {
   type: 'CREATE';
   payload: {
     id: string;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -51,7 +47,6 @@ type FilterSetWorkspaceDuplicateAction = {
   type: 'DUPLICATE';
   payload: {
     newId: string;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -60,7 +55,6 @@ type FilterSetWorkspaceLoadAction = {
   payload: {
     id?: string;
     filterSet: ExplorerFilterSet;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -68,7 +62,6 @@ type FilterSetWorkspaceSaveAction = {
   type: 'SAVE';
   payload: {
     filterSet: ExplorerFilterSet;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -76,7 +69,6 @@ type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
     newId: string;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -84,7 +76,6 @@ type FilterSetWorkspaceUpdateAction = {
   type: 'UPDATE';
   payload: {
     filter: ExplorerFilter;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 
@@ -92,7 +83,6 @@ type FilterSetWorkspaceUseAction = {
   type: 'USE';
   payload: {
     id: string;
-    callback?: FilterSetWorkspaceActionCallback;
   };
 };
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -19,33 +19,33 @@ export type FilterSetWorkspaceState = {
   size: number;
 };
 
-type FilterSetWorkspaceClearAction = {
+export type FilterSetWorkspaceClearAction = {
   type: 'CLEAR';
   payload: undefined;
 };
 
-type FilterSetWorkspaceClearAllAction = {
+export type FilterSetWorkspaceClearAllAction = {
   type: 'CLEAR-ALL';
   payload: {
     newId: string;
   };
 };
 
-type FilterSetWorkspaceCreactAction = {
+export type FilterSetWorkspaceCreactAction = {
   type: 'CREATE';
   payload: {
     newId: string;
   };
 };
 
-type FilterSetWorkspaceDuplicateAction = {
+export type FilterSetWorkspaceDuplicateAction = {
   type: 'DUPLICATE';
   payload: {
     newId: string;
   };
 };
 
-type FilterSetWorkspaceLoadAction = {
+export type FilterSetWorkspaceLoadAction = {
   type: 'LOAD';
   payload: {
     newId?: string;
@@ -53,28 +53,28 @@ type FilterSetWorkspaceLoadAction = {
   };
 };
 
-type FilterSetWorkspaceSaveAction = {
-  type: 'SAVE';
-  payload: {
-    filterSet: ExplorerFilterSet;
-  };
-};
-
-type FilterSetWorkspaceRemoveAction = {
+export type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
     newId: string;
   };
 };
 
-type FilterSetWorkspaceUpdateAction = {
+export type FilterSetWorkspaceSaveAction = {
+  type: 'SAVE';
+  payload: {
+    filterSet: ExplorerFilterSet;
+  };
+};
+
+export type FilterSetWorkspaceUpdateAction = {
   type: 'UPDATE';
   payload: {
     filter: ExplorerFilter;
   };
 };
 
-type FilterSetWorkspaceUseAction = {
+export type FilterSetWorkspaceUseAction = {
   type: 'USE';
   payload: {
     id: string;
@@ -87,7 +87,7 @@ export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceCreactAction
   | FilterSetWorkspaceDuplicateAction
   | FilterSetWorkspaceLoadAction
-  | FilterSetWorkspaceSaveAction
   | FilterSetWorkspaceRemoveAction
+  | FilterSetWorkspaceSaveAction
   | FilterSetWorkspaceUpdateAction
   | FilterSetWorkspaceUseAction;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -89,6 +89,14 @@ type FilterSetWorkspaceUpdateAction = {
   };
 };
 
+type FilterSetWorkspaceUseAction = {
+  type: 'USE';
+  payload: {
+    id: string;
+    callback?: FilterSetWorkspaceActionCallback;
+  };
+};
+
 export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceClearAction
   | FilterSetWorkspaceClearAllAction
@@ -97,4 +105,5 @@ export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceLoadAction
   | FilterSetWorkspaceSaveAction
   | FilterSetWorkspaceRemoveAction
-  | FilterSetWorkspaceUpdateAction;
+  | FilterSetWorkspaceUpdateAction
+  | FilterSetWorkspaceUseAction;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -19,11 +19,6 @@ export type FilterSetWorkspaceState = {
   size: number;
 };
 
-export type FilterSetWorkspaceActionCallback = (args: {
-  id: string;
-  filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
-}) => void;
-
 type FilterSetWorkspaceClearAction = {
   type: 'CLEAR';
   payload: undefined;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -9,7 +9,9 @@ export type UnsavedExplorerFilterSet = Pick<
 };
 
 export type FilterSetWorkspaceState = {
-  [key: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
+  all: {
+    [id: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
+  };
 };
 
 export type FilterSetWorkspaceActionCallback = (args: {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -20,7 +20,6 @@ export type FilterSetWorkspaceState = {
 
 export type FilterSetWorkspaceClearAction = {
   type: 'CLEAR';
-  payload: undefined;
 };
 
 export type FilterSetWorkspaceClearAllAction = {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -32,14 +32,14 @@ type FilterSetWorkspaceClearAction = {
 type FilterSetWorkspaceClearAllAction = {
   type: 'CLEAR-ALL';
   payload: {
-    id: string;
+    newId: string;
   };
 };
 
 type FilterSetWorkspaceCreactAction = {
   type: 'CREATE';
   payload: {
-    id: string;
+    newId: string;
   };
 };
 
@@ -53,7 +53,7 @@ type FilterSetWorkspaceDuplicateAction = {
 type FilterSetWorkspaceLoadAction = {
   type: 'LOAD';
   payload: {
-    id?: string;
+    newId?: string;
     filterSet: ExplorerFilterSet;
   };
 };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -31,7 +31,7 @@ export type FilterSetWorkspaceClearAllAction = {
   };
 };
 
-export type FilterSetWorkspaceCreactAction = {
+export type FilterSetWorkspaceCreateAction = {
   type: 'CREATE';
   payload: {
     newId: string;
@@ -84,7 +84,7 @@ export type FilterSetWorkspaceUseAction = {
 export type FilterSetWorkspaceAction =
   | FilterSetWorkspaceClearAction
   | FilterSetWorkspaceClearAllAction
-  | FilterSetWorkspaceCreactAction
+  | FilterSetWorkspaceCreateAction
   | FilterSetWorkspaceDuplicateAction
   | FilterSetWorkspaceLoadAction
   | FilterSetWorkspaceRemoveAction

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -16,7 +16,6 @@ export type FilterSetWorkspaceState = {
   all: {
     [id: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
   };
-  size: number;
 };
 
 export type FilterSetWorkspaceClearAction = {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/types.ts
@@ -9,6 +9,10 @@ export type UnsavedExplorerFilterSet = Pick<
 };
 
 export type FilterSetWorkspaceState = {
+  active: {
+    filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
+    id: string;
+  };
   all: {
     [id: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
   };
@@ -23,7 +27,6 @@ export type FilterSetWorkspaceActionCallback = (args: {
 type FilterSetWorkspaceClearAction = {
   type: 'CLEAR';
   payload: {
-    id: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
 };
@@ -47,7 +50,6 @@ type FilterSetWorkspaceCreactAction = {
 type FilterSetWorkspaceDuplicateAction = {
   type: 'DUPLICATE';
   payload: {
-    id: string;
     newId: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
@@ -65,7 +67,6 @@ type FilterSetWorkspaceLoadAction = {
 type FilterSetWorkspaceSaveAction = {
   type: 'SAVE';
   payload: {
-    id: string;
     filterSet: ExplorerFilterSet;
     callback?: FilterSetWorkspaceActionCallback;
   };
@@ -74,7 +75,6 @@ type FilterSetWorkspaceSaveAction = {
 type FilterSetWorkspaceRemoveAction = {
   type: 'REMOVE';
   payload: {
-    id: string;
     newId: string;
     callback?: FilterSetWorkspaceActionCallback;
   };
@@ -83,7 +83,6 @@ type FilterSetWorkspaceRemoveAction = {
 type FilterSetWorkspaceUpdateAction = {
   type: 'UPDATE';
   payload: {
-    id: string;
     filter: ExplorerFilter;
     callback?: FilterSetWorkspaceActionCallback;
   };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -39,7 +39,7 @@ function reducer(state, action) {
       return { ...state, [id]: filterSet };
     }
     case 'CLEAR-ALL': {
-      const id = crypto.randomUUID();
+      const { id } = payload;
       const filterSet = EMPTY_WORKSPACE_FILTERSET;
 
       payload.callback?.({ filterSet, id });
@@ -47,7 +47,7 @@ function reducer(state, action) {
       return { [id]: filterSet };
     }
     case 'CREATE': {
-      const id = crypto.randomUUID();
+      const { id } = payload;
       const filterSet = EMPTY_WORKSPACE_FILTERSET;
 
       payload.callback?.({ filterSet, id });
@@ -60,7 +60,7 @@ function reducer(state, action) {
 
       const [firstEntry] = Object.entries(newState);
       const [id, filterSet] = firstEntry ?? [
-        crypto.randomUUID(),
+        payload.newId,
         EMPTY_WORKSPACE_FILTERSET,
       ];
 
@@ -69,7 +69,7 @@ function reducer(state, action) {
       return { ...newState, [id]: filterSet };
     }
     case 'LOAD': {
-      const id = payload.id ?? crypto.randomUUID();
+      const { id } = payload;
       const filterSet = cloneDeep(payload.filterSet);
 
       payload.callback?.({ filterSet, id });
@@ -84,12 +84,12 @@ function reducer(state, action) {
       return { ...state, [id]: filterSet };
     }
     case 'DUPLICATE': {
-      const id = crypto.randomUUID();
+      const { newId } = payload;
       const filterSet = { filter: cloneDeep(state[payload.id].filter) };
 
-      payload.callback?.({ filterSet, id });
+      payload.callback?.({ filterSet, id: newId });
 
-      return { ...state, [id]: filterSet };
+      return { ...state, [newId]: filterSet };
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
@@ -138,6 +138,7 @@ export default function useFilterSetWorkspace() {
     dispatch({
       type: 'CLEAR-ALL',
       payload: {
+        id: crypto.randomUUID(),
         callback(args) {
           setId(args.id);
           callback?.(args.filterSet);
@@ -150,6 +151,7 @@ export default function useFilterSetWorkspace() {
     dispatch({
       type: 'CREATE',
       payload: {
+        id: crypto.randomUUID(),
         callback(args) {
           setId(args.id);
           callback?.(args.filterSet);
@@ -163,6 +165,7 @@ export default function useFilterSetWorkspace() {
       type: 'DUPLICATE',
       payload: {
         id,
+        newId: crypto.randomUUID(),
         callback(args) {
           setId(args.id);
           callback?.(args.filterSet);
@@ -180,7 +183,7 @@ export default function useFilterSetWorkspace() {
     dispatch({
       type: 'LOAD',
       payload: {
-        id: shouldOverwrite ? id : undefined,
+        id: shouldOverwrite ? id : crypto.randomUUID(),
         filterSet,
         callback(args) {
           setId(args.id);
@@ -214,6 +217,7 @@ export default function useFilterSetWorkspace() {
       type: 'REMOVE',
       payload: {
         id,
+        newId: crypto.randomUUID(),
         callback(args) {
           setId(args.id);
           callback?.(args.filterSet);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -34,7 +34,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { ...state, [id]: filterSet };
+      return { all: { ...state.all, [id]: filterSet } };
     }
     case 'CLEAR-ALL': {
       const { id } = payload;
@@ -42,7 +42,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { [id]: filterSet };
+      return { all: { [id]: filterSet } };
     }
     case 'CREATE': {
       const { id } = payload;
@@ -50,13 +50,13 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { ...state, [id]: filterSet };
+      return { all: { ...state.all, [id]: filterSet } };
     }
     case 'REMOVE': {
       const newState = cloneDeep(state);
-      delete newState[payload.id];
+      delete newState.all[payload.id];
 
-      const [firstEntry] = Object.entries(newState);
+      const [firstEntry] = Object.entries(newState.all);
       const [id, filterSet] = firstEntry ?? [
         payload.newId,
         createEmptyWorkspaceFilterSet(),
@@ -64,7 +64,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { ...newState, [id]: filterSet };
+      return { all: { ...newState.all, [id]: filterSet } };
     }
     case 'LOAD': {
       const { id } = payload;
@@ -72,14 +72,14 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { ...state, [id]: filterSet };
+      return { all: { ...state.all, [id]: filterSet } };
     }
     case 'SAVE': {
       const { filterSet, id } = payload;
 
       payload.callback?.({ filterSet, id });
 
-      return { ...state, [id]: filterSet };
+      return { all: { ...state.all, [id]: filterSet } };
     }
     case 'DUPLICATE': {
       const { newId } = payload;
@@ -87,7 +87,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id: newId });
 
-      return { ...state, [newId]: filterSet };
+      return { all: { ...state.all, [newId]: filterSet } };
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
@@ -95,7 +95,7 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { ...state, [id]: filterSet };
+      return { all: { ...state.all, [id]: filterSet } };
     }
     default:
       return state;
@@ -110,11 +110,11 @@ export default function useFilterSetWorkspace() {
   );
   useEffect(() => {
     // sync filter UI with non-empty initial workspace filter
-    const values = Object.values(initialWsState);
+    const values = Object.values(initialWsState.all);
     if (values.length > 1 || !checkIfFilterEmpty(values[0].filter))
       handleFilterChange(values[0].filter);
   }, []);
-  const [id, setId] = useState(Object.keys(initialWsState)[0]);
+  const [id, setId] = useState(Object.keys(initialWsState.all)[0]);
   const [wsState, dispatch] = useReducer(reducer, initialWsState);
   useEffect(() => storeWorkspaceState(wsState), [wsState]);
 
@@ -254,9 +254,9 @@ export default function useFilterSetWorkspace() {
 
   return useMemo(
     () => ({
-      active: { id, filterSet: wsState[id] },
-      all: wsState,
-      size: Object.keys(wsState).length,
+      ...wsState,
+      active: { id, filterSet: wsState.all[id] },
+      size: Object.keys(wsState.all).length,
       clear,
       clearAll,
       create,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -19,6 +19,9 @@ import {
  * @returns {void}
  */
 
+/** @type {UnsavedExplorerFilterSet} */
+const EMPTY_WORKSPACE_FILTERSET = { filter: {} };
+
 /**
  * @param {FilterSetWorkspaceState} state
  * @param {FilterSetWorkspaceAction} action
@@ -29,8 +32,7 @@ function reducer(state, action) {
   switch (type) {
     case 'CLEAR': {
       const { id } = payload;
-      /** @type {UnsavedExplorerFilterSet} */
-      const filterSet = { filter: {} };
+      const filterSet = EMPTY_WORKSPACE_FILTERSET;
 
       payload.callback?.({ filterSet, id });
 
@@ -38,8 +40,7 @@ function reducer(state, action) {
     }
     case 'CLEAR-ALL': {
       const id = crypto.randomUUID();
-      /** @type {UnsavedExplorerFilterSet} */
-      const filterSet = { filter: {} };
+      const filterSet = EMPTY_WORKSPACE_FILTERSET;
 
       payload.callback?.({ filterSet, id });
 
@@ -47,8 +48,7 @@ function reducer(state, action) {
     }
     case 'CREATE': {
       const id = crypto.randomUUID();
-      /** @type {UnsavedExplorerFilterSet} */
-      const filterSet = { filter: {} };
+      const filterSet = EMPTY_WORKSPACE_FILTERSET;
 
       payload.callback?.({ filterSet, id });
 
@@ -61,7 +61,7 @@ function reducer(state, action) {
       const [firstEntry] = Object.entries(newState);
       const [id, filterSet] = firstEntry ?? [
         crypto.randomUUID(),
-        { filter: {} },
+        EMPTY_WORKSPACE_FILTERSET,
       ];
 
       payload.callback?.({ filterSet, id });

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -113,6 +113,14 @@ function reducer(state, action) {
       const size = Object.keys(all).length;
       return { all, size };
     }
+    case 'USE': {
+      const { id } = payload;
+      const filterSet = state.all[id];
+
+      payload.callback?.({ filterSet, id });
+
+      return state;
+    }
     default:
       return state;
   }
@@ -264,8 +272,16 @@ export default function useFilterSetWorkspace() {
    * @param {FilterSetWorkspaceMethodCallback} [callback]
    */
   function use(newId, callback) {
-    setId(newId);
-    callback?.(wsState[newId]);
+    dispatch({
+      type: 'USE',
+      payload: {
+        id: newId,
+        callback(args) {
+          setId(args.id);
+          callback?.(args.filterSet);
+        },
+      },
+    });
   }
 
   return useMemo(

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -34,7 +34,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...state.all, [id]: filterSet } };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'CLEAR-ALL': {
       const { id } = payload;
@@ -42,7 +44,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { [id]: filterSet } };
+      const all = { [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'CREATE': {
       const { id } = payload;
@@ -50,7 +54,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...state.all, [id]: filterSet } };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'REMOVE': {
       const newState = cloneDeep(state);
@@ -64,7 +70,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...newState.all, [id]: filterSet } };
+      const all = { ...newState.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'LOAD': {
       const { id } = payload;
@@ -72,14 +80,18 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...state.all, [id]: filterSet } };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'SAVE': {
       const { filterSet, id } = payload;
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...state.all, [id]: filterSet } };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'DUPLICATE': {
       const { newId } = payload;
@@ -87,7 +99,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id: newId });
 
-      return { all: { ...state.all, [newId]: filterSet } };
+      const all = { ...state.all, [newId]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
@@ -95,7 +109,9 @@ function reducer(state, action) {
 
       payload.callback?.({ filterSet, id });
 
-      return { all: { ...state.all, [id]: filterSet } };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { all, size };
     }
     default:
       return state;
@@ -256,7 +272,6 @@ export default function useFilterSetWorkspace() {
     () => ({
       ...wsState,
       active: { id, filterSet: wsState.all[id] },
-      size: Object.keys(wsState.all).length,
       clear,
       clearAll,
       create,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -104,6 +104,7 @@ export default function useFilterSetWorkspace() {
   return useMemo(
     () => ({
       ...state,
+      size: Object.keys(state.all).length,
       clear,
       clearAll,
       create,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -95,7 +95,7 @@ function reducer(state, action) {
     }
     case 'DUPLICATE': {
       const { newId } = payload;
-      const filterSet = { filter: cloneDeep(state[payload.id].filter) };
+      const filterSet = { filter: cloneDeep(state.all[payload.id].filter) };
 
       payload.callback?.({ filterSet, id: newId });
 
@@ -105,7 +105,7 @@ function reducer(state, action) {
     }
     case 'UPDATE': {
       const { id, filter: newFilter } = payload;
-      const filterSet = { ...state[id], filter: cloneDeep(newFilter) };
+      const filterSet = { ...state.all[id], filter: cloneDeep(newFilter) };
 
       payload.callback?.({ filterSet, id });
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -38,7 +38,6 @@ export default function useFilterSetWorkspace() {
   function clear() {
     dispatch({
       type: 'CLEAR',
-      payload: undefined,
     });
   }
   function clearAll() {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -1,117 +1,14 @@
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import cloneDeep from 'lodash.clonedeep';
 import { useExplorerState } from '../ExplorerStateContext';
 import {
   checkIfFilterEmpty,
-  createEmptyWorkspaceFilterSet,
   initializeWorkspaceState,
   storeWorkspaceState,
+  workspaceReducer,
 } from './utils';
 
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 /** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
-/** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
-/** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
-
-/**
- * @param {FilterSetWorkspaceState} state
- * @param {FilterSetWorkspaceAction} action
- * @returns {FilterSetWorkspaceState}
- */
-function reducer(state, action) {
-  const { type, payload } = action;
-  switch (type) {
-    case 'CLEAR': {
-      const { id } = state.active;
-      const filterSet = createEmptyWorkspaceFilterSet();
-
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'CLEAR-ALL': {
-      const id = payload.newId;
-      const filterSet = createEmptyWorkspaceFilterSet();
-
-      const active = { filterSet, id };
-      const all = { [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'CREATE': {
-      const id = payload.newId;
-      const filterSet = createEmptyWorkspaceFilterSet();
-
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'DUPLICATE': {
-      const { id } = state.active;
-      const { newId } = payload;
-      const filterSet = { filter: cloneDeep(state.all[id].filter) };
-
-      const active = { filterSet, id: newId };
-      const all = { ...state.all, [newId]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'LOAD': {
-      const id = payload.newId ?? state.active.id;
-      const filterSet = cloneDeep(payload.filterSet);
-
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'REMOVE': {
-      const newState = cloneDeep(state);
-      delete newState.all[state.active.id];
-
-      const [firstEntry] = Object.entries(newState.all);
-      const [id, filterSet] = firstEntry ?? [
-        payload.newId,
-        createEmptyWorkspaceFilterSet(),
-      ];
-
-      const active = { filterSet, id };
-      const all = { ...newState.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'SAVE': {
-      const { id } = state.active;
-      const { filterSet } = payload;
-
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'UPDATE': {
-      const { id } = state.active;
-      const { filter: newFilter } = payload;
-      const filterSet = { ...state.all[id], filter: cloneDeep(newFilter) };
-
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
-    }
-    case 'USE': {
-      const { id } = payload;
-      const filterSet = state.all[id];
-
-      const active = { filterSet, id };
-      return { ...state, active };
-    }
-    default:
-      return state;
-  }
-}
 
 export default function useFilterSetWorkspace() {
   const { explorerFilter, handleFilterChange } = useExplorerState();
@@ -124,7 +21,7 @@ export default function useFilterSetWorkspace() {
     if (!checkIfFilterEmpty(initialWsState.active.filterSet.filter))
       handleFilterChange(initialWsState.active.filterSet.filter);
   }, []);
-  const [state, dispatch] = useReducer(reducer, initialWsState);
+  const [state, dispatch] = useReducer(workspaceReducer, initialWsState);
   const prevActiveFilter = useRef(state.active.filterSet.filter);
   useEffect(() => {
     storeWorkspaceState(state);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash.clonedeep';
 import { useExplorerState } from '../ExplorerStateContext';
 import {
   checkIfFilterEmpty,
+  createEmptyWorkspaceFilterSet,
   initializeWorkspaceState,
   storeWorkspaceState,
 } from './utils';
@@ -19,9 +20,6 @@ import {
  * @returns {void}
  */
 
-/** @type {UnsavedExplorerFilterSet} */
-const EMPTY_WORKSPACE_FILTERSET = { filter: {} };
-
 /**
  * @param {FilterSetWorkspaceState} state
  * @param {FilterSetWorkspaceAction} action
@@ -32,7 +30,7 @@ function reducer(state, action) {
   switch (type) {
     case 'CLEAR': {
       const { id } = payload;
-      const filterSet = EMPTY_WORKSPACE_FILTERSET;
+      const filterSet = createEmptyWorkspaceFilterSet();
 
       payload.callback?.({ filterSet, id });
 
@@ -40,7 +38,7 @@ function reducer(state, action) {
     }
     case 'CLEAR-ALL': {
       const { id } = payload;
-      const filterSet = EMPTY_WORKSPACE_FILTERSET;
+      const filterSet = createEmptyWorkspaceFilterSet();
 
       payload.callback?.({ filterSet, id });
 
@@ -48,7 +46,7 @@ function reducer(state, action) {
     }
     case 'CREATE': {
       const { id } = payload;
-      const filterSet = EMPTY_WORKSPACE_FILTERSET;
+      const filterSet = createEmptyWorkspaceFilterSet();
 
       payload.callback?.({ filterSet, id });
 
@@ -61,7 +59,7 @@ function reducer(state, action) {
       const [firstEntry] = Object.entries(newState);
       const [id, filterSet] = firstEntry ?? [
         payload.newId,
-        EMPTY_WORKSPACE_FILTERSET,
+        createEmptyWorkspaceFilterSet(),
       ];
 
       payload.callback?.({ filterSet, id });

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -12,13 +12,6 @@ import {
 /** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
 /** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
-/** @typedef {import('./types').UnsavedExplorerFilterSet} UnsavedExplorerFilterSet */
-
-/**
- * @callback FilterSetWorkspaceMethodCallback
- * @param {ExplorerFilterSet | UnsavedExplorerFilterSet} filterSet
- * @returns {void}
- */
 
 /**
  * @param {FilterSetWorkspaceState} state

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -53,7 +53,7 @@ export function retrieveWorkspaceState() {
 
     const id = crypto.randomUUID();
     const filterSet = { filter: {} };
-    return { all: { [id]: filterSet }, size: 1 };
+    return { active: { filterSet, id }, all: { [id]: filterSet }, size: 1 };
   }
 }
 
@@ -63,7 +63,7 @@ export function initializeWorkspaceState(filter) {
 
   const id = crypto.randomUUID();
   const filterSet = { filter };
-  return { all: { [id]: filterSet }, size: 1 };
+  return { active: { filterSet, id }, all: { [id]: filterSet }, size: 1 };
 }
 
 /** @param {FilterSetWorkspaceState} state */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -109,25 +109,24 @@ export function workspaceReducer(state, action) {
       return { active, all };
     }
     case 'CLEAR-ALL': {
-      const id = action.payload.newId;
+      const { newId } = action.payload;
       const filterSet = createEmptyWorkspaceFilterSet();
 
-      const active = { filterSet, id };
-      const all = { [id]: filterSet };
+      const active = { filterSet, id: newId };
+      const all = { [newId]: filterSet };
       return { active, all };
     }
     case 'CREATE': {
-      const id = action.payload.newId;
+      const { newId } = action.payload;
       const filterSet = createEmptyWorkspaceFilterSet();
 
-      const active = { filterSet, id };
-      const all = { ...state.all, [id]: filterSet };
+      const active = { filterSet, id: newId };
+      const all = { ...state.all, [newId]: filterSet };
       return { active, all };
     }
     case 'DUPLICATE': {
-      const { id } = state.active;
       const { newId } = action.payload;
-      const filterSet = { filter: cloneDeep(state.all[id].filter) };
+      const filterSet = { filter: cloneDeep(state.active.filterSet.filter) };
 
       const active = { filterSet, id: newId };
       const all = { ...state.all, [newId]: filterSet };
@@ -165,8 +164,10 @@ export function workspaceReducer(state, action) {
     }
     case 'UPDATE': {
       const { id } = state.active;
-      const { filter: newFilter } = action.payload;
-      const filterSet = { ...state.all[id], filter: cloneDeep(newFilter) };
+      const filterSet = {
+        ...state.active.filterSet,
+        filter: cloneDeep(action.payload.filter),
+      };
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -79,3 +79,8 @@ export function findFilterSetIdInWorkspaceState(filterSetId, state) {
 
   return undefined;
 }
+
+/** @returns {import('./types').UnsavedExplorerFilterSet} */
+export function createEmptyWorkspaceFilterSet() {
+  return { filter: {} };
+}

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -50,15 +50,20 @@ export function retrieveWorkspaceState() {
     return JSON.parse(str);
   } catch (e) {
     if (e.message !== 'No stored query') console.error(e);
-    return { all: { [crypto.randomUUID()]: { filter: {} } }, size: 1 };
+
+    const id = crypto.randomUUID();
+    const filterSet = { filter: {} };
+    return { all: { [id]: filterSet }, size: 1 };
   }
 }
 
 /** @param {ExplorerFilter} filter */
 export function initializeWorkspaceState(filter) {
-  return checkIfFilterEmpty(filter)
-    ? retrieveWorkspaceState()
-    : { all: { [crypto.randomUUID()]: { filter } }, size: 1 };
+  if (checkIfFilterEmpty(filter)) return retrieveWorkspaceState();
+
+  const id = crypto.randomUUID();
+  const filterSet = { filter };
+  return { all: { [id]: filterSet }, size: 1 };
 }
 
 /** @param {FilterSetWorkspaceState} state */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -50,7 +50,7 @@ export function retrieveWorkspaceState() {
     return JSON.parse(str);
   } catch (e) {
     if (e.message !== 'No stored query') console.error(e);
-    return { all: { [crypto.randomUUID()]: { filter: {} } } };
+    return { all: { [crypto.randomUUID()]: { filter: {} } }, size: 1 };
   }
 }
 
@@ -58,7 +58,7 @@ export function retrieveWorkspaceState() {
 export function initializeWorkspaceState(filter) {
   return checkIfFilterEmpty(filter)
     ? retrieveWorkspaceState()
-    : { all: { [crypto.randomUUID()]: { filter } } };
+    : { all: { [crypto.randomUUID()]: { filter } }, size: 1 };
 }
 
 /** @param {FilterSetWorkspaceState} state */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -1,6 +1,9 @@
+import cloneDeep from 'lodash.clonedeep';
+
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 /** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
+/** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
 
 /**
  * @param {Object} args
@@ -88,4 +91,104 @@ export function findFilterSetIdInWorkspaceState(filterSetId, state) {
 /** @returns {import('./types').UnsavedExplorerFilterSet} */
 export function createEmptyWorkspaceFilterSet() {
   return { filter: {} };
+}
+
+/**
+ * @param {FilterSetWorkspaceState} state
+ * @param {FilterSetWorkspaceAction} action
+ * @returns {FilterSetWorkspaceState}
+ */
+export function workspaceReducer(state, action) {
+  const { type, payload } = action;
+  switch (type) {
+    case 'CLEAR': {
+      const { id } = state.active;
+      const filterSet = createEmptyWorkspaceFilterSet();
+
+      const active = { filterSet, id };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'CLEAR-ALL': {
+      const id = payload.newId;
+      const filterSet = createEmptyWorkspaceFilterSet();
+
+      const active = { filterSet, id };
+      const all = { [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'CREATE': {
+      const id = payload.newId;
+      const filterSet = createEmptyWorkspaceFilterSet();
+
+      const active = { filterSet, id };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'DUPLICATE': {
+      const { id } = state.active;
+      const { newId } = payload;
+      const filterSet = { filter: cloneDeep(state.all[id].filter) };
+
+      const active = { filterSet, id: newId };
+      const all = { ...state.all, [newId]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'LOAD': {
+      const id = payload.newId ?? state.active.id;
+      const filterSet = cloneDeep(payload.filterSet);
+
+      const active = { filterSet, id };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'REMOVE': {
+      const newState = cloneDeep(state);
+      delete newState.all[state.active.id];
+
+      const [firstEntry] = Object.entries(newState.all);
+      const [id, filterSet] = firstEntry ?? [
+        payload.newId,
+        createEmptyWorkspaceFilterSet(),
+      ];
+
+      const active = { filterSet, id };
+      const all = { ...newState.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'SAVE': {
+      const { id } = state.active;
+      const { filterSet } = payload;
+
+      const active = { filterSet, id };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'UPDATE': {
+      const { id } = state.active;
+      const { filter: newFilter } = payload;
+      const filterSet = { ...state.all[id], filter: cloneDeep(newFilter) };
+
+      const active = { filterSet, id };
+      const all = { ...state.all, [id]: filterSet };
+      const size = Object.keys(all).length;
+      return { active, all, size };
+    }
+    case 'USE': {
+      const { id } = payload;
+      const filterSet = state.all[id];
+
+      const active = { filterSet, id };
+      return { ...state, active };
+    }
+    default:
+      return state;
+  }
 }

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -99,8 +99,7 @@ export function createEmptyWorkspaceFilterSet() {
  * @returns {FilterSetWorkspaceState}
  */
 export function workspaceReducer(state, action) {
-  const { type, payload } = action;
-  switch (type) {
+  switch (action.type) {
     case 'CLEAR': {
       const { id } = state.active;
       const filterSet = createEmptyWorkspaceFilterSet();
@@ -110,7 +109,7 @@ export function workspaceReducer(state, action) {
       return { active, all };
     }
     case 'CLEAR-ALL': {
-      const id = payload.newId;
+      const id = action.payload.newId;
       const filterSet = createEmptyWorkspaceFilterSet();
 
       const active = { filterSet, id };
@@ -118,7 +117,7 @@ export function workspaceReducer(state, action) {
       return { active, all };
     }
     case 'CREATE': {
-      const id = payload.newId;
+      const id = action.payload.newId;
       const filterSet = createEmptyWorkspaceFilterSet();
 
       const active = { filterSet, id };
@@ -127,7 +126,7 @@ export function workspaceReducer(state, action) {
     }
     case 'DUPLICATE': {
       const { id } = state.active;
-      const { newId } = payload;
+      const { newId } = action.payload;
       const filterSet = { filter: cloneDeep(state.all[id].filter) };
 
       const active = { filterSet, id: newId };
@@ -135,8 +134,8 @@ export function workspaceReducer(state, action) {
       return { active, all };
     }
     case 'LOAD': {
-      const id = payload.newId ?? state.active.id;
-      const filterSet = cloneDeep(payload.filterSet);
+      const id = action.payload.newId ?? state.active.id;
+      const filterSet = cloneDeep(action.payload.filterSet);
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
@@ -148,7 +147,7 @@ export function workspaceReducer(state, action) {
 
       const [firstEntry] = Object.entries(newState.all);
       const [id, filterSet] = firstEntry ?? [
-        payload.newId,
+        action.payload.newId,
         createEmptyWorkspaceFilterSet(),
       ];
 
@@ -158,7 +157,7 @@ export function workspaceReducer(state, action) {
     }
     case 'SAVE': {
       const { id } = state.active;
-      const { filterSet } = payload;
+      const { filterSet } = action.payload;
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
@@ -166,7 +165,7 @@ export function workspaceReducer(state, action) {
     }
     case 'UPDATE': {
       const { id } = state.active;
-      const { filter: newFilter } = payload;
+      const { filter: newFilter } = action.payload;
       const filterSet = { ...state.all[id], filter: cloneDeep(newFilter) };
 
       const active = { filterSet, id };
@@ -174,7 +173,7 @@ export function workspaceReducer(state, action) {
       return { active, all };
     }
     case 'USE': {
-      const { id } = payload;
+      const { id } = action.payload;
       const filterSet = state.all[id];
 
       const active = { filterSet, id };

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -56,7 +56,7 @@ export function retrieveWorkspaceState() {
 
     const id = crypto.randomUUID();
     const filterSet = { filter: {} };
-    return { active: { filterSet, id }, all: { [id]: filterSet }, size: 1 };
+    return { active: { filterSet, id }, all: { [id]: filterSet } };
   }
 }
 
@@ -66,7 +66,7 @@ export function initializeWorkspaceState(filter) {
 
   const id = crypto.randomUUID();
   const filterSet = { filter };
-  return { active: { filterSet, id }, all: { [id]: filterSet }, size: 1 };
+  return { active: { filterSet, id }, all: { [id]: filterSet } };
 }
 
 /** @param {FilterSetWorkspaceState} state */
@@ -107,8 +107,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'CLEAR-ALL': {
       const id = payload.newId;
@@ -116,8 +115,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'CREATE': {
       const id = payload.newId;
@@ -125,8 +123,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'DUPLICATE': {
       const { id } = state.active;
@@ -135,8 +132,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id: newId };
       const all = { ...state.all, [newId]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'LOAD': {
       const id = payload.newId ?? state.active.id;
@@ -144,8 +140,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'REMOVE': {
       const newState = cloneDeep(state);
@@ -159,8 +154,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...newState.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'SAVE': {
       const { id } = state.active;
@@ -168,8 +162,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'UPDATE': {
       const { id } = state.active;
@@ -178,8 +171,7 @@ export function workspaceReducer(state, action) {
 
       const active = { filterSet, id };
       const all = { ...state.all, [id]: filterSet };
-      const size = Object.keys(all).length;
-      return { active, all, size };
+      return { active, all };
     }
     case 'USE': {
       const { id } = payload;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -50,7 +50,7 @@ export function retrieveWorkspaceState() {
     return JSON.parse(str);
   } catch (e) {
     if (e.message !== 'No stored query') console.error(e);
-    return { [crypto.randomUUID()]: { filter: {} } };
+    return { all: { [crypto.randomUUID()]: { filter: {} } } };
   }
 }
 
@@ -58,7 +58,7 @@ export function retrieveWorkspaceState() {
 export function initializeWorkspaceState(filter) {
   return checkIfFilterEmpty(filter)
     ? retrieveWorkspaceState()
-    : { [crypto.randomUUID()]: { filter } };
+    : { all: { [crypto.randomUUID()]: { filter } } };
 }
 
 /** @param {FilterSetWorkspaceState} state */
@@ -74,7 +74,7 @@ export function storeWorkspaceState(state) {
  * @param {FilterSetWorkspaceState} state
  */
 export function findFilterSetIdInWorkspaceState(filterSetId, state) {
-  for (const [id, filterSet] of Object.entries(state))
+  for (const [id, filterSet] of Object.entries(state.all))
     if ('id' in filterSet && filterSet.id === filterSetId) return id;
 
   return undefined;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
@@ -1,4 +1,12 @@
-import { pluckFromFilter, pluckFromAnchorFilter } from './utils';
+import {
+  pluckFromFilter,
+  pluckFromAnchorFilter,
+  workspaceReducer,
+  createEmptyWorkspaceFilterSet,
+} from './utils';
+
+/** @typedef {import('./types').FilterSetWorkspaceState} FilterSetWorkspaceState */
+/** @typedef {import('./types').FilterSetWorkspaceAction} FilterSetWorkspaceAction */
 
 describe('pluckFromFilter', () => {
   test('no filter', () => {
@@ -98,5 +106,264 @@ describe('pluckFromAnchorFilter', () => {
     });
     const expected2 = { foo: {}, 'x:y': { filter: { bar: {} } } };
     expect(received2).toStrictEqual(expected2);
+  });
+});
+
+describe('workspaceReducer', () => {
+  const EMPTY_FILTER_SET = createEmptyWorkspaceFilterSet();
+  const SIMPLE_FILTER_SET = { filter: { x: {}, y: {} } };
+  const SIMPLE_SAVED_FILTER_SET = {
+    ...SIMPLE_FILTER_SET,
+    explorerId: 0,
+    description: 'ipsum',
+    id: 0,
+    name: 'lorem',
+  };
+
+  test('clear', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceClearAction} */ ({
+        type: 'CLEAR',
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      ...initialState,
+      active: { ...initialState.active, filterSet: EMPTY_FILTER_SET },
+      all: {
+        ...initialState.all,
+        [initialState.active.id]: EMPTY_FILTER_SET,
+      },
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('clear all', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
+      all: { foo: EMPTY_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceClearAllAction} */ ({
+        type: 'CLEAR-ALL',
+        payload: { newId: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { filterSet: EMPTY_FILTER_SET, id: action.payload.newId },
+      all: {
+        [action.payload.newId]: EMPTY_FILTER_SET,
+      },
+      size: 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('create', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceCreateAction} */ ({
+        type: 'CREATE',
+        payload: { newId: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { filterSet: EMPTY_FILTER_SET, id: action.payload.newId },
+      all: {
+        ...initialState.all,
+        [action.payload.newId]: EMPTY_FILTER_SET,
+      },
+      size: initialState.size + 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('duplicate', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_SAVED_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_SAVED_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceDuplicateAction} */ ({
+        type: 'DUPLICATE',
+        payload: { newId: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { filterSet: SIMPLE_FILTER_SET, id: action.payload.newId },
+      all: {
+        ...initialState.all,
+        [action.payload.newId]: SIMPLE_FILTER_SET,
+      },
+      size: initialState.size + 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('load', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
+      all: { foo: EMPTY_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceLoadAction} */ ({
+        type: 'LOAD',
+        payload: { filterSet: SIMPLE_SAVED_FILTER_SET, newId: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { filterSet: action.payload.filterSet, id: action.payload.newId },
+      all: {
+        ...initialState.all,
+        [action.payload.newId]: action.payload.filterSet,
+      },
+      size: initialState.size + 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('load: overwrite', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
+      all: { foo: EMPTY_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceLoadAction} */ ({
+        type: 'LOAD',
+        payload: { filterSet: SIMPLE_SAVED_FILTER_SET },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      ...initialState,
+      active: { ...initialState.active, filterSet: action.payload.filterSet },
+      all: {
+        ...initialState.all,
+        [initialState.active.id]: action.payload.filterSet,
+      },
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('remove', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_FILTER_SET, bar: SIMPLE_FILTER_SET },
+      size: 2,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceRemoveAction} */ ({
+        type: 'REMOVE',
+        payload: { newId: 'baz' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { id: 'bar', filterSet: initialState.all.bar },
+      all: {
+        bar: initialState.all.bar,
+      },
+      size: initialState.size - 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('remove: last', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceRemoveAction} */ ({
+        type: 'REMOVE',
+        payload: { newId: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      active: { filterSet: EMPTY_FILTER_SET, id: action.payload.newId },
+      all: {
+        [action.payload.newId]: EMPTY_FILTER_SET,
+      },
+      size: 1,
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('save', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
+      all: { foo: EMPTY_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceSaveAction} */ ({
+        type: 'SAVE',
+        payload: { filterSet: SIMPLE_SAVED_FILTER_SET },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      ...initialState,
+      active: { ...initialState.active, filterSet: action.payload.filterSet },
+      all: {
+        ...initialState.all,
+        [initialState.active.id]: action.payload.filterSet,
+      },
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('update', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
+      all: { foo: SIMPLE_FILTER_SET },
+      size: 1,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceUpdateAction} */ ({
+        type: 'UPDATE',
+        payload: { filter: { z: {} } },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      ...initialState,
+      active: {
+        ...initialState.active,
+        filterSet: {
+          ...initialState.active.filterSet,
+          filter: action.payload.filter,
+        },
+      },
+      all: {
+        ...initialState.all,
+        [initialState.active.id]: {
+          ...initialState.all[initialState.active.id],
+          filter: action.payload.filter,
+        },
+      },
+    };
+    expect(newState).toStrictEqual(expected);
+  });
+  test('use', () => {
+    const initialState = /** @type {FilterSetWorkspaceState} */ ({
+      active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
+      all: { foo: EMPTY_FILTER_SET, bar: EMPTY_FILTER_SET },
+      size: 2,
+    });
+    const action =
+      /** @type {import('./types').FilterSetWorkspaceUseAction} */ ({
+        type: 'USE',
+        payload: { id: 'bar' },
+      });
+    const newState = workspaceReducer(initialState, action);
+    const expected = {
+      ...initialState,
+      active: {
+        filterSet: initialState.all[action.payload.id],
+        id: action.payload.id,
+      },
+    };
+    expect(newState).toStrictEqual(expected);
   });
 });

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
@@ -124,7 +124,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceClearAction} */ ({
@@ -145,7 +144,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
       all: { foo: EMPTY_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceClearAllAction} */ ({
@@ -158,7 +156,6 @@ describe('workspaceReducer', () => {
       all: {
         [action.payload.newId]: EMPTY_FILTER_SET,
       },
-      size: 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -166,7 +163,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceCreateAction} */ ({
@@ -180,7 +176,6 @@ describe('workspaceReducer', () => {
         ...initialState.all,
         [action.payload.newId]: EMPTY_FILTER_SET,
       },
-      size: initialState.size + 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -188,7 +183,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_SAVED_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_SAVED_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceDuplicateAction} */ ({
@@ -202,7 +196,6 @@ describe('workspaceReducer', () => {
         ...initialState.all,
         [action.payload.newId]: SIMPLE_FILTER_SET,
       },
-      size: initialState.size + 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -210,7 +203,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
       all: { foo: EMPTY_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceLoadAction} */ ({
@@ -224,7 +216,6 @@ describe('workspaceReducer', () => {
         ...initialState.all,
         [action.payload.newId]: action.payload.filterSet,
       },
-      size: initialState.size + 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -232,7 +223,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
       all: { foo: EMPTY_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceLoadAction} */ ({
@@ -254,7 +244,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_FILTER_SET, bar: SIMPLE_FILTER_SET },
-      size: 2,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceRemoveAction} */ ({
@@ -267,7 +256,6 @@ describe('workspaceReducer', () => {
       all: {
         bar: initialState.all.bar,
       },
-      size: initialState.size - 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -275,7 +263,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceRemoveAction} */ ({
@@ -288,7 +275,6 @@ describe('workspaceReducer', () => {
       all: {
         [action.payload.newId]: EMPTY_FILTER_SET,
       },
-      size: 1,
     };
     expect(newState).toStrictEqual(expected);
   });
@@ -296,7 +282,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
       all: { foo: EMPTY_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceSaveAction} */ ({
@@ -318,7 +303,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: SIMPLE_FILTER_SET, id: 'foo' },
       all: { foo: SIMPLE_FILTER_SET },
-      size: 1,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceUpdateAction} */ ({
@@ -349,7 +333,6 @@ describe('workspaceReducer', () => {
     const initialState = /** @type {FilterSetWorkspaceState} */ ({
       active: { filterSet: EMPTY_FILTER_SET, id: 'foo' },
       all: { foo: EMPTY_FILTER_SET, bar: EMPTY_FILTER_SET },
-      size: 2,
     });
     const action =
       /** @type {import('./types').FilterSetWorkspaceUseAction} */ ({


### PR DESCRIPTION
This PR refactors the reducer in the `useFilterSetWorkspace` custom hook with the key objective of making its `reducer` function pure.

In doing so the PR makes the following changes that shouldn't impact the observed behavior:

* Handle `use` action in reducer
* Remove `callback` payload in reducer actions and rely on `useEffect` to synchronize with `<ExplorerStateContext>` filter state.
* Reshape workspace state object to include `active` & `all` values.
    * `all` value holds what used to be the state
    * `active` removes the need for a separate `id` state
* Rename `reducer` to `workspaceReducer`, put it under `utils.js`, and create tests for it in `utils.test.js` 

The PR also includes refactoring efforts for improved readability & maintainability.