### PR TITLE
Fetch top bar documents from server on runtime PEDS-766

### DIFF
--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import useLatestDocuments from '../../hooks/useDocumentItems';
 import { TopBarLink } from './TopBarItems';
 import TopBarMenu from './TopBarMenu';
 import './TopBar.css';
@@ -31,6 +32,8 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
     if (item.leftOrientation) leftItems.push(item);
     else rightItems.push(item);
 
+  const documents = useLatestDocuments();
+
   return (
     <nav className='top-bar' aria-label='Top Navigation'>
       <div>
@@ -57,21 +60,42 @@ function TopBar({ config, isAdminUser, onLogoutClick, username }) {
           />
         ))}
         <div className='top-bar__menu-group'>
-          {config.menuItems?.length > 0 && (
+          {(documents.data?.length > 0 || documents.isError) && (
             <TopBarMenu
               buttonIcon={<FontAwesomeIcon icon='circle-question' />}
               title='Documents'
             >
-              {config.menuItems.map((item) => (
-                <TopBarMenu.Item key={item.link}>
-                  <a href={item.link} target='_blank' rel='noopener noreferrer'>
-                    {item.name}
-                    {item.icon && (
-                      <i className={`g3-icon g3-icon--${item.icon}`} />
-                    )}
-                  </a>
-                </TopBarMenu.Item>
-              ))}
+              {documents.isError ? (
+                <>
+                  <TopBarMenu.Item>
+                    <small>
+                      <FontAwesomeIcon
+                        icon='triangle-exclamation'
+                        color='var(--g3-primary-btn__bg-color)'
+                      />{' '}
+                      Error in fetching documents...
+                    </small>
+                  </TopBarMenu.Item>
+                  <TopBarMenu.Item>
+                    <button onClick={documents.refresh} type='button'>
+                      Refresh documents
+                    </button>
+                  </TopBarMenu.Item>
+                </>
+              ) : (
+                documents.data.map((item) => (
+                  <TopBarMenu.Item key={item.formatted}>
+                    <a
+                      href={item.formatted}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      {item.name}
+                      <i className='g3-icon g3-icon--external-link' />
+                    </a>
+                  </TopBarMenu.Item>
+                ))
+              )}
             </TopBarMenu>
           )}
           {(location.pathname !== '/login' || username !== undefined) && (

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -33,7 +33,8 @@
   width: 100%;
 }
 
-.top-bar-menu__item > *:not(span):hover {
+.top-bar-menu__item > a:hover,
+.top-bar-menu__item > button:hover {
   background-color: var(--g3-color__silver);
   color: var(--g3-color__gray);
 }
@@ -45,6 +46,10 @@
   position: relative;
   top: 2px;
   width: 14px;
+}
+
+.top-bar-menu {
+  color: var(--g3-color__gray);
 }
 
 .top-bar-menu:not(:last-child) {

--- a/src/hooks/useDocumentItems.js
+++ b/src/hooks/useDocumentItems.js
@@ -16,7 +16,7 @@ export default function useLatestDocuments() {
   function refresh() {
     setIsError(false);
     fetchLatestDocuments()
-      .then(setData)
+      .then((docs) => setData(docs.filter((d) => Boolean(d.formatted))))
       .catch(() => setIsError(true));
   }
   useEffect(refresh, []);

--- a/src/hooks/useDocumentItems.js
+++ b/src/hooks/useDocumentItems.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+async function fetchLatestDocuments() {
+  const response = await fetch('/user/user/documents/latest');
+  if (!response.ok) throw Error();
+  return response.json();
+}
+
+const initialData =
+  /** @type {import('../UserPopup').UserReviewDocument[]} */ ([]);
+
+export default function useLatestDocuments() {
+  const [data, setData] = useState(initialData);
+  const [isError, setIsError] = useState(false);
+
+  function refresh() {
+    setIsError(false);
+    fetchLatestDocuments()
+      .then(setData)
+      .catch(() => setIsError(true));
+  }
+  useEffect(refresh, []);
+
+  return { data, isError, refresh };
+}


### PR DESCRIPTION
Ticket: [PEDS-766](https://pcdc.atlassian.net/browse/PEDS-766)

This PR changes where the top bar document menu items are sourced from--i.e. switching from static configuration values to server data fetched on runtime (from `/user/user/documents/latest`). This is to allow documents list to be updated independent of portal app deployment.

Since runtime data fetching can fail, the PR also includes basic UI/UX for recovery:

<image src="https://user-images.githubusercontent.com/22449454/175383539-e2c325ab-70f0-4eec-b48d-d68a42844caa.png" width="500px" />

This is a follow-up to https://github.com/chicagopcdc/data-portal/pull/420.