### PR TITLE
Redesign & reorganize top bar menus PEDS-766 

### DIFF
--- a/src/components/layout/TopBar.css
+++ b/src/components/layout/TopBar.css
@@ -2,11 +2,11 @@
   background-color: var(--pcdc-color__primary);
   color: white;
   display: flex;
+  align-items: center;
   justify-content: space-between;
   margin: auto;
   min-height: 40px;
   overflow: hidden;
-  vertical-align: middle;
   width: 100%;
 }
 

--- a/src/components/layout/TopBar.css
+++ b/src/components/layout/TopBar.css
@@ -10,6 +10,10 @@
   width: 100%;
 }
 
+.top-bar__menu-group {
+  margin-right: 20px;
+}
+
 @media screen and (max-width: 1090px) {
   .top-bar {
     justify-content: flex-end;

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -55,6 +55,20 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
             to={item.link}
           />
         ))}
+        {config.menuItems?.length > 0 && (
+          <TopBarMenu buttonIcon='copy'>
+            {config.menuItems.map((item) => (
+              <TopBarMenu.Item key={item.link}>
+                <a href={item.link} target='_blank' rel='noopener noreferrer'>
+                  {item.name}
+                  {item.icon && (
+                    <i className={`g3-icon g3-icon--${item.icon}`} />
+                  )}
+                </a>
+              </TopBarMenu.Item>
+            ))}
+          </TopBarMenu>
+        )}
         {username !== undefined ? (
           <TopBarMenu buttonIcon='user-circle'>
             <TopBarMenu.Item>
@@ -72,16 +86,6 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
                 <Link to='/submission'>Data Submission</Link>
               </TopBarMenu.Item>
             )}
-            {config.menuItems?.map((item) => (
-              <TopBarMenu.Item key={item.link}>
-                <a href={item.link} target='_blank' rel='noopener noreferrer'>
-                  {item.name}
-                  {item.icon && (
-                    <i className={`g3-icon g3-icon--${item.icon}`} />
-                  )}
-                </a>
-              </TopBarMenu.Item>
-            ))}
             <hr />
             <TopBarMenu.Item>
               <button onClick={onLogoutClick} type='button'>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { TopBarLink } from './TopBarItems';
 import TopBarMenu from './TopBarMenu';
 import './TopBar.css';
