### PR TITLE
Fix lost sync between workspace and filter sets context states

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import { useExplorerState } from '../ExplorerStateContext';
 import {
   checkIfFilterEmpty,
@@ -12,6 +13,7 @@ import {
 
 export default function useFilterSetWorkspace() {
   const { explorerFilter, handleFilterChange } = useExplorerState();
+  const filterSets = useExplorerFilterSets();
   const initialWsState = useMemo(
     () => initializeWorkspaceState(explorerFilter),
     []
@@ -26,13 +28,16 @@ export default function useFilterSetWorkspace() {
   useEffect(() => {
     storeWorkspaceState(state);
 
-    const { filter } = state.active.filterSet;
+    const { filter, id } = state.active.filterSet;
+
     const isActiveFilterChanged =
       JSON.stringify(prevActiveFilter.current) !== JSON.stringify(filter);
     if (isActiveFilterChanged) {
       prevActiveFilter.current = filter;
       handleFilterChange(filter);
     }
+
+    filterSets.use(id);
   }, [state]);
 
   function clear() {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -26,15 +26,18 @@ export default function useFilterSetWorkspace() {
   const [state, dispatch] = useReducer(workspaceReducer, initialWsState);
   const prevActiveFilterSet = useRef(state.active.filterSet);
   useEffect(() => {
+    // sync with browser store
     storeWorkspaceState(state);
 
     const { filter: prevFilter, id: prevId } = prevActiveFilterSet.current;
     const { filter, id } = state.active.filterSet;
 
+    // sync with explorer filter state
     const isFilterChanged =
       JSON.stringify(prevFilter) !== JSON.stringify(filter);
     if (isFilterChanged) handleFilterChange(filter);
 
+    // sync with explorer filter sets state
     const isFilterSetIdChanged = prevId !== id;
     if (isFilterSetIdChanged) filterSets.use(id);
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -24,20 +24,22 @@ export default function useFilterSetWorkspace() {
       handleFilterChange(initialWsState.active.filterSet.filter);
   }, []);
   const [state, dispatch] = useReducer(workspaceReducer, initialWsState);
-  const prevActiveFilter = useRef(state.active.filterSet.filter);
+  const prevActiveFilterSet = useRef(state.active.filterSet);
   useEffect(() => {
     storeWorkspaceState(state);
 
+    const { filter: prevFilter, id: prevId } = prevActiveFilterSet.current;
     const { filter, id } = state.active.filterSet;
 
-    const isActiveFilterChanged =
-      JSON.stringify(prevActiveFilter.current) !== JSON.stringify(filter);
-    if (isActiveFilterChanged) {
-      prevActiveFilter.current = filter;
-      handleFilterChange(filter);
-    }
+    const isFilterChanged =
+      JSON.stringify(prevFilter) !== JSON.stringify(filter);
+    if (isFilterChanged) handleFilterChange(filter);
 
-    filterSets.use(id);
+    const isFilterSetIdChanged = prevId !== id;
+    if (isFilterSetIdChanged) filterSets.use(id);
+
+    if (isFilterChanged || isFilterSetIdChanged)
+      prevActiveFilterSet.current = state.active.filterSet;
   }, [state]);
 
   function clear() {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -41,8 +41,7 @@ export default function useFilterSetWorkspace() {
     const isFilterSetIdChanged = prevId !== id;
     if (isFilterSetIdChanged) filterSets.use(id);
 
-    if (isFilterChanged || isFilterSetIdChanged)
-      prevActiveFilterSet.current = state.active.filterSet;
+    prevActiveFilterSet.current = state.active.filterSet;
   }, [state]);
 
   function clear() {


### PR DESCRIPTION
This PR fixes the de-synchronized states between `useFilterSetWorkspace` and `ExplorerFilterSetsContext`.

This bug was introduced during the previous refactoring effort (#405), specifically by this commit (https://github.com/chicagopcdc/data-portal/commit/63365f7f4aaa7a668c08de672ef5ec5abc53f87c) that moved away from callback functions in reducer to synchronize states. The change, inadvertently, only preserved filter state synchronization and missed filter sets state synchronization.

The fix brings back the missing synchronization between workspace active filter set state and filter sets context state.