### PR TITLE
Patch release 1.6.1 PEDS-760 PEDS-762

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.18.2",

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -341,19 +341,6 @@ function GuppyWrapper({
     fetchRawDataFromGuppy({ fields, updateDataWhenReceive: true });
   }
 
-  useEffect(() => {
-    getAllFieldsFromGuppy({
-      type: guppyConfig.dataType,
-    }).then((allFields) => {
-      if (isMounted.current) {
-        setState((prevState) => ({ ...prevState, allFields }));
-        fetchGuppyData(
-          rawDataFieldsConfig?.length > 0 ? rawDataFieldsConfig : allFields
-        );
-      }
-    });
-  }, []);
-
   const rawDataFields =
     rawDataFieldsConfig?.length > 0 ? rawDataFieldsConfig : state.allFields;
 
@@ -361,8 +348,14 @@ function GuppyWrapper({
   useEffect(() => {
     if (isInitialRenderRef.current) {
       isInitialRenderRef.current = false;
-      return;
+
+      // initialize allFields
+      getAllFieldsFromGuppy({ type: guppyConfig.dataType }).then((fields) => {
+        if (isMounted.current)
+          setState((prevState) => ({ ...prevState, allFields: fields }));
+      });
     }
+
     fetchGuppyData(rawDataFields);
   }, [filterState, patientIds]);
 

--- a/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSet/index.jsx
@@ -99,8 +99,8 @@ function ExplorerFilterSet({ className, filter }) {
         overlay={
           <div>
             All Saved Filter Sets features have been incorporated into the
-            Filter Set Workspace. This interface will be removed in an upcoming
-            release.
+            Filter Set Workspace. This interface will be removed in the July
+            2022 release.
           </div>
         }
         arrowContent={<div className='rc-tooltip-arrow-inner' />}

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetDeleteForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetDeleteForm.jsx
@@ -14,6 +14,9 @@ function FilterSetDeleteForm({ currentFilterSet, onAction, onClose }) {
   return (
     <div className='explorer-filter-set-form'>
       <h4>Are you sure to delete the current Filter Set?</h4>
+      <p style={{ marginBottom: '2rem' }}>
+        Once deleted, this Filter Set will no longer be available.
+      </p>
       <div>
         <Button buttonType='default' label='Back to page' onClick={onClose} />
         <Button

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import FilterDisplay from '../../components/FilterDisplay';
 import SimplePopup from '../../components/SimplePopup';
 import { useExplorerConfig } from '../ExplorerConfigContext';
@@ -24,14 +24,6 @@ function ExplorerFilterSetWorkspace() {
   const { handleFilterChange } = useExplorerState();
   const filterSets = useExplorerFilterSets();
   const workspace = useFilterSetWorkspace();
-  useEffect(() => {
-    const activeFilterSetId = workspace.active.filterSet.id;
-    if (activeFilterSetId !== undefined) filterSets.use(activeFilterSetId);
-  }, []);
-  useEffect(() => {
-    if (filterSets.active?.id !== undefined)
-      workspace.load(filterSets.active, true);
-  }, [filterSets.active]);
 
   const [actionFormType, setActionFormType] = useState(
     /** @type {ActionFormType} */ (undefined)

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -20,9 +20,15 @@ export default function useFilterSetWorkspace() {
     []
   );
   useEffect(() => {
+    const initialActiveFilterSet = initialWsState.active.filterSet;
+
+    // sync explorer filter set state with initial workspace active filter set
+    if ('id' in initialActiveFilterSet)
+      filterSets.use(initialActiveFilterSet.id);
+
     // sync explorer filter state with non-empty initial workspace active filter
-    if (!checkIfFilterEmpty(initialWsState.active.filterSet.filter))
-      handleFilterChange(initialWsState.active.filterSet.filter);
+    if (!checkIfFilterEmpty(initialActiveFilterSet.filter))
+      handleFilterChange(initialActiveFilterSet.filter);
   }, []);
 
   const [state, dispatch] = useReducer(workspaceReducer, initialWsState);
@@ -44,6 +50,12 @@ export default function useFilterSetWorkspace() {
     // sync browser store with workspace state
     storeWorkspaceState(state);
   }, [state]);
+
+  useEffect(() => {
+    // sync workspace active filter with explorer filter set state
+    if (filterSets.active?.id !== undefined)
+      dispatch({ type: 'LOAD', payload: { filterSet: filterSets.active } });
+  }, [filterSets.active]);
 
   const isInitialRender = useRef(true);
   useEffect(() => {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -15,12 +15,12 @@ export default function useFilterSetWorkspace() {
   const { explorerFilter, handleFilterChange } = useExplorerState();
   const filterSets = useExplorerFilterSets();
 
-  const initialWsState = useMemo(
+  const initialState = useMemo(
     () => initializeWorkspaceState(explorerFilter),
     []
   );
   useEffect(() => {
-    const initialActiveFilterSet = initialWsState.active.filterSet;
+    const initialActiveFilterSet = initialState.active.filterSet;
 
     // sync explorer filter set state with initial workspace active filter set
     if ('id' in initialActiveFilterSet)
@@ -31,7 +31,7 @@ export default function useFilterSetWorkspace() {
       handleFilterChange(initialActiveFilterSet.filter);
   }, []);
 
-  const [state, dispatch] = useReducer(workspaceReducer, initialWsState);
+  const [state, dispatch] = useReducer(workspaceReducer, initialState);
   const prevActiveFilterSet = useRef(state.active.filterSet);
   useEffect(() => {
     const { filter: prevFilter, id: prevId } = prevActiveFilterSet.current;

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -198,6 +198,7 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
           placeholder='Select Filter Set to analyze'
           options={filterSetOptions}
           onChange={setSelectFilterSetOption}
+          maxMenuHeight={160}
           value={selectFilterSetOption}
           theme={overrideSelectTheme}
         />


### PR DESCRIPTION
Tickets: [PEDS-760](https://pcdc.atlassian.net/browse/PEDS-760), [PEDS-762](https://pcdc.atlassian.net/browse/PEDS-762)

This PR bumps the project version to 1.6.1 and includes the following fixes & changes:

* Fixes data fetching issue with non-empty initial workspace active filter
* Fixes the survival analysis UI issue with filter set select input where the select menu with many items lead to unreachable options (by setting a smaller max height value)
* Update legacy filter set UI deprecation message in tooltip to specify the time for removal  <img width="583" alt="image" src="https://user-images.githubusercontent.com/22449454/172665079-588b325d-3f50-484c-816f-8e8f75841d52.png">
* Update filter set delete form UI to further clarify the consequences of deleting  <img width="507" alt="image" src="https://user-images.githubusercontent.com/22449454/172664895-28a4eedc-b443-49c7-960d-c3cddaa65491.png">
* Move all workspace-related effects to inside `useFilterSetWorkspace` hook

