### PR TITLE
Refactor and reorganize Redux code Pt.2 PEDS-754

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import Layout from './Layout';
 import ReduxLogin from './Login/ReduxLogin';
 import ProtectedContent from './Login/ProtectedContent';
 // import { fetchCoreMetadata } from './CoreMetadata/reduxer';
-import { fetchAccess } from './UserProfile/ReduxUserProfile';
 import {
   enableResourceBrowser,
   // workspaceUrl,
@@ -18,6 +17,7 @@ import { fetchVersionInfo } from './actions.thunk';
 import { fetchGraphvizLayout } from './DataDictionary/actions.thunk';
 import { fetchGuppySchema, fetchSchema } from './GraphQLEditor/actions.thunk';
 import { fetchDictionary } from './Submission/actions.thunk';
+import { fetchAccess } from './UserProfile/actions.thunk';
 import useSessionMonitor from './hooks/useSessionMonitor';
 
 // lazy-loaded pages

--- a/src/CoreMetadata/reducers.js
+++ b/src/CoreMetadata/reducers.js
@@ -10,10 +10,6 @@ const coreMetadata = (state = {}, action) => {
       return { ...state, error: action.error };
     case 'CLEAR_SIGNED_URL':
       return { ...state, url: null, error: null };
-    case 'DOWNLOAD_FILE':
-      return { ...state, file: action.data };
-    case 'DOWNLOAD_FILE_ERROR':
-      return { ...state, error: action.error };
     default:
       return state;
   }

--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -3,13 +3,13 @@ import CoreMetadataHeader from './CoreMetadataHeader';
 import FileTypePicture from '../components/FileTypePicture';
 import CoreMetadataTable from './CoreMetadataTable';
 import { coreMetadataPath, userapiPath } from '../localconf';
-import { updatePopup } from '../actions';
+import { connectionError, updatePopup } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
 
 export const generateSignedURL = (objectId) => (dispatch) =>
   fetchWithCreds({
     path: `${userapiPath}/data/download/${objectId}?expires_in=3600`,
-    dispatch,
+    onError: () => dispatch(connectionError()),
   }).then(({ status, data }) => {
     switch (status) {
       case 200:
@@ -35,7 +35,7 @@ export const fetchCoreMetadata = (objectId) => (dispatch) =>
   fetchWithCreds({
     path: coreMetadataPath + objectId,
     customHeaders: { Accept: 'application/json' },
-    dispatch,
+    onError: () => dispatch(connectionError()),
   })
     .then(({ status, data }) => {
       switch (status) {

--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -4,7 +4,7 @@ import FileTypePicture from '../components/FileTypePicture';
 import CoreMetadataTable from './CoreMetadataTable';
 import { coreMetadataPath, userapiPath } from '../localconf';
 import { connectionError, updatePopup } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 
 export const generateSignedURL = (objectId) => (dispatch) =>
   fetchWithCreds({

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
@@ -1,11 +1,13 @@
 import { connect } from 'react-redux';
 import ExplorerButtonGroup from '.';
+import { setJobStatusInterval } from '../../actions';
 import {
   dispatchJob,
-  checkJob,
   fetchJobResult,
   resetJobState,
+  checkJobStatus,
 } from '../../actions.thunk';
+import { asyncSetInterval } from '../../utils';
 
 /** @typedef {import('../../types').KubeState} KubeState */
 /** @typedef {import('../../types').UserAccessState} UserAccessState */
@@ -22,7 +24,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(dispatchJob(body));
   },
   checkJobStatus: () => {
-    dispatch(checkJob());
+    const interval = asyncSetInterval(() => dispatch(checkJobStatus()), 1000);
+    dispatch(setJobStatusInterval(interval));
   },
   /** @param {string} jobId */
   fetchJobResult: (jobId) => dispatch(fetchJobResult(jobId)),

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -7,7 +7,7 @@ import Toaster from '../../gen3-ui-component/components/Toaster';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 import { calculateDropdownButtonConfigs, humanizeNumber } from '../utils';
 import { ButtonConfigType, GuppyConfigType } from '../configTypeDef';
-import { fetchWithCreds } from '../../actions.thunk';
+import { fetchWithCreds } from '../../utils.fetch';
 import {
   manifestServiceApiPath,
   guppyGraphQLUrl,

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -5,7 +5,7 @@ import SimplePopup from '../../components/SimplePopup';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
 import { overrideSelectTheme } from '../../utils';
-import { fetchWithCreds } from '../../actions.thunk';
+import { fetchWithCreds } from '../../utils.fetch';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 import './ExplorerExploreExternalButton.css';

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import { useExplorerConfig } from './ExplorerConfigContext';
 import { createEmptyFilterSet } from './ExplorerFilterSet/utils';
 

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/useSurvivalAnalysisResult.js
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
-import { fetchWithCreds } from '../../actions.thunk';
+import { fetchWithCreds } from '../../utils.fetch';
 import { useExplorerConfig } from '../ExplorerConfigContext';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */

--- a/src/Index/actions.thunk.js
+++ b/src/Index/actions.thunk.js
@@ -43,7 +43,7 @@ function parseCounts(data) {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function getIndexPageCounts() {
+export function fetchIndexPageCounts() {
   /**
    * @param {import('redux').Dispatch} dispatch
    * @param {() => { index: import('./types').IndexState }} getState

--- a/src/Index/actions.thunk.js
+++ b/src/Index/actions.thunk.js
@@ -1,4 +1,4 @@
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import { consortiumList } from '../params';
 import { receiveIndexPageCounts } from './actions';
 

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -8,16 +8,17 @@ import {
   ReduxIntroduction,
 } from './reduxer';
 import UserPopup from '../UserPopup';
-import { getIndexPageCounts } from './utils';
+import { fetchIndexPageCounts } from './actions.thunk';
 import dictIcons from '../img/icons';
 import { components } from '../params';
 import { breakpoints } from '../localconf';
 import './page.css';
 
 function IndexPage() {
+  /** @type {import('redux-thunk').ThunkDispatch} */
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(getIndexPageCounts());
+    dispatch(fetchIndexPageCounts());
   }, []);
 
   const { width: screenWidth } = useResizeDetector({

--- a/src/Indexing/Indexing.jsx
+++ b/src/Indexing/Indexing.jsx
@@ -6,12 +6,12 @@ import {
   jobapiPath,
   hostname,
 } from '../localconf';
-import { fetchWithCreds, fetchWithCredsAndTimeout } from '../actions.thunk';
-import './Indexing.css';
+import { fetchWithCreds, fetchWithCredsAndTimeout } from '../utils.fetch';
 import Popup from '../components/Popup';
 import Spinner from '../components/Spinner';
 import IconComponent from '../components/Icon';
 import dictIcons from '../img/icons/index';
+import './Indexing.css';
 
 class Indexing extends Component {
   constructor(props) {

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -7,7 +7,7 @@ import { clearQueryNodes } from '../QueryNode/actions';
 import { clearCounts } from '../Submission/actions';
 import Spinner from '../components/Spinner';
 import AuthPopup from './AuthPopup';
-import { fetchLogin } from './ReduxLogin';
+import { fetchLogin } from './actions.thunk';
 
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
 /** @typedef {import('../types').UserState} UserState */

--- a/src/Login/ReduxLogin.js
+++ b/src/Login/ReduxLogin.js
@@ -1,46 +1,8 @@
 import { connect } from 'react-redux';
-
 import Login from './Login';
-import { fetchWithCreds } from '../actions.thunk';
-import { loginPath } from '../localconf';
 import { components } from '../params';
-import { loginEndpointErrored, receiveLoginEndpoint } from './actions';
 
-/** @typedef {import('./types').LoginProvider} LoginProvider */
 /** @typedef {import('./types').LoginState} LoginState */
-
-/**
- * @param {{ providers: LoginProvider[]; error: any }} data
- * @param {number} status
- * @returns {import('redux').AnyAction}
- */
-function getLoginAction(data, status) {
-  switch (status) {
-    case 200:
-      return receiveLoginEndpoint(data.providers);
-    case 404:
-      return receiveLoginEndpoint([
-        {
-          idp: 'google',
-          name: 'Google OAuth',
-          urls: [
-            {
-              name: 'Google OAuth',
-              url: `${loginPath}google/`,
-            },
-          ],
-        },
-      ]);
-    default:
-      return loginEndpointErrored(data.error);
-  }
-}
-
-export const fetchLogin =
-  () => (/** @type {import('redux').Dispatch} */ dispatch) =>
-    fetchWithCreds({ path: loginPath, dispatch }).then(({ data, status }) => {
-      dispatch(getLoginAction(data, status));
-    });
 
 /** @param {{ login: LoginState; user: import('../types').UserState }} state */
 const mapStateToProps = (state) => ({

--- a/src/Login/actions.thunk.js
+++ b/src/Login/actions.thunk.js
@@ -1,0 +1,33 @@
+/* eslint-disable import/prefer-default-export */
+
+import { fetchWithCreds } from '../actions.thunk';
+import { loginPath } from '../localconf';
+import { loginEndpointErrored, receiveLoginEndpoint } from './actions';
+
+/** @type {import('./types').LoginProvider[]} */
+const defaultProviders = [
+  {
+    idp: 'google',
+    name: 'Google OAuth',
+    urls: [
+      {
+        name: 'Google OAuth',
+        url: `${loginPath}google/`,
+      },
+    ],
+  },
+];
+
+export function fetchLogin() {
+  /** @param {import('redux').Dispatch} dispatch */
+  return async (dispatch) => {
+    const { data, status } = await fetchWithCreds({
+      path: loginPath,
+      dispatch,
+    });
+
+    if (status === 200) return dispatch(receiveLoginEndpoint(data.providers));
+    if (status === 404) return dispatch(receiveLoginEndpoint(defaultProviders));
+    return dispatch(loginEndpointErrored(data.error));
+  };
+}

--- a/src/Login/actions.thunk.js
+++ b/src/Login/actions.thunk.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { connectionError } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import { loginPath } from '../localconf';
 import { loginEndpointErrored, receiveLoginEndpoint } from './actions';
 

--- a/src/Login/actions.thunk.js
+++ b/src/Login/actions.thunk.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
+import { connectionError } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
 import { loginPath } from '../localconf';
 import { loginEndpointErrored, receiveLoginEndpoint } from './actions';
@@ -23,7 +24,7 @@ export function fetchLogin() {
   return async (dispatch) => {
     const { data, status } = await fetchWithCreds({
       path: loginPath,
-      dispatch,
+      onError: () => dispatch(connectionError()),
     });
 
     if (status === 200) return dispatch(receiveLoginEndpoint(data.providers));

--- a/src/QueryNode/ReduxQueryNode.js
+++ b/src/QueryNode/ReduxQueryNode.js
@@ -1,17 +1,8 @@
 import { connect } from 'react-redux';
 import { updatePopup } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
-import { getSubmitPath } from '../utils';
-import { submissionApiPath } from '../localconf';
 import QueryNode from './QueryNode';
-import {
-  clearDeleteSession,
-  deleteErrored,
-  deleteSucceded,
-  receiveQueryNode,
-  receiveSearchEntities,
-  storeNodeInfo,
-} from './actions';
+import { clearDeleteSession, storeNodeInfo } from './actions';
+import { deleteNode, fetchQueryNode, submitSearchForm } from './actions.thunk';
 
 /** @typedef {import('redux').Dispatch} Dispatch */
 /** @typedef {import('./types').QueryNodeState} QueryNodeState */
@@ -19,79 +10,6 @@ import {
 /** @typedef {import('../Submission/types').SubmissionState} SubmissionState */
 
 /**
- * @param {any} opts
- * @param {Function} [cb]
- */
-export const submitSearchForm =
-  (opts, cb) => (/** @type {Dispatch} */ dispatch) => {
-    const nodeType = opts.node_type;
-    const submitterId = opts.submitter_id || '';
-
-    return fetchWithCreds({
-      path: `${submissionApiPath}graphql`,
-      body: JSON.stringify({
-        query: `query Test { ${nodeType} (first: 20, project_id: "${opts.project}", quick_search: "${submitterId}", order_by_desc: "updated_datetime") {id, type, submitter_id}}`,
-      }),
-      method: 'POST',
-      dispatch,
-    })
-      .then(({ status, data }) => {
-        switch (status) {
-          case 200:
-            return receiveSearchEntities({
-              search_result: data,
-              search_status: `succeed: ${status}`,
-            });
-          default:
-            return receiveSearchEntities({
-              search_result: data,
-              search_status: `failed: ${status}`,
-            });
-        }
-      })
-      .then((msg) => dispatch(msg))
-      .then(() => cb?.());
-  };
-
-/** @param {{ project: string; id: string; }} param */
-const deleteNode =
-  ({ id, project }) =>
-  (/** @type {Dispatch} */ dispatch) =>
-    fetchWithCreds({
-      path: `${getSubmitPath(project)}/entities/${id}`,
-      method: 'DELETE',
-      dispatch,
-    }).then(({ status, data }) => {
-      // console.log('receive delete');
-      dispatch(updatePopup({ nodedelete_popup: false, view_popup: false }));
-
-      switch (status) {
-        case 200:
-          dispatch(deleteSucceded(id));
-          return dispatch(clearDeleteSession());
-        default:
-          return dispatch(deleteErrored(data));
-      }
-    });
-
-/** @param {{ project: string; id: string; }} param */
-const fetchQueryNode =
-  ({ id, project }) =>
-  (/** @type {Dispatch} */ dispatch) =>
-    fetchWithCreds({
-      path: `${getSubmitPath(project)}/export?ids=${id}&format=json`,
-      dispatch,
-    }).then(({ status, data }) => {
-      switch (status) {
-        case 200:
-          return dispatch(receiveQueryNode(data[0]));
-        default:
-          return null;
-      }
-    });
-
-/**
- *
  * @param {Object} state
  * @param {PopupState} state.popups
  * @param {QueryNodeState} state.queryNodes

--- a/src/QueryNode/actions.thunk.js
+++ b/src/QueryNode/actions.thunk.js
@@ -1,5 +1,5 @@
 import { connectionError, updatePopup } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import { getSubmitPath } from '../utils';
 import { submissionApiPath } from '../localconf';
 import {

--- a/src/QueryNode/actions.thunk.js
+++ b/src/QueryNode/actions.thunk.js
@@ -1,4 +1,4 @@
-import { updatePopup } from '../actions';
+import { connectionError, updatePopup } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
 import { getSubmitPath } from '../utils';
 import { submissionApiPath } from '../localconf';
@@ -22,7 +22,7 @@ export const deleteNode =
     const { data, status } = await fetchWithCreds({
       path: `${getSubmitPath(project)}/entities/${id}`,
       method: 'DELETE',
-      dispatch,
+      onError: () => dispatch(connectionError()),
     });
     // console.log('receive delete');
     dispatch(updatePopup({ nodedelete_popup: false, view_popup: false }));
@@ -41,7 +41,7 @@ export const fetchQueryNode =
   async (/** @type {Dispatch} */ dispatch) => {
     const { data, status } = await fetchWithCreds({
       path: `${getSubmitPath(project)}/export?ids=${id}&format=json`,
-      dispatch,
+      onError: () => dispatch(connectionError()),
     });
 
     if (status === 200) dispatch(receiveQueryNode(data[0]));
@@ -62,7 +62,7 @@ export const submitSearchForm =
         query: `query Test { ${nodeType} (first: 20, project_id: "${opts.project}", quick_search: "${submitterId}", order_by_desc: "updated_datetime") {id, type, submitter_id}}`,
       }),
       method: 'POST',
-      dispatch,
+      onError: () => dispatch(connectionError()),
     });
 
     const payload = {

--- a/src/QueryNode/actions.thunk.js
+++ b/src/QueryNode/actions.thunk.js
@@ -1,0 +1,76 @@
+import { updatePopup } from '../actions';
+import { fetchWithCreds } from '../actions.thunk';
+import { getSubmitPath } from '../utils';
+import { submissionApiPath } from '../localconf';
+import {
+  clearDeleteSession,
+  deleteErrored,
+  deleteSucceded,
+  receiveQueryNode,
+  receiveSearchEntities,
+} from './actions';
+
+/** @typedef {import('redux').Dispatch} Dispatch */
+/** @typedef {import('./types').QueryNodeState} QueryNodeState */
+/** @typedef {import('../types').PopupState} PopupState */
+/** @typedef {import('../Submission/types').SubmissionState} SubmissionState */
+
+/** @param {{ project: string; id: string; }} param */
+export const deleteNode =
+  ({ id, project }) =>
+  async (/** @type {Dispatch} */ dispatch) => {
+    const { data, status } = await fetchWithCreds({
+      path: `${getSubmitPath(project)}/entities/${id}`,
+      method: 'DELETE',
+      dispatch,
+    });
+    // console.log('receive delete');
+    dispatch(updatePopup({ nodedelete_popup: false, view_popup: false }));
+
+    if (status === 200) {
+      dispatch(deleteSucceded(id));
+      dispatch(clearDeleteSession());
+    } else {
+      dispatch(deleteErrored(data));
+    }
+  };
+
+/** @param {{ project: string; id: string; }} param */
+export const fetchQueryNode =
+  ({ id, project }) =>
+  async (/** @type {Dispatch} */ dispatch) => {
+    const { data, status } = await fetchWithCreds({
+      path: `${getSubmitPath(project)}/export?ids=${id}&format=json`,
+      dispatch,
+    });
+
+    if (status === 200) dispatch(receiveQueryNode(data[0]));
+  };
+
+/**
+ * @param {any} opts
+ * @param {Function} [cb]
+ */
+export const submitSearchForm =
+  (opts, cb) => async (/** @type {Dispatch} */ dispatch) => {
+    const nodeType = opts.node_type;
+    const submitterId = opts.submitter_id || '';
+
+    const { data, status } = await fetchWithCreds({
+      path: `${submissionApiPath}graphql`,
+      body: JSON.stringify({
+        query: `query Test { ${nodeType} (first: 20, project_id: "${opts.project}", quick_search: "${submitterId}", order_by_desc: "updated_datetime") {id, type, submitter_id}}`,
+      }),
+      method: 'POST',
+      dispatch,
+    });
+
+    const payload = {
+      search_result: data,
+      search_status:
+        status === 200 ? `succeed: ${status}` : `failed: ${status}`,
+    };
+
+    dispatch(receiveSearchEntities(payload));
+    cb?.();
+  };

--- a/src/Submission/ReduxMapFiles.js
+++ b/src/Submission/ReduxMapFiles.js
@@ -1,50 +1,12 @@
 import { connect } from 'react-redux';
 import MapFiles from './MapFiles';
-import { fetchErrored } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
-import { STARTING_DID, FETCH_LIMIT } from './utils';
-import { indexdPath, useIndexdAuthz } from '../localconf';
-import { receiveFilesToMap, receiveUnmappedFiles } from './actions';
+import { STARTING_DID } from './utils';
+import { receiveFilesToMap } from './actions';
+import { fetchUnmappedFiles } from './actions.thunk';
 
-/** @typedef {import('redux').AnyAction} AnyAction */
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
 /** @typedef {import('./types').SubmissionState} SubmissionState */
 /** @typedef {import('../types').UserState} UserState */
-
-/**
- * @param {UserState['username']} username
- * @param {SubmissionState['unmappedFiles']} total
- * @param {string} start
- */
-const fetchUnmappedFiles =
-  (username, total, start) => (/** @type {ThunkDispatch} */ dispatch) => {
-    const unmappedFilesCheck = useIndexdAuthz ? 'authz=null' : 'acl=null';
-    return fetchWithCreds({
-      path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${username}&start=${start}&limit=${FETCH_LIMIT}`,
-      method: 'GET',
-    })
-      .then(({ status, data }) => {
-        switch (status) {
-          case 200:
-            total = total.concat(data.records ?? []);
-            if (data.records?.length === FETCH_LIMIT) {
-              return dispatch(
-                fetchUnmappedFiles(
-                  username,
-                  total,
-                  data.records[FETCH_LIMIT - 1].did
-                )
-              );
-            }
-            return receiveUnmappedFiles(total);
-          default:
-            return fetchErrored(data.records);
-        }
-      }, fetchErrored)
-      .then((msg) => {
-        if (msg) dispatch(msg);
-      });
-  };
 
 const ReduxMapFiles = (() => {
   /** @param {{ submission: SubmissionState; user: UserState }} state */

--- a/src/Submission/actions.thunk.js
+++ b/src/Submission/actions.thunk.js
@@ -1,21 +1,31 @@
 import { fetchErrored } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
-import { submissionApiPath } from '../localconf';
+import {
+  indexdPath,
+  lineLimit,
+  submissionApiPath,
+  useIndexdAuthz,
+} from '../localconf';
 import { predictFileType } from '../utils';
 import {
   receiveCounts,
   receiveDictionary,
+  receiveSubmission,
+  receiveUnmappedFiles,
+  receiveUnmappedFileStatistics,
   requestUpload,
+  resetSubmissionStatus,
   updateFile,
 } from './actions';
-import { buildCountsQuery } from './utils';
+import { buildCountsQuery, FETCH_LIMIT } from './utils';
 
 /** @typedef {import('redux').AnyAction} AnyAction */
 /** @typedef {import('redux').Dispatch} Dispatch */
+/** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
 /** @typedef {import('./types').SubmissionState} SubmissionState */
 export function fetchDictionary() {
   /**
-   * @param {import('redux').Dispatch} dispatch
+   * @param {Dispatch} dispatch
    * @param {() => { submission: SubmissionState }} getState
    */
   return (dispatch, getState) =>
@@ -25,6 +35,88 @@ export function fetchDictionary() {
           dispatch(receiveDictionary(data))
         );
 }
+
+/**
+ * @param {import('../types').UserState['username']} username
+ * @param {SubmissionState['unmappedFiles']} total
+ * @param {string} start
+ */
+export const fetchUnmappedFiles =
+  (username, total, start) => (/** @type {ThunkDispatch} */ dispatch) => {
+    const unmappedFilesCheck = useIndexdAuthz ? 'authz=null' : 'acl=null';
+    return fetchWithCreds({
+      path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${username}&start=${start}&limit=${FETCH_LIMIT}`,
+      method: 'GET',
+    })
+      .then(({ status, data }) => {
+        const files = total.concat(data.records ?? []);
+        switch (status) {
+          case 200:
+            if (data.records?.length === FETCH_LIMIT) {
+              return dispatch(
+                fetchUnmappedFiles(
+                  username,
+                  files,
+                  data.records[FETCH_LIMIT - 1].did
+                )
+              );
+            }
+            return receiveUnmappedFiles(files);
+          default:
+            return fetchErrored(data.records);
+        }
+      }, fetchErrored)
+      .then((msg) => {
+        if (msg) dispatch(msg);
+      });
+  };
+
+/**
+ * @param {import('../types').UserState['username']} username
+ * @param {SubmissionState['unmappedFiles']} total
+ * @param {string} start
+ * @returns
+ */
+export const fetchUnmappedFileStats =
+  (username, total, start) => (/** @type {ThunkDispatch} */ dispatch) => {
+    const unmappedFilesCheck = useIndexdAuthz ? 'authz=null' : 'acl=null';
+    return fetchWithCreds({
+      path: `${indexdPath}index?${unmappedFilesCheck}&uploader=${username}&start=${start}&limit=${FETCH_LIMIT}`,
+      method: 'GET',
+    })
+      .then(({ status, data }) => {
+        const files = total.concat(data.records ?? []);
+        switch (status) {
+          case 200:
+            if (data.records?.length === FETCH_LIMIT) {
+              return dispatch(
+                fetchUnmappedFileStats(
+                  username,
+                  files,
+                  data.records[FETCH_LIMIT - 1].did
+                )
+              );
+            }
+            return receiveUnmappedFileStatistics({
+              unmappedFileCount: files.length,
+              unmappedFileSize: files.reduce(
+                /**
+                 * @param {number} size
+                 * @param {Object} current
+                 */
+                (size, current) => size + current.size,
+                0
+              ),
+            });
+
+          default:
+            return fetchErrored(data.records);
+        }
+      }, fetchErrored)
+      .then((msg) => {
+        if (msg) dispatch(msg);
+      });
+  };
 
 /**
  * Compose and send a single graphql query to get a count of how
@@ -58,6 +150,103 @@ export const getCounts =
       .then((msg) => {
         dispatch(msg);
       });
+  };
+
+/**
+ * @param {Object} args
+ * @param {string} args.fullProject
+ * @param {string} [args.methodIn]
+ * @param {() => void} [args.callback]
+ */
+export const submitToServer =
+  ({ fullProject, methodIn = 'PUT', callback }) =>
+  /**
+   * @param {Dispatch} dispatch
+   * @param {() => { submission: SubmissionState }} getState
+   */
+  (dispatch, getState) => {
+    dispatch(resetSubmissionStatus());
+
+    /** @type {string[]} */
+    const fileArray = [];
+    const path = fullProject.split('-');
+    const program = path[0];
+    const project = path.slice(1).join('-');
+    const { submission } = getState();
+    const method = /* path === 'graphql' ? 'POST' : */ methodIn;
+
+    let { file } = submission;
+    if (!file) {
+      return Promise.reject(new Error('No file to submit'));
+    }
+    if (submission.file_type !== 'text/tab-separated-values') {
+      // remove line break in json file
+      file = file.replace(/\r\n?|\n/g, '');
+    }
+
+    if (submission.file_type === 'text/tab-separated-values') {
+      const fileSplited = file.split(/\r\n?|\n/g);
+      if (fileSplited.length > lineLimit && lineLimit > 0) {
+        let fileHeader = fileSplited[0];
+        fileHeader += '\n';
+        let count = lineLimit;
+        let fileChunk = fileHeader;
+
+        for (let i = 1; i < fileSplited.length; i += 1) {
+          if (fileSplited[i] !== '') {
+            fileChunk += fileSplited[i];
+            fileChunk += '\n';
+            count -= 1;
+          }
+          if (count === 0) {
+            fileArray.push(fileChunk);
+            fileChunk = fileHeader;
+            count = lineLimit;
+          }
+        }
+        if (fileChunk !== fileHeader) {
+          fileArray.push(fileChunk);
+        }
+      } else {
+        fileArray.push(file);
+      }
+    } else {
+      fileArray.push(file);
+    }
+
+    let subUrl = submissionApiPath;
+    if (program !== '_root') {
+      subUrl = `${subUrl + program}/${project}/`;
+    }
+
+    const totalChunk = fileArray.length;
+
+    /** @param {string[]} chunkArray */
+    function recursiveFetch(chunkArray) {
+      if (chunkArray.length === 0) {
+        return null;
+      }
+
+      return fetchWithCreds({
+        path: subUrl,
+        method,
+        customHeaders: new Headers({ 'Content-Type': submission.file_type }),
+        body: chunkArray.shift(),
+        dispatch,
+      })
+        .then(recursiveFetch(chunkArray))
+        .then(({ status, data }) =>
+          receiveSubmission({
+            data,
+            submit_status: status,
+            submit_total: totalChunk,
+          })
+        )
+        .then((msg) => dispatch(msg))
+        .then(callback);
+    }
+
+    return recursiveFetch(fileArray);
   };
 
 /**

--- a/src/Submission/actions.thunk.js
+++ b/src/Submission/actions.thunk.js
@@ -1,4 +1,4 @@
-import { fetchErrored } from '../actions';
+import { connectionError, fetchErrored } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
 import {
   indexdPath,
@@ -137,7 +137,7 @@ export const getCounts =
         query: buildCountsQuery(dictionary, nodeTypes, project),
       }),
       method: 'POST',
-      dispatch,
+      onError: () => dispatch(connectionError()),
     })
       .then(({ status, data }) => {
         switch (status) {
@@ -232,7 +232,7 @@ export const submitToServer =
         method,
         customHeaders: new Headers({ 'Content-Type': submission.file_type }),
         body: chunkArray.shift(),
-        dispatch,
+        onError: () => dispatch(connectionError()),
       })
         .then(recursiveFetch(chunkArray))
         .then(({ status, data }) =>

--- a/src/Submission/actions.thunk.js
+++ b/src/Submission/actions.thunk.js
@@ -1,5 +1,5 @@
 import { connectionError, fetchErrored } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import {
   indexdPath,
   lineLimit,

--- a/src/UserPopup/index.jsx
+++ b/src/UserPopup/index.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import SimplePopup from '../components/SimplePopup';
 import { receiveUser } from '../actions';
 import { fetchUser, fetchUserAccess } from '../actions.thunk';
-import { getIndexPageCounts } from '../Index/utils';
+import { fetchIndexPageCounts } from '../Index/actions.thunk';
 import { headers, userapiPath } from '../localconf';
 import RegistrationForm from './RegistrationForm';
 import ReviewForm from './ReviewForm';
@@ -92,7 +92,7 @@ function UserPopup() {
 
       dispatch(receiveUser(user));
       /** @type {ThunkDispatch} */ (dispatch)(fetchUserAccess());
-      /** @type {ThunkDispatch} */ (dispatch)(getIndexPageCounts());
+      /** @type {ThunkDispatch} */ (dispatch)(fetchIndexPageCounts());
       return 'success';
     } catch (e) {
       console.error(e); // eslint-disable-line no-console

--- a/src/UserProfile/ReduxUserProfile.js
+++ b/src/UserProfile/ReduxUserProfile.js
@@ -2,93 +2,18 @@ import { connect } from 'react-redux';
 
 import UserProfile from './UserProfile';
 import { updatePopup } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
-import { credentialCdisPath } from '../localconf';
 import {
   clearCreationSession,
   clearDeleteKeySession,
-  createFailed,
-  createSucceeded,
-  deleteKeyFailed,
-  deleteKeySucceeded,
-  receiveUserProfile,
   requestDeleteKey,
-  userProfileErrored,
 } from './actions';
+import { createKey, deleteKey, fetchAccess } from './actions.thunk';
 
-/** @typedef {import('redux').AnyAction} AnyAction */
-/** @typedef {import('redux').Dispatch} Dispatch */
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
+/** @typedef {import('../types').PopupState} PopupState */
+/** @typedef {import('../types').UserState} UserState */
 /** @typedef {import('./types').JtiData} JtiData */
 /** @typedef {import('./types').UserProfileState} UserProfileState */
-/** @typedef {import('../types').UserState} UserState */
-/** @typedef {import('../types').PopupState} PopupState */
-
-export const fetchAccess = () => (/** @type {Dispatch} */ dispatch) =>
-  fetchWithCreds({
-    path: credentialCdisPath,
-    dispatch,
-  })
-    .then(({ status, data }) => {
-      switch (status) {
-        case 200:
-          return receiveUserProfile(data.jtis);
-        default:
-          return userProfileErrored(data.error);
-      }
-    })
-    .then((msg) => dispatch(msg));
-
-/**
- * @param {JtiData['jti']} jti
- * @param {JtiData['exp']} exp
- * @param {string} path
- */
-export const deleteKey =
-  (jti, exp, path) => (/** @type {ThunkDispatch} */ dispatch) =>
-    fetchWithCreds({
-      path: path + jti,
-      method: 'DELETE',
-      body: JSON.stringify({ exp }),
-      dispatch,
-    }).then(({ status, data }) => {
-      switch (status) {
-        case 204:
-          dispatch(deleteKeySucceeded());
-          dispatch(clearDeleteKeySession());
-          dispatch(updatePopup({ deleteTokenPopup: false }));
-          return dispatch(fetchAccess());
-        default:
-          return dispatch(deleteKeyFailed(data));
-      }
-    });
-
-/** @param {string} path */
-export const createKey = (path) => (/** @type {ThunkDispatch} */ dispatch) =>
-  fetchWithCreds({
-    path,
-    method: 'POST',
-    body: JSON.stringify({
-      scope: ['data', 'user'],
-    }),
-    dispatch,
-    customHeaders: new Headers({ 'Content-Type': 'application/json' }),
-  }).then(({ status, data }) => {
-    switch (status) {
-      case 200:
-        dispatch(
-          createSucceeded({
-            refreshCred: data,
-            strRefreshCred: JSON.stringify(data, null, '\t'),
-          })
-        );
-        dispatch(updatePopup({ saveTokenPopup: true }));
-        return dispatch(fetchAccess());
-      default:
-        dispatch(createFailed(`Error: ${data.error || data.message}`));
-        return dispatch(updatePopup({ saveTokenPopup: true }));
-    }
-  });
 
 /**
  * @param {Object} state

--- a/src/UserProfile/ReduxUserProfile.test.jsx
+++ b/src/UserProfile/ReduxUserProfile.test.jsx
@@ -3,13 +3,14 @@ import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import fetchMock from 'jest-fetch-mock';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import ReduxUserProfile, { createKey, deleteKey } from './ReduxUserProfile';
+import ReduxUserProfile from './ReduxUserProfile';
 import {
   clearDeleteKeySession,
   createSucceeded,
   deleteKeySucceeded,
   receiveUserProfile,
 } from './actions';
+import { createKey, deleteKey } from './actions.thunk';
 
 const { mockResponseOnce } = fetchMock;
 const expectedData = {

--- a/src/UserProfile/actions.thunk.js
+++ b/src/UserProfile/actions.thunk.js
@@ -1,5 +1,5 @@
 import { connectionError, updatePopup } from '../actions';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import { credentialCdisPath } from '../localconf';
 import {
   clearDeleteKeySession,

--- a/src/UserProfile/actions.thunk.js
+++ b/src/UserProfile/actions.thunk.js
@@ -1,0 +1,82 @@
+import { updatePopup } from '../actions';
+import { fetchWithCreds } from '../actions.thunk';
+import { credentialCdisPath } from '../localconf';
+import {
+  clearDeleteKeySession,
+  createFailed,
+  createSucceeded,
+  deleteKeyFailed,
+  deleteKeySucceeded,
+  receiveUserProfile,
+  userProfileErrored,
+} from './actions';
+
+/** @typedef {import('redux').Dispatch} Dispatch */
+/** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
+/** @typedef {import('./types').JtiData} JtiData */
+/** @typedef {import('../types').PopupState} PopupState */
+
+export const fetchAccess = () => (/** @type {Dispatch} */ dispatch) =>
+  fetchWithCreds({
+    path: credentialCdisPath,
+    dispatch,
+  })
+    .then(({ status, data }) => {
+      switch (status) {
+        case 200:
+          return receiveUserProfile(data.jtis);
+        default:
+          return userProfileErrored(data.error);
+      }
+    })
+    .then((msg) => dispatch(msg));
+
+/** @param {string} path */
+export const createKey = (path) => (/** @type {ThunkDispatch} */ dispatch) =>
+  fetchWithCreds({
+    path,
+    method: 'POST',
+    body: JSON.stringify({
+      scope: ['data', 'user'],
+    }),
+    dispatch,
+    customHeaders: new Headers({ 'Content-Type': 'application/json' }),
+  }).then(({ status, data }) => {
+    switch (status) {
+      case 200:
+        dispatch(
+          createSucceeded({
+            refreshCred: data,
+            strRefreshCred: JSON.stringify(data, null, '\t'),
+          })
+        );
+        dispatch(updatePopup({ saveTokenPopup: true }));
+        return dispatch(fetchAccess());
+      default:
+        dispatch(createFailed(`Error: ${data.error || data.message}`));
+        return dispatch(updatePopup({ saveTokenPopup: true }));
+    }
+  });
+/**
+ * @param {JtiData['jti']} jti
+ * @param {JtiData['exp']} exp
+ * @param {string} path
+ */
+export const deleteKey =
+  (jti, exp, path) => (/** @type {ThunkDispatch} */ dispatch) =>
+    fetchWithCreds({
+      path: path + jti,
+      method: 'DELETE',
+      body: JSON.stringify({ exp }),
+      dispatch,
+    }).then(({ status, data }) => {
+      switch (status) {
+        case 204:
+          dispatch(deleteKeySucceeded());
+          dispatch(clearDeleteKeySession());
+          dispatch(updatePopup({ deleteTokenPopup: false }));
+          return dispatch(fetchAccess());
+        default:
+          return dispatch(deleteKeyFailed(data));
+      }
+    });

--- a/src/UserProfile/actions.thunk.js
+++ b/src/UserProfile/actions.thunk.js
@@ -1,4 +1,4 @@
-import { updatePopup } from '../actions';
+import { connectionError, updatePopup } from '../actions';
 import { fetchWithCreds } from '../actions.thunk';
 import { credentialCdisPath } from '../localconf';
 import {
@@ -19,7 +19,7 @@ import {
 export const fetchAccess = () => (/** @type {Dispatch} */ dispatch) =>
   fetchWithCreds({
     path: credentialCdisPath,
-    dispatch,
+    onError: () => dispatch(connectionError()),
   })
     .then(({ status, data }) => {
       switch (status) {
@@ -39,7 +39,7 @@ export const createKey = (path) => (/** @type {ThunkDispatch} */ dispatch) =>
     body: JSON.stringify({
       scope: ['data', 'user'],
     }),
-    dispatch,
+    onError: () => dispatch(connectionError()),
     customHeaders: new Headers({ 'Content-Type': 'application/json' }),
   }).then(({ status, data }) => {
     switch (status) {
@@ -68,7 +68,7 @@ export const deleteKey =
       path: path + jti,
       method: 'DELETE',
       body: JSON.stringify({ exp }),
-      dispatch,
+      onError: () => dispatch(connectionError()),
     }).then(({ status, data }) => {
       switch (status) {
         case 204:

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -10,7 +10,7 @@ import {
   workspaceStatusUrl,
 } from '../localconf';
 import './Workspace.css';
-import { fetchWithCreds } from '../actions.thunk';
+import { fetchWithCreds } from '../utils.fetch';
 import Spinner from '../components/Spinner';
 import jupyterIcon from '../img/icons/jupyter.svg';
 import rStudioIcon from '../img/icons/rstudio.svg';

--- a/src/actions.thunk.js
+++ b/src/actions.thunk.js
@@ -12,7 +12,6 @@ import {
 } from './actions';
 import {
   userapiPath,
-  headers,
   hostname,
   submissionApiPath,
   authzPath,
@@ -20,164 +19,11 @@ import {
   jobapiPath,
 } from './localconf';
 import { config } from './params';
+import { fetchCreds, fetchWithCreds } from './utils.fetch';
 
 /** @typedef {import('redux').AnyAction} AnyAction */
 /** @typedef {import('redux').Dispatch} Dispatch */
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
-/** @typedef {import('./types').FetchHelperOptions} FetchHelperOptions */
-/** @typedef {import('./types').FetchHelperResult} FetchHelperResult */
-
-/** @type {{ [path: string]: string; }} */
-const fetchCache = {};
-
-/**
- * @param {string} path
- * @param {Response} response
- * @param {boolean} useCache
- * @param {string} method
- * @returns {Promise<FetchHelperResult>}
- */
-const getJsonOrText = (path, response, useCache, method = 'GET') =>
-  response.text().then((textData) => {
-    let data = textData;
-    if (data) {
-      try {
-        data = JSON.parse(data);
-        if (useCache && method === 'GET' && response.status === 200)
-          fetchCache[path] = textData;
-      } catch (e) {
-        // # do nothing
-      }
-    }
-    return {
-      response,
-      data,
-      status: response.status,
-      headers: response.headers,
-    };
-  });
-
-/** @type {Promise<FetchHelperResult>} */
-let pendingRequest = null;
-/**
- * @param {Object} opts
- * @param {string} [opts.path]
- * @param {string} [opts.method]
- * @param {() => void} [opts.onError]
- */
-export const fetchCreds = (opts) => {
-  if (pendingRequest) {
-    return pendingRequest;
-  }
-  const { path = `${userapiPath}user/`, method = 'GET', onError } = opts;
-
-  pendingRequest = fetch(path, {
-    credentials: 'include',
-    headers,
-    method,
-  })
-    .then((response) => {
-      pendingRequest = null;
-      return getJsonOrText(path, response, false);
-    })
-    .catch((error) => {
-      pendingRequest = null;
-      onError?.();
-      return error;
-    });
-  return pendingRequest;
-};
-
-/**
- * Little helper issues fetch, then resolves response
- * as text, and tries to JSON.parse the text before resolving, but
- * ignores JSON.parse failure and reponse.status, and returns {response, data} either way.
- * If dispatch is supplied, then dispatch(connectionError()) on fetch reject.
- * If useCache is supplied and method is GET,
- * then text for 200 JSON responses are cached, and re-used, and
- * the result promise only includes {data, status} - where JSON data is re-parsed
- * every time to avoid mutation by the client
- *
- * @param {FetchHelperOptions} opts
- * @return {Promise<FetchHelperResult>}
- */
-export const fetchWithCreds = (opts) => {
-  const {
-    path,
-    method = 'GET',
-    body = null,
-    customHeaders,
-    onError,
-    useCache,
-    signal,
-  } = opts;
-  if (useCache && method === 'GET' && fetchCache[path]) {
-    return Promise.resolve({ status: 200, data: JSON.parse(fetchCache[path]) });
-  }
-  /** @type {RequestInit} */
-  const request = {
-    credentials: 'include',
-    headers: { ...headers, ...customHeaders },
-    method,
-    body,
-    signal,
-  };
-  return fetch(path, request)
-    .then((response) => {
-      if (response.status !== 403 && response.status !== 401)
-        return getJsonOrText(path, response, useCache, method);
-
-      return fetchCreds({ onError }).then((resp) => {
-        switch (resp.status) {
-          case 200:
-            return fetch(path, request).then((res) =>
-              getJsonOrText(path, res, useCache, method)
-            );
-          default:
-            return {
-              response: resp.response,
-              data: { data: {} },
-              status: resp.status,
-              headers: resp.headers,
-            };
-        }
-      });
-    })
-    .catch((error) => {
-      onError?.();
-      return Promise.reject(error);
-    });
-};
-
-/**
- * @param {FetchHelperOptions} opts
- * @param {number} timeoutInMS
- */
-export const fetchWithCredsAndTimeout = (opts, timeoutInMS) => {
-  let didTimeOut = false;
-
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      didTimeOut = true;
-      reject(new Error('Request timed out'));
-    }, timeoutInMS);
-
-    fetchWithCreds(opts)
-      .then((response) => {
-        // Clear the timeout as cleanup
-        clearTimeout(timeout);
-        if (!didTimeOut) {
-          resolve(response);
-        }
-      })
-      .catch((err) => {
-        // Rejection already happened with setTimeout
-        if (didTimeOut) return;
-        // Reject with error
-        reject(err);
-      });
-  });
-};
 
 /* SLICE: KUBE */
 /** @param {any} body */
@@ -274,7 +120,7 @@ export const fetchProjects =
         });
 
 /* SLICE: USER */
-/** @param {FetchHelperResult} result */
+/** @param {import('./types').FetchHelperResult} result */
 export const handleFetchUser = ({ status, data }) => {
   switch (status) {
     case 200:

--- a/src/actions.thunk.js
+++ b/src/actions.thunk.js
@@ -185,17 +185,6 @@ export const fetchWithCredsAndTimeout = (opts, timeoutInMS) => {
   });
 };
 
-/**
- * @param {string} did
- * @param {string} method
- */
-export const getPresignedUrl = (did, method) => {
-  const urlPath = `${userapiPath}data/${method}/${did}`;
-  return fetchWithCreds({ path: urlPath, method: 'GET' }).then(
-    ({ data }) => /** @type {string} */ (data.url)
-  );
-};
-
 /* SLICE: KUBE */
 /** @param {any} body */
 export const dispatchJob = (body) => (/** @type {Dispatch} */ dispatch) =>
@@ -252,14 +241,6 @@ export const checkJobStatus = (dispatch, getState) => {
     });
 };
 
-// dispatch the job with body
-// then start pulling job status
-// save the interval id in redux that can be used to clear the timer later
-
-// TODO: need to get result urls from a Gen3 service
-export const submitJob = (body) => (/** @type {ThunkDispatch} */ dispatch) =>
-  dispatch(dispatchJob(body));
-
 export const checkJob = () => (/** @type {ThunkDispatch} */ dispatch) =>
   asyncSetInterval(() => dispatch(checkJobStatus), 1000).then(
     (intervalValue) => {
@@ -304,36 +285,6 @@ export const fetchProjects =
           else dispatch(fetchErrored(data));
         });
 
-/* SLICE: STATUS */
-/**
- * @param {Object} opts
- * @param {string} [opts.path]
- * @param {string} [opts.method]
- * @param {Dispatch} [opts.dispatch]
- * @returns {?Promise<FetchHelperResult>}
- */
-export const fetchIsUserLoggedInNoRefresh = (opts) => {
-  const { path = `${submissionApiPath}`, method = 'GET', dispatch } = opts;
-
-  let requestPromise = fetch(path, {
-    credentials: 'include',
-    headers,
-    method,
-  }).then(
-    (response) => {
-      requestPromise = null;
-      return getJsonOrText(path, response, false);
-    },
-    (error) => {
-      requestPromise = null;
-      if (dispatch) dispatch(connectionError());
-
-      return error;
-    }
-  );
-  return requestPromise;
-};
-
 /* SLICE: USER */
 /** @param {FetchHelperResult} result */
 export const handleFetchUser = ({ status, data }) => {
@@ -349,11 +300,6 @@ export const handleFetchUser = ({ status, data }) => {
 
 export const fetchUser = () => (/** @type {Dispatch} */ dispatch) =>
   fetchCreds({ dispatch }).then((res) => dispatch(handleFetchUser(res)));
-
-export const fetchUserNoRefresh = () => (/** @type {Dispatch} */ dispatch) =>
-  fetchIsUserLoggedInNoRefresh({ dispatch }).then((res) =>
-    dispatch(handleFetchUser(res))
-  );
 
 /** @param {boolean} displayAuthPopup */
 export const logoutAPI =

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -87,8 +87,6 @@ const user = (state = /** @type {UserState} */ ({}), action) => {
       };
     case 'FETCH_ERROR':
       return { ...state, fetched_user: true, fetch_error: action.payload };
-    case 'RECEIVE_API_LOGOUT':
-      return { ...state, lastAuthMs: 0 };
     default:
       return state;
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,12 +3,12 @@ import type { UserReviewDocument } from './UserPopup/types';
 
 export type FetchHelperOptions = {
   path: string;
-  method?: string; // Default is "GET"
   body?: any; // Default is null
   customHeaders?: Headers;
-  dispatch?: Dispatch;
-  useCache?: boolean;
+  method?: string; // Default is "GET"
+  onError?: () => void;
   signal?: AbortSignal;
+  useCache?: boolean;
 };
 
 export type FetchHelperResult = {

--- a/src/utils.fetch.js
+++ b/src/utils.fetch.js
@@ -1,0 +1,157 @@
+import { headers, userapiPath } from './localconf';
+
+/** @typedef {import('./types').FetchHelperOptions} FetchHelperOptions */
+/** @typedef {import('./types').FetchHelperResult} FetchHelperResult */
+
+/** @type {{ [path: string]: string; }} */
+const fetchCache = {};
+
+/**
+ * @param {string} path
+ * @param {Response} response
+ * @param {boolean} useCache
+ * @param {string} method
+ * @returns {Promise<FetchHelperResult>}
+ */
+const getJsonOrText = (path, response, useCache, method = 'GET') =>
+  response.text().then((textData) => {
+    let data = textData;
+    if (data) {
+      try {
+        data = JSON.parse(data);
+        if (useCache && method === 'GET' && response.status === 200)
+          fetchCache[path] = textData;
+      } catch (e) {
+        // # do nothing
+      }
+    }
+    return {
+      response,
+      data,
+      status: response.status,
+      headers: response.headers,
+    };
+  });
+
+/** @type {Promise<FetchHelperResult>} */
+let pendingRequest = null;
+
+/**
+ * @param {Object} opts
+ * @param {string} [opts.path]
+ * @param {string} [opts.method]
+ * @param {() => void} [opts.onError]
+ */
+export const fetchCreds = (opts) => {
+  if (pendingRequest) {
+    return pendingRequest;
+  }
+  const { path = `${userapiPath}user/`, method = 'GET', onError } = opts;
+
+  pendingRequest = fetch(path, {
+    credentials: 'include',
+    headers,
+    method,
+  })
+    .then((response) => {
+      pendingRequest = null;
+      return getJsonOrText(path, response, false);
+    })
+    .catch((error) => {
+      pendingRequest = null;
+      onError?.();
+      return error;
+    });
+  return pendingRequest;
+};
+
+/**
+ * Little helper issues fetch, then resolves response
+ * as text, and tries to JSON.parse the text before resolving, but
+ * ignores JSON.parse failure and reponse.status, and returns {response, data} either way.
+ * If dispatch is supplied, then dispatch(connectionError()) on fetch reject.
+ * If useCache is supplied and method is GET,
+ * then text for 200 JSON responses are cached, and re-used, and
+ * the result promise only includes {data, status} - where JSON data is re-parsed
+ * every time to avoid mutation by the client
+ *
+ * @param {FetchHelperOptions} opts
+ * @return {Promise<FetchHelperResult>}
+ */
+export const fetchWithCreds = (opts) => {
+  const {
+    path,
+    method = 'GET',
+    body = null,
+    customHeaders,
+    onError,
+    useCache,
+    signal,
+  } = opts;
+  if (useCache && method === 'GET' && fetchCache[path]) {
+    return Promise.resolve({ status: 200, data: JSON.parse(fetchCache[path]) });
+  }
+  /** @type {RequestInit} */
+  const request = {
+    credentials: 'include',
+    headers: { ...headers, ...customHeaders },
+    method,
+    body,
+    signal,
+  };
+  return fetch(path, request)
+    .then((response) => {
+      if (response.status !== 403 && response.status !== 401)
+        return getJsonOrText(path, response, useCache, method);
+
+      return fetchCreds({ onError }).then((resp) => {
+        switch (resp.status) {
+          case 200:
+            return fetch(path, request).then((res) =>
+              getJsonOrText(path, res, useCache, method)
+            );
+          default:
+            return {
+              response: resp.response,
+              data: { data: {} },
+              status: resp.status,
+              headers: resp.headers,
+            };
+        }
+      });
+    })
+    .catch((error) => {
+      onError?.();
+      return Promise.reject(error);
+    });
+};
+
+/**
+ * @param {FetchHelperOptions} opts
+ * @param {number} timeoutInMS
+ */
+export const fetchWithCredsAndTimeout = (opts, timeoutInMS) => {
+  let didTimeOut = false;
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      didTimeOut = true;
+      reject(new Error('Request timed out'));
+    }, timeoutInMS);
+
+    fetchWithCreds(opts)
+      .then((response) => {
+        // Clear the timeout as cleanup
+        clearTimeout(timeout);
+        if (!didTimeOut) {
+          resolve(response);
+        }
+      })
+      .catch((err) => {
+        // Rejection already happened with setTimeout
+        if (didTimeOut) return;
+        // Reject with error
+        reject(err);
+      });
+  });
+};


### PR DESCRIPTION
Ticket: [PEDS-754](https://pcdc.atlassian.net/browse/PEDS-754)

This PR refactors & reorganizes the Redux code (reducers, actions, thunk actions) as a preparatory step for adopting Redux ToolKit. It is also a follow up to https://github.com/chicagopcdc/data-portal/pull/418 and shares the same objectives:

> * Use action creators for all actions
> * Make all actions to have the uniform `{ type, payload }` shape
> * Put thunk actions into separate `actions.thunk` files
> * Reorganize actions/thunk actions by "slice" where possible