@@ -58,7 +59,9 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
         <div className='top-bar__menu-group'>
           {config.menuItems?.length > 0 && (
             <TopBarMenu
-              buttonIcon={<i className='g3-icon g3-icon--copy' />}
+              buttonIcon={
+                <FontAwesomeIcon icon='circle-question' fontSize={24} />
+              }
               title='Documents'
             >
               {config.menuItems.map((item) => (
@@ -75,7 +78,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           )}
           {username !== undefined ? (
             <TopBarMenu
-              buttonIcon={<i className='g3-icon g3-icon--user-circle' />}
+              buttonIcon={<FontAwesomeIcon icon='circle-user' fontSize={24} />}
               title='Profile'
             >
               <TopBarMenu.Item>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -56,7 +56,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           />
         ))}
         {config.menuItems?.length > 0 && (
-          <TopBarMenu buttonIcon='copy'>
+          <TopBarMenu buttonIcon='copy' title='Documents'>
             {config.menuItems.map((item) => (
               <TopBarMenu.Item key={item.link}>
                 <a href={item.link} target='_blank' rel='noopener noreferrer'>
@@ -70,7 +70,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           </TopBarMenu>
         )}
         {username !== undefined ? (
-          <TopBarMenu buttonIcon='user-circle'>
+          <TopBarMenu buttonIcon='user-circle' title='Profile'>
             <TopBarMenu.Item>
               <span>{username}</span>
             </TopBarMenu.Item>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -56,7 +56,11 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           />
         ))}
         {username !== undefined ? (
-          <TopBarMenu buttonProps={{ icon: 'user-circle', name: username }}>
+          <TopBarMenu buttonIcon='user-circle'>
+            <TopBarMenu.Item>
+              <span>{username}</span>
+            </TopBarMenu.Item>
+            <hr />
             <TopBarMenu.Item>
               <Link to='/identity'>View Profile</Link>
             </TopBarMenu.Item>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -55,49 +55,51 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
             to={item.link}
           />
         ))}
-        {config.menuItems?.length > 0 && (
-          <TopBarMenu buttonIcon='copy' title='Documents'>
-            {config.menuItems.map((item) => (
-              <TopBarMenu.Item key={item.link}>
-                <a href={item.link} target='_blank' rel='noopener noreferrer'>
-                  {item.name}
-                  {item.icon && (
-                    <i className={`g3-icon g3-icon--${item.icon}`} />
-                  )}
-                </a>
-              </TopBarMenu.Item>
-            ))}
-          </TopBarMenu>
-        )}
-        {username !== undefined ? (
-          <TopBarMenu buttonIcon='user-circle' title='Profile'>
-            <TopBarMenu.Item>
-              <span>{username}</span>
-            </TopBarMenu.Item>
-            <hr />
-            <TopBarMenu.Item>
-              <Link to='/identity'>View Profile</Link>
-            </TopBarMenu.Item>
-            <TopBarMenu.Item>
-              <Link to='/requests'>Data Requests</Link>
-            </TopBarMenu.Item>
-            {isAdminUser && (
+        <div className='top-bar__menu-group'>
+          {config.menuItems?.length > 0 && (
+            <TopBarMenu buttonIcon='copy' title='Documents'>
+              {config.menuItems.map((item) => (
+                <TopBarMenu.Item key={item.link}>
+                  <a href={item.link} target='_blank' rel='noopener noreferrer'>
+                    {item.name}
+                    {item.icon && (
+                      <i className={`g3-icon g3-icon--${item.icon}`} />
+                    )}
+                  </a>
+                </TopBarMenu.Item>
+              ))}
+            </TopBarMenu>
+          )}
+          {username !== undefined ? (
+            <TopBarMenu buttonIcon='user-circle' title='Profile'>
               <TopBarMenu.Item>
-                <Link to='/submission'>Data Submission</Link>
+                <span>{username}</span>
               </TopBarMenu.Item>
-            )}
-            <hr />
-            <TopBarMenu.Item>
-              <button onClick={onLogoutClick} type='button'>
-                Logout <i className='g3-icon g3-icon--exit' />
-              </button>
-            </TopBarMenu.Item>
-          </TopBarMenu>
-        ) : (
-          location.pathname !== '/login' && (
-            <TopBarLink icon='exit' name='Login' to='/login' />
-          )
-        )}
+              <hr />
+              <TopBarMenu.Item>
+                <Link to='/identity'>View Profile</Link>
+              </TopBarMenu.Item>
+              <TopBarMenu.Item>
+                <Link to='/requests'>Data Requests</Link>
+              </TopBarMenu.Item>
+              {isAdminUser && (
+                <TopBarMenu.Item>
+                  <Link to='/submission'>Data Submission</Link>
+                </TopBarMenu.Item>
+              )}
+              <hr />
+              <TopBarMenu.Item>
+                <button onClick={onLogoutClick} type='button'>
+                  Logout <i className='g3-icon g3-icon--exit' />
+                </button>
+              </TopBarMenu.Item>
+            </TopBarMenu>
+          ) : (
+            location.pathname !== '/login' && (
+              <TopBarLink icon='exit' name='Login' to='/login' />
+            )
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { TopBarLink } from './TopBarItems';
 import TopBarMenu from './TopBarMenu';
@@ -56,12 +56,35 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           />
         ))}
         {username !== undefined ? (
-          <TopBarMenu
-            isAdminUser={isAdminUser}
-            items={config.menuItems}
-            onLogoutClick={onLogoutClick}
-            username={username}
-          />
+          <TopBarMenu buttonProps={{ icon: 'user-circle', name: username }}>
+            <TopBarMenu.Item>
+              <Link to='/identity'>View Profile</Link>
+            </TopBarMenu.Item>
+            <TopBarMenu.Item>
+              <Link to='/requests'>Data Requests</Link>
+            </TopBarMenu.Item>
+            {isAdminUser && (
+              <TopBarMenu.Item>
+                <Link to='/submission'>Data Submission</Link>
+              </TopBarMenu.Item>
+            )}
+            {config.menuItems?.map((item) => (
+              <TopBarMenu.Item key={item.link}>
+                <a href={item.link} target='_blank' rel='noopener noreferrer'>
+                  {item.name}
+                  {item.icon && (
+                    <i className={`g3-icon g3-icon--${item.icon}`} />
+                  )}
+                </a>
+              </TopBarMenu.Item>
+            ))}
+            <hr />
+            <TopBarMenu.Item>
+              <button onClick={onLogoutClick} type='button'>
+                Logout <i className='g3-icon g3-icon--exit' />
+              </button>
+            </TopBarMenu.Item>
+          </TopBarMenu>
         ) : (
           location.pathname !== '/login' && (
             <TopBarLink icon='exit' name='Login' to='/login' />

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -60,7 +60,11 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           {config.menuItems?.length > 0 && (
             <TopBarMenu
               buttonIcon={
-                <FontAwesomeIcon icon='circle-question' fontSize={24} />
+                <FontAwesomeIcon
+                  color='white'
+                  fontSize={24}
+                  icon='circle-question'
+                />
               }
               title='Documents'
             >
@@ -78,7 +82,13 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           )}
           {username !== undefined ? (
             <TopBarMenu
-              buttonIcon={<FontAwesomeIcon icon='circle-user' fontSize={24} />}
+              buttonIcon={
+                <FontAwesomeIcon
+                  color='white'
+                  fontSize={24}
+                  icon='circle-user'
+                />
+              }
               title='Profile'
             >
               <TopBarMenu.Item>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -74,37 +74,43 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
               ))}
             </TopBarMenu>
           )}
-          {username !== undefined ? (
+          {(location.pathname !== '/login' || username !== undefined) && (
             <TopBarMenu
               buttonIcon={<FontAwesomeIcon icon='circle-user' />}
               title='Profile'
             >
-              <TopBarMenu.Item>
-                <span>{username}</span>
-              </TopBarMenu.Item>
-              <hr />
-              <TopBarMenu.Item>
-                <Link to='/identity'>View Profile</Link>
-              </TopBarMenu.Item>
-              <TopBarMenu.Item>
-                <Link to='/requests'>Data Requests</Link>
-              </TopBarMenu.Item>
-              {isAdminUser && (
+              {username === undefined ? (
                 <TopBarMenu.Item>
-                  <Link to='/submission'>Data Submission</Link>
+                  <Link to='/login'>
+                    Login <i className='g3-icon g3-icon--exit' />
+                  </Link>
                 </TopBarMenu.Item>
+              ) : (
+                <>
+                  <TopBarMenu.Item>
+                    <span>{username}</span>
+                  </TopBarMenu.Item>
+                  <hr />
+                  <TopBarMenu.Item>
+                    <Link to='/identity'>View Profile</Link>
+                  </TopBarMenu.Item>
+                  <TopBarMenu.Item>
+                    <Link to='/requests'>Data Requests</Link>
+                  </TopBarMenu.Item>
+                  {isAdminUser && (
+                    <TopBarMenu.Item>
+                      <Link to='/submission'>Data Submission</Link>
+                    </TopBarMenu.Item>
+                  )}
+                  <hr />
+                  <TopBarMenu.Item>
+                    <button onClick={onLogoutClick} type='button'>
+                      Logout <i className='g3-icon g3-icon--exit' />
+                    </button>
+                  </TopBarMenu.Item>
+                </>
               )}
-              <hr />
-              <TopBarMenu.Item>
-                <button onClick={onLogoutClick} type='button'>
-                  Logout <i className='g3-icon g3-icon--exit' />
-                </button>
-              </TopBarMenu.Item>
             </TopBarMenu>
-          ) : (
-            location.pathname !== '/login' && (
-              <TopBarLink icon='exit' name='Login' to='/login' />
-            )
           )}
         </div>
       </div>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -59,13 +59,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
         <div className='top-bar__menu-group'>
           {config.menuItems?.length > 0 && (
             <TopBarMenu
-              buttonIcon={
-                <FontAwesomeIcon
-                  color='white'
-                  fontSize={24}
-                  icon='circle-question'
-                />
-              }
+              buttonIcon={<FontAwesomeIcon icon='circle-question' />}
               title='Documents'
             >
               {config.menuItems.map((item) => (
@@ -82,13 +76,7 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           )}
           {username !== undefined ? (
             <TopBarMenu
-              buttonIcon={
-                <FontAwesomeIcon
-                  color='white'
-                  fontSize={24}
-                  icon='circle-user'
-                />
-              }
+              buttonIcon={<FontAwesomeIcon icon='circle-user' />}
               title='Profile'
             >
               <TopBarMenu.Item>

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -57,7 +57,10 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
         ))}
         <div className='top-bar__menu-group'>
           {config.menuItems?.length > 0 && (
-            <TopBarMenu buttonIcon='copy' title='Documents'>
+            <TopBarMenu
+              buttonIcon={<i className='g3-icon g3-icon--copy' />}
+              title='Documents'
+            >
               {config.menuItems.map((item) => (
                 <TopBarMenu.Item key={item.link}>
                   <a href={item.link} target='_blank' rel='noopener noreferrer'>
@@ -71,7 +74,10 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
             </TopBarMenu>
           )}
           {username !== undefined ? (
-            <TopBarMenu buttonIcon='user-circle' title='Profile'>
+            <TopBarMenu
+              buttonIcon={<i className='g3-icon g3-icon--user-circle' />}
+              title='Profile'
+            >
               <TopBarMenu.Item>
                 <span>{username}</span>
               </TopBarMenu.Item>

--- a/src/components/layout/TopBarItems.css
+++ b/src/components/layout/TopBarItems.css
@@ -2,10 +2,7 @@
   border-right: 2px solid var(--pcdc-color__primary-light);
   display: inline-block;
   text-align: center;
-  vertical-align: middle;
   padding: 0 0;
-  margin-top: 9px;
-  margin-bottom: 9px;
 }
 
 button.top-bar-item {

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -10,7 +10,7 @@ function joinClassNames(...args) {
 /**
  * @typedef {Object} TopBarButtonProps
  * @property {string} [className]
- * @property {string} [icon]
+ * @property {React.ReactNode} [icon]
  * @property {boolean} [isActive]
  * @property {string} [name]
  * @property {React.MouseEventHandler<HTMLButtonElement>} onClick
@@ -36,7 +36,7 @@ export function TopBarButton({
     >
       <span className='top-bar-item__content body-typo'>
         {name}
-        {icon && <i className={`g3-icon g3-icon--${icon}`} />}
+        {icon}
       </span>
     </button>
   );
@@ -44,7 +44,7 @@ export function TopBarButton({
 
 TopBarButton.propTypes = {
   className: PropTypes.string,
-  icon: PropTypes.string,
+  icon: PropTypes.node,
   isActive: PropTypes.bool,
   name: PropTypes.string,
   onClick: PropTypes.func.isRequired,

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -12,7 +12,7 @@ function joinClassNames(...args) {
  * @property {string} [className]
  * @property {string} [icon]
  * @property {boolean} [isActive]
- * @property {string} name
+ * @property {string} [name]
  * @property {React.MouseEventHandler<HTMLButtonElement>} onClick
  */
 
@@ -46,7 +46,7 @@ TopBarButton.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string,
   isActive: PropTypes.bool,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   onClick: PropTypes.func.isRequired,
 };
 

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import './TopBarItems.css';
@@ -6,47 +7,6 @@ import './TopBarItems.css';
 function joinClassNames(...args) {
   return args.filter(Boolean).join(' ');
 }
-
-/**
- * @typedef {Object} TopBarButtonProps
- * @property {string} [className]
- * @property {React.ReactNode} [icon]
- * @property {boolean} [isActive]
- * @property {React.MouseEventHandler<HTMLButtonElement>} onClick
- * @property {string} [title]
- */
-
-/** @param {TopBarButtonProps} props */
-export function TopBarButton({
-  className,
-  icon,
-  isActive = false,
-  onClick,
-  title,
-}) {
-  const baseClassName = isActive
-    ? 'top-bar-item top-bar-item--active'
-    : 'top-bar-item';
-
-  return (
-    <button
-      className={joinClassNames(baseClassName, className)}
-      onClick={onClick}
-      type='button'
-      title={title}
-    >
-      {icon}
-    </button>
-  );
-}
-
-TopBarButton.propTypes = {
-  className: PropTypes.string,
-  icon: PropTypes.node,
-  isActive: PropTypes.bool,
-  onClick: PropTypes.func.isRequired,
-  title: PropTypes.string,
-};
 
 /**
  * @typedef {Object} TopBarLinkProps

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -12,8 +12,8 @@ function joinClassNames(...args) {
  * @property {string} [className]
  * @property {React.ReactNode} [icon]
  * @property {boolean} [isActive]
- * @property {string} [name]
  * @property {React.MouseEventHandler<HTMLButtonElement>} onClick
+ * @property {string} [title]
  */
 
 /** @param {TopBarButtonProps} props */
@@ -21,8 +21,8 @@ export function TopBarButton({
   className,
   icon,
   isActive = false,
-  name,
   onClick,
+  title,
 }) {
   const baseClassName = isActive
     ? 'top-bar-item top-bar-item--active'
@@ -33,11 +33,9 @@ export function TopBarButton({
       className={joinClassNames(baseClassName, className)}
       onClick={onClick}
       type='button'
+      title={title}
     >
-      <span className='top-bar-item__content body-typo'>
-        {name}
-        {icon}
-      </span>
+      <span className='top-bar-item__content body-typo'>{icon}</span>
     </button>
   );
 }
@@ -46,8 +44,8 @@ TopBarButton.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.node,
   isActive: PropTypes.bool,
-  name: PropTypes.string,
   onClick: PropTypes.func.isRequired,
+  title: PropTypes.string,
 };
 
 /**

--- a/src/components/layout/TopBarItems.jsx
+++ b/src/components/layout/TopBarItems.jsx
@@ -35,7 +35,7 @@ export function TopBarButton({
       type='button'
       title={title}
     >
-      <span className='top-bar-item__content body-typo'>{icon}</span>
+      {icon}
     </button>
   );
 }

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -71,3 +71,8 @@
 .top-bar-menu > button > .top-bar-item__content:hover i.g3-icon {
   background-color: var(--pcdc-color__secondary-light);
 }
+
+.top-bar-menu > button.top-bar-item--active > .top-bar-item__content svg,
+.top-bar-menu > button > .top-bar-item__content:hover svg {
+  color: var(--pcdc-color__secondary-light);
+}

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -51,7 +51,7 @@
   margin-right: 8px;
 }
 
-.top-bar-menu button {
+.top-bar-menu > button {
   margin: 0;
   height: auto;
   width: auto;

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -47,8 +47,8 @@
   width: 14px;
 }
 
-.top-bar-menu {
-  margin-right: 20px;
+.top-bar-menu:not(:last-child) {
+  margin-right: 8px;
 }
 
 .top-bar-menu button .top-bar-item__content {

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -33,7 +33,7 @@
   width: 100%;
 }
 
-.top-bar-menu__item > *:hover {
+.top-bar-menu__item > *:not(span):hover {
   background-color: var(--g3-color__silver);
   color: var(--g3-color__gray);
 }
@@ -45,4 +45,29 @@
   position: relative;
   top: 2px;
   width: 14px;
+}
+
+.top-bar-menu {
+  margin-right: 20px;
+}
+
+.top-bar-menu button .top-bar-item__content {
+  margin: 0;
+}
+
+.top-bar-menu > button i.g3-icon {
+  height: 24px;
+  width: 24px;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.top-bar-menu > button.top-bar-item--active > .top-bar-item__content,
+.top-bar-menu > button > .top-bar-item__content:hover {
+  border-bottom: none;
+}
+
+.top-bar-menu > button.top-bar-item--active > .top-bar-item__content i.g3-icon,
+.top-bar-menu > button > .top-bar-item__content:hover i.g3-icon {
+  background-color: var(--pcdc-color__secondary-light);
 }

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -62,17 +62,12 @@
   margin-right: 0.25rem;
 }
 
-.top-bar-menu > button.top-bar-item--active > .top-bar-item__content,
-.top-bar-menu > button > .top-bar-item__content:hover {
-  border-bottom: none;
-}
-
-.top-bar-menu > button.top-bar-item--active > .top-bar-item__content i.g3-icon,
-.top-bar-menu > button > .top-bar-item__content:hover i.g3-icon {
+.top-bar-menu > button.top-bar-item--active i.g3-icon,
+.top-bar-menu > button:hover i.g3-icon {
   background-color: var(--pcdc-color__secondary-light);
 }
 
-.top-bar-menu > button.top-bar-item--active > .top-bar-item__content svg,
-.top-bar-menu > button > .top-bar-item__content:hover svg {
+.top-bar-menu > button.top-bar-item--active svg,
+.top-bar-menu > button:hover svg {
   color: var(--pcdc-color__secondary-light);
 }

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -51,23 +51,37 @@
   margin-right: 8px;
 }
 
-.top-bar-menu button .top-bar-item__content {
+.top-bar-menu button {
   margin: 0;
+  height: auto;
+  width: auto;
+  background: none;
+  border: none;
+  border-radius: 0;
+}
+
+.top-bar-menu > button i.g3-icon,
+.top-bar-menu > button svg {
+  height: 24px;
+  width: 24px;
+  margin-left: 0.1rem;
+  margin-right: 0.1rem;
 }
 
 .top-bar-menu > button i.g3-icon {
-  height: 24px;
-  width: 24px;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
+  background-color: white;
 }
 
-.top-bar-menu > button.top-bar-item--active i.g3-icon,
+.top-bar-menu > button svg {
+  color: white;
+}
+
+.top-bar-menu > button[data-menu-active='true'] i.g3-icon,
 .top-bar-menu > button:hover i.g3-icon {
   background-color: var(--pcdc-color__secondary-light);
 }
 
-.top-bar-menu > button.top-bar-item--active svg,
+.top-bar-menu > button[data-menu-active='true'] svg,
 .top-bar-menu > button:hover svg {
   color: var(--pcdc-color__secondary-light);
 }

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -5,12 +5,10 @@ import './TopBarMenu.css';
 
 /**
  * @param {Object} props
- * @param {Object} props.buttonProps
- * @param {Object} props.buttonProps.icon
- * @param {Object} [props.buttonProps.name]
+ * @param {string} props.buttonIcon
  * @param {React.ReactNode[]} props.children
  */
-function TopBarMenu({ buttonProps, children }) {
+function TopBarMenu({ buttonIcon, children }) {
   const [showMenu, setShowMenu] = useState(false);
   function handleMenuBlur(e) {
     if (showMenu && !e.currentTarget.contains(e.relatedTarget))
@@ -20,11 +18,10 @@ function TopBarMenu({ buttonProps, children }) {
     setShowMenu((s) => !s);
   }
   return (
-    <span onBlur={handleMenuBlur}>
+    <span className='top-bar-menu' onBlur={handleMenuBlur}>
       <TopBarButton
         isActive={showMenu}
-        icon={buttonProps.icon}
-        name={buttonProps.name}
+        icon={buttonIcon}
         onClick={toggleMenu}
       />
       {showMenu && <ul className='top-bar-menu__items'>{children}</ul>}
@@ -33,10 +30,7 @@ function TopBarMenu({ buttonProps, children }) {
 }
 
 TopBarMenu.propTypes = {
-  buttonProps: PropTypes.exact({
-    icon: PropTypes.string,
-    name: PropTypes.string,
-  }),
+  buttonIcon: PropTypes.string.isRequired,
   children: PropTypes.arrayOf(PropTypes.node),
 };
 

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -1,17 +1,16 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { TopBarButton } from './TopBarItems';
 import './TopBarMenu.css';
 
 /**
  * @param {Object} props
- * @param {boolean} [props.isAdminUser]
- * @param {{ icon?: string; link: string; name: string; }[]} [props.items]
- * @param {React.MouseEventHandler<HTMLButtonElement>} props.onLogoutClick
- * @param {string} props.username
+ * @param {Object} props.buttonProps
+ * @param {Object} props.buttonProps.icon
+ * @param {Object} [props.buttonProps.name]
+ * @param {React.ReactNode[]} props.children
  */
-function TopBarMenu({ isAdminUser, items, onLogoutClick, username }) {
+function TopBarMenu({ buttonProps, children }) {
   const [showMenu, setShowMenu] = useState(false);
   function handleMenuBlur(e) {
     if (showMenu && !e.currentTarget.contains(e.relatedTarget))
@@ -24,54 +23,31 @@ function TopBarMenu({ isAdminUser, items, onLogoutClick, username }) {
     <span onBlur={handleMenuBlur}>
       <TopBarButton
         isActive={showMenu}
-        icon='user-circle'
-        name={username}
+        icon={buttonProps.icon}
+        name={buttonProps.name}
         onClick={toggleMenu}
       />
-      {showMenu && (
-        <ul className='top-bar-menu__items'>
-          <li className='top-bar-menu__item'>
-            <Link to='/identity'>View Profile</Link>
-          </li>
-          <li className='top-bar-menu__item'>
-            <Link to='/requests'>Data Requests</Link>
-          </li>
-          {isAdminUser && (
-            <li className='top-bar-menu__item'>
-              <Link to='/submission'>Data Submission</Link>
-            </li>
-          )}
-          {items?.map((item) => (
-            <li key={item.link} className='top-bar-menu__item'>
-              <a href={item.link} target='_blank' rel='noopener noreferrer'>
-                {item.name}
-                {item.icon && <i className={`g3-icon g3-icon--${item.icon}`} />}
-              </a>
-            </li>
-          ))}
-          <hr />
-          <li className='top-bar-menu__item'>
-            <button onClick={onLogoutClick} type='button'>
-              Logout <i className='g3-icon g3-icon--exit' />
-            </button>
-          </li>
-        </ul>
-      )}
+      {showMenu && <ul className='top-bar-menu__items'>{children}</ul>}
     </span>
   );
 }
 
 TopBarMenu.propTypes = {
-  isAdminUser: PropTypes.bool,
-  items: PropTypes.arrayOf(
-    PropTypes.exact({
-      icon: PropTypes.string,
-      link: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    })
-  ),
-  onLogoutClick: PropTypes.func.isRequired,
-  username: PropTypes.string.isRequired,
+  buttonProps: PropTypes.exact({
+    icon: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  children: PropTypes.arrayOf(PropTypes.node),
 };
 
+/** @param {{ children: React.ReactNode }} */
+function Item({ children }) {
+  return <li className='top-bar-menu__item'>{children}</li>;
+}
+
+Item.propTypes = {
+  children: PropTypes.node,
+};
+
+TopBarMenu.Item = Item;
 export default TopBarMenu;

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -7,8 +7,9 @@ import './TopBarMenu.css';
  * @param {Object} props
  * @param {string} props.buttonIcon
  * @param {React.ReactNode[]} props.children
+ * @param {string} [props.title]
  */
-function TopBarMenu({ buttonIcon, children }) {
+function TopBarMenu({ buttonIcon, children, title }) {
   const [showMenu, setShowMenu] = useState(false);
   function handleMenuBlur(e) {
     if (showMenu && !e.currentTarget.contains(e.relatedTarget))
@@ -18,7 +19,7 @@ function TopBarMenu({ buttonIcon, children }) {
     setShowMenu((s) => !s);
   }
   return (
-    <span className='top-bar-menu' onBlur={handleMenuBlur}>
+    <span className='top-bar-menu' onBlur={handleMenuBlur} title={title}>
       <TopBarButton
         isActive={showMenu}
         icon={buttonIcon}
@@ -32,6 +33,7 @@ function TopBarMenu({ buttonIcon, children }) {
 TopBarMenu.propTypes = {
   buttonIcon: PropTypes.string.isRequired,
   children: PropTypes.arrayOf(PropTypes.node),
+  title: PropTypes.string,
 };
 
 /** @param {{ children: React.ReactNode }} */

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -5,7 +5,7 @@ import './TopBarMenu.css';
 /**
  * @param {Object} props
  * @param {React.ReactNode} props.buttonIcon
- * @param {React.ReactNode[]} props.children
+ * @param {React.ReactNode | React.ReactNode[]} props.children
  * @param {string} [props.title]
  */
 function TopBarMenu({ buttonIcon, children, title }) {
@@ -34,7 +34,10 @@ function TopBarMenu({ buttonIcon, children, title }) {
 
 TopBarMenu.propTypes = {
   buttonIcon: PropTypes.node.isRequired,
-  children: PropTypes.arrayOf(PropTypes.node),
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
   title: PropTypes.string,
 };
 

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -5,7 +5,7 @@ import './TopBarMenu.css';
 
 /**
  * @param {Object} props
- * @param {string} props.buttonIcon
+ * @param {React.ReactNode} props.buttonIcon
  * @param {React.ReactNode[]} props.children
  * @param {string} [props.title]
  */
@@ -31,7 +31,7 @@ function TopBarMenu({ buttonIcon, children, title }) {
 }
 
 TopBarMenu.propTypes = {
-  buttonIcon: PropTypes.string.isRequired,
+  buttonIcon: PropTypes.node.isRequired,
   children: PropTypes.arrayOf(PropTypes.node),
   title: PropTypes.string,
 };

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { TopBarButton } from './TopBarItems';
 import './TopBarMenu.css';
 
 /**
@@ -20,12 +19,14 @@ function TopBarMenu({ buttonIcon, children, title }) {
   }
   return (
     <span className='top-bar-menu' onBlur={handleMenuBlur}>
-      <TopBarButton
-        isActive={showMenu}
-        icon={buttonIcon}
+      <button
+        data-menu-active={showMenu}
         onClick={toggleMenu}
         title={title}
-      />
+        type='button'
+      >
+        {buttonIcon}
+      </button>
       {showMenu && <ul className='top-bar-menu__items'>{children}</ul>}
     </span>
   );

--- a/src/components/layout/TopBarMenu.jsx
+++ b/src/components/layout/TopBarMenu.jsx
@@ -19,11 +19,12 @@ function TopBarMenu({ buttonIcon, children, title }) {
     setShowMenu((s) => !s);
   }
   return (
-    <span className='top-bar-menu' onBlur={handleMenuBlur} title={title}>
+    <span className='top-bar-menu' onBlur={handleMenuBlur}>
       <TopBarButton
         isActive={showMenu}
         icon={buttonIcon}
         onClick={toggleMenu}
+        title={title}
       />
       {showMenu && <ul className='top-bar-menu__items'>{children}</ul>}
     </span>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,6 +9,8 @@ import {
   faMicroscope,
   faTriangleExclamation,
   faUser,
+  faCircleUser,
+  faCircleQuestion,
 } from '@fortawesome/free-solid-svg-icons';
 import ReactGA from 'react-ga';
 import { Provider } from 'react-redux';
@@ -31,6 +33,8 @@ library.add(
   faAngleUp,
   faAngleDown,
   faCircleCheck,
+  faCircleQuestion,
+  faCircleUser,
   faFlask,
   faMicroscope,
   faTriangleExclamation,


### PR DESCRIPTION
Ticket: [PEDS-766](https://pcdc.atlassian.net/browse/PEDS-766)

This PR implements the redesign & reorganization of the top bar menu for user-specific links/actions and links to public documents. The key changes include:

* Separate documents links from user-specific links/actions, each under its own menu
  * The documents menu is always visible regardless of authentication status 
* Make menu button an icon button

See the following demo screen recording:

https://user-images.githubusercontent.com/22449454/174876678-3728afec-7e0c-4a16-8db8-8d918b13de4f.mov