### PR TITLE
Display submission link on top bar menu PEDS-710

### DIFF
--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -60,6 +60,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
         )}
         {username !== undefined ? (
           <TopBarMenu
+            isAdminUser={isAdminUser}
             items={config.menuItems}
             onLogoutClick={onLogoutClick}
             username={username}

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -45,19 +45,16 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
         ))}
       </div>
       <div>
-        {rightItems.map(
-          (item) =>
-            (item.link !== '/submission' || isAdminUser) && (
-              <TopBarLink
-                key={item.link}
-                className='hidden-md-and-down'
-                name={item.name}
-                icon={item.icon}
-                isActive={location.pathname === item.link}
-                to={item.link}
-              />
-            )
-        )}
+        {rightItems.map((item) => (
+          <TopBarLink
+            key={item.link}
+            className='hidden-md-and-down'
+            name={item.name}
+            icon={item.icon}
+            isActive={location.pathname === item.link}
+            to={item.link}
+          />
+        ))}
         {username !== undefined ? (
           <TopBarMenu
             isAdminUser={isAdminUser}

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -6,11 +6,12 @@ import './TopBarMenu.css';
 
 /**
  * @param {Object} props
+ * @param {boolean} [props.isAdminUser]
  * @param {{ icon?: string; link: string; name: string; }[]} [props.items]
  * @param {React.MouseEventHandler<HTMLButtonElement>} props.onLogoutClick
  * @param {string} props.username
  */
-function TopBarMenu({ items, onLogoutClick, username }) {
+function TopBarMenu({ isAdminUser, items, onLogoutClick, username }) {
   const [showMenu, setShowMenu] = useState(false);
   function handleMenuBlur(e) {
     if (showMenu && !e.currentTarget.contains(e.relatedTarget))
@@ -35,6 +36,11 @@ function TopBarMenu({ items, onLogoutClick, username }) {
           <li className='top-bar-menu__item'>
             <Link to='/requests'>Data Requests</Link>
           </li>
+          {isAdminUser && (
+            <li className='top-bar-menu__item'>
+              <Link to='/submission'>Data Submission</Link>
+            </li>
+          )}
           {items?.map((item) => (
             <li key={item.link} className='top-bar-menu__item'>
               <a href={item.link} target='_blank' rel='noopener noreferrer'>
@@ -56,6 +62,7 @@ function TopBarMenu({ items, onLogoutClick, username }) {
 }
 
 TopBarMenu.propTypes = {
+  isAdminUser: PropTypes.bool,
   items: PropTypes.arrayOf(
     PropTypes.exact({
       icon: PropTypes.string,


### PR DESCRIPTION
Ticket: [PEDS-710](https://pcdc.atlassian.net/browse/PEDS-710)

This PR adds a link button to the admin-only "Data Submission" to the top bar "user menu" as a permanent item. The PR also removes a logic to conditionally display the link to the same page on the top bar itself.

See the following screenshot:

<img width="773" alt="image" src="https://user-images.githubusercontent.com/22449454/171907192-ab790524-823a-497f-a027-6b78a3a3a95c.png">

This change is meant to be coupled with https://github.com/chicagopcdc/configuration-files/pull/15.
