### PR TITLE
Deprecate sidebar Saved Filter Sets UI PEDS-756

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
@@ -94,7 +94,36 @@ function ExplorerFilterSet({ className, filter }) {
     JSON.stringify(filter) !== JSON.stringify(filterSet.filter);
 
   return (
-    <div className={className}>
+    <div className={className} style={{ backgroundColor: '#f001' }}>
+      <Tooltip
+        overlay={
+          <div>
+            All Saved Filter Sets features have been incorporated into the
+            Filter Set Workspace. This interface will be removed in an upcoming
+            release.
+          </div>
+        }
+        arrowContent={<div className='rc-tooltip-arrow-inner' />}
+        trigger={['hover', 'focus']}
+      >
+        <div
+          style={{
+            padding: '-0.5rem',
+            letterSpacing: '0rem',
+            fontWeight: 'var(--g3-font__semi-bold-weight)',
+          }}
+        >
+          <FontAwesomeIcon
+            icon='triangle-exclamation'
+            color='red'
+            size='xs'
+            style={{
+              cursor: 'pointer',
+            }}
+          />{' '}
+          Deprecated! Use Filter Set Workspace instead.
+        </div>
+      </Tooltip>
       {filterSets.isError ? (
         <div className='explorer-filter-set__error'>
           <h2>Error obtaining saved Filter Set data...</h2>

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -199,7 +199,6 @@ function ExplorerVisualization({
     if (!explorerViews.includes(explorerView))
       updateExplorerView(explorerViews[0]);
   }, []);
-  const showFilterSetWorkspace = explorerView !== 'survival analysis';
 
   const chartData = getChartData({
     aggsChartData,
@@ -276,9 +275,7 @@ function ExplorerVisualization({
           <ReduxExplorerButtonGroup {...buttonGroupProps} />
         </div>
       </div>
-      <div style={{ display: showFilterSetWorkspace ? 'initial' : 'none' }}>
-        <ExplorerFilterSetWorkspace />
-      </div>
+      <ExplorerFilterSetWorkspace />
       <ViewContainer
         showIf={explorerView === 'summary view'}
         isLoading={isLoadingAggsData}


### PR DESCRIPTION
Ticket: [PEDS-756](https://pcdc.atlassian.net/browse/PEDS-756)

This PR adds deprecation warning to the legacy sidebar Saved Filter Sets UI, which is planned to be removed in the next release for the portal app (v1.7.0).

See the following demo screenshot:

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/22449454/172224278-7c92dc23-309a-4e21-ad90-f5eb7eafb3dd.png">

Note that the Workspace is now always on display for all explorer views--including survival analysis. This change is necessary to preserve the UX that lets users manage saved filter sets while on the survival analysis view. 