### PR TITLE
Patch release 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.17.10",

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -64,7 +64,7 @@ export function createFilterSet(explorerId, filterSet) {
     body: JSON.stringify(convertToFilterSetDTO(filterSet)),
   }).then(({ response, data, status }) => {
     if (status !== 200) throw response.statusText;
-    return data;
+    return convertFromFilterSetDTO(data);
   });
 }
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -13,7 +13,7 @@ const FILTER_SET_URL = '/amanuensis/filter-sets';
  * @returns {ExplorerFilterSetDTO}
  */
 function convertToFilterSetDTO({ filter: filters, ...rest }) {
-  return { filters, ...rest };
+  return { ...rest, filters };
 }
 
 /**
@@ -22,12 +22,12 @@ function convertToFilterSetDTO({ filter: filters, ...rest }) {
  */
 function convertFromFilterSetDTO({ filters, ...rest }) {
   return {
+    ...rest,
     filter:
       '__combineMode' in filters
         ? filters
         : // backward compat for old filter sets missing __combineMode value
           { __combineMode: 'AND', ...filters },
-    ...rest,
   };
 }
 


### PR DESCRIPTION
This PR bumps the project version to 1.5.3.

The PR includes a fix for broken "Save As" feature for filter sets where the updated filter content is not reflected in the new saved filter set. The bug was caused by missing conversion from filter set DTO to proper filter set object in `createFilterSet` return value, coupled with failing to properly overwriting object props in convert functions (`convertToFilterSetDTO` and `convertFromFilterSetDTO`).