### PR TITLE
Use offiical PCDC docs site page locations for document links PEDS-776

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/UserAgreement.jsx
@@ -8,7 +8,7 @@ import Button from '../../gen3-ui-component/components/Button';
 
 const acceptableUsePolicyLink = (
   <a
-    href='https://github.com/chicagopcdc/Documents/blob/pcdc_dev/governance/acceptable_use_policy/PCDC%20Acceptable%20Use%20Policy.pdf'
+    href='https://docs.pedscommons.org/AcceptableUsePolicy/'
     target='_black'
     rel='noopener noreferrer'
   >
@@ -19,7 +19,7 @@ const acceptableUsePolicyLink = (
 
 const pcdcStatisticalManualLink = (
   <a
-    href='https://commons.cri.uchicago.edu/wp-content/uploads/2022/04/PCDC-Analytics-Tool-Documentation-Statistical-Manual.pdf'
+    href='https://docs.pedscommons.org/StatisticalManual/'
     target='_black'
     rel='noopener noreferrer'
   >


### PR DESCRIPTION
Ticket: [PEDS-776](https://pcdc.atlassian.net/browse/PEDS-776)

This PR updates links to PCDC documents to use the official PCDC docs site locations.