### PR TITLE
Refactor and reorganize Redux code Pt.3 PEDS-754

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux';
 import ExplorerButtonGroup from '.';
-import { resetJob, setJobStatusInterval } from '../../actions';
-import {
-  dispatchJob,
-  fetchJobResult,
-  checkJobStatus,
-} from '../../actions.thunk';
+import { connectionError, resetJob, setJobStatusInterval } from '../../actions';
+import { dispatchJob, checkJobStatus } from '../../actions.thunk';
+import { jobapiPath } from '../../localconf';
 import { asyncSetInterval } from '../../utils';
+import { fetchWithCreds } from '../../utils.fetch';
 
 /** @typedef {import('../../types').KubeState} KubeState */
 /** @typedef {import('../../types').UserAccessState} UserAccessState */
@@ -27,7 +25,12 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setJobStatusInterval(interval));
   },
   /** @param {string} jobId */
-  fetchJobResult: (jobId) => dispatch(fetchJobResult(jobId)),
+  fetchJobResult: (jobId) =>
+    fetchWithCreds({
+      path: `${jobapiPath}output?UID=${jobId}`,
+      method: 'GET',
+      onError: () => dispatch(connectionError()),
+    }),
   resetJobState: () => {
     dispatch(resetJob());
   },

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
@@ -1,10 +1,9 @@
 import { connect } from 'react-redux';
 import ExplorerButtonGroup from '.';
-import { setJobStatusInterval } from '../../actions';
+import { resetJob, setJobStatusInterval } from '../../actions';
 import {
   dispatchJob,
   fetchJobResult,
-  resetJobState,
   checkJobStatus,
 } from '../../actions.thunk';
 import { asyncSetInterval } from '../../utils';
@@ -30,7 +29,7 @@ const mapDispatchToProps = (dispatch) => ({
   /** @param {string} jobId */
   fetchJobResult: (jobId) => dispatch(fetchJobResult(jobId)),
   resetJobState: () => {
-    dispatch(resetJobState());
+    dispatch(resetJob());
   },
 });
 const ReduxExplorerButtonGroup = connect(

--- a/src/Submission/ReduxSubmitForm.js
+++ b/src/Submission/ReduxSubmitForm.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import SubmitForm from './SubmitForm';
-import { updateFormSchema } from './actions';
-import { uploadTSV } from './actions.thunk';
+import { requestUpload, updateFormSchema } from './actions';
 
 /** @typedef {import('./types').SubmissionState} SubmissionState */
 
@@ -13,10 +12,11 @@ const mapStateToProps = (state) => ({
 /** @param {import('redux-thunk').ThunkDispatch} dispatch */
 const mapDispatchToProps = (dispatch) => ({
   /**
-   * @param {SubmissionState['file']} value
-   * @param {SubmissionState['file_type']} type
+   * @param {SubmissionState['file']} file
+   * @param {SubmissionState['file_type']} fileType
    */
-  onUploadClick: (value, type) => dispatch(uploadTSV(value, type)),
+  onUploadClick: (file, fileType) =>
+    dispatch(requestUpload({ file, file_type: fileType })),
   /**
    * @param {SubmissionState['formSchema']} formSchema
    */

--- a/src/Submission/ReduxSubmitTSV.js
+++ b/src/Submission/ReduxSubmitTSV.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import SubmitTSV from './SubmitTSV';
-import { requestUpload, updateFile } from './actions';
+import { requestUpload, resetSubmissionStatus, updateFile } from './actions';
 import { getCounts, submitToServer } from './actions.thunk';
 import { predictFileType } from '../utils';
 
@@ -23,6 +23,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
   /** @param {string} project */
   onSubmitClick: (project, callback) => {
+    dispatch(resetSubmissionStatus());
     dispatch(submitToServer({ fullProject: project, callback }));
   },
   /** @param {SubmissionState['file']} file */

--- a/src/Submission/ReduxSubmitTSV.js
+++ b/src/Submission/ReduxSubmitTSV.js
@@ -21,10 +21,16 @@ const mapDispatchToProps = (dispatch) => ({
   onUploadClick: (file, fileType) => {
     dispatch(requestUpload({ file, file_type: fileType }));
   },
-  /** @param {string} project */
-  onSubmitClick: (project, callback) => {
+  /**
+   * @param {Object} args
+   * @param {string} args.file
+   * @param {string} args.fileType
+   * @param {string} args.fullProject
+   * @param {() => void} [args.callback]
+   */
+  onSubmitClick: (args) => {
     dispatch(resetSubmissionStatus());
-    dispatch(submitToServer({ fullProject: project, callback }));
+    dispatch(submitToServer(args));
   },
   /** @param {SubmissionState['file']} file */
   onFileChange: (file) => {

--- a/src/Submission/ReduxSubmitTSV.js
+++ b/src/Submission/ReduxSubmitTSV.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import SubmitTSV from './SubmitTSV';
-import { lineLimit } from '../localconf';
 import { requestUpload, resetSubmissionStatus, updateFile } from './actions';
 import { getCounts, submitFileChunk } from './actions.thunk';
 import { predictFileType } from '../utils';
@@ -33,7 +32,7 @@ const mapDispatchToProps = (dispatch) => ({
   onSubmitClick: ({ file, fileType, fullProject, callback }) => {
     dispatch(resetSubmissionStatus());
 
-    const fileChunks = getFileChunksToSubmit({ file, fileType, lineLimit });
+    const fileChunks = getFileChunksToSubmit({ file, fileType });
     const fileChunkTotal = fileChunks.length;
     async function submitFile() {
       for await (const fileChunk of fileChunks) {

--- a/src/Submission/ReduxSubmitTSV.js
+++ b/src/Submission/ReduxSubmitTSV.js
@@ -1,11 +1,8 @@
 import { connect } from 'react-redux';
 import SubmitTSV from './SubmitTSV';
-import {
-  getCounts,
-  uploadTSV,
-  updateFileContent,
-  submitToServer,
-} from './actions.thunk';
+import { requestUpload, updateFile } from './actions';
+import { getCounts, submitToServer } from './actions.thunk';
+import { predictFileType } from '../utils';
 
 /** @typedef {import('redux-thunk').ThunkDispatch} ThunkDispatch */
 /** @typedef {import('./types').SubmissionState} SubmissionState */
@@ -18,19 +15,19 @@ const mapStateToProps = (state) => ({
 /** @param {ThunkDispatch} dispatch */
 const mapDispatchToProps = (dispatch) => ({
   /**
-   * @param {SubmissionState['file']} value
-   * @param {SubmissionState['file_type']} type
+   * @param {SubmissionState['file']} file
+   * @param {SubmissionState['file_type']} fileType
    */
-  onUploadClick: (value, type) => {
-    dispatch(uploadTSV(value, type));
+  onUploadClick: (file, fileType) => {
+    dispatch(requestUpload({ file, file_type: fileType }));
   },
   /** @param {string} project */
   onSubmitClick: (project, callback) => {
     dispatch(submitToServer({ fullProject: project, callback }));
   },
-  /** @param {SubmissionState['file']} value */
-  onFileChange: (value) => {
-    dispatch(updateFileContent(value));
+  /** @param {SubmissionState['file']} file */
+  onFileChange: (file) => {
+    dispatch(updateFile({ file, file_type: predictFileType(file) }));
   },
   /** @param {string} project */
   onFinish: (project) => {

--- a/src/Submission/SubmitTSV.jsx
+++ b/src/Submission/SubmitTSV.jsx
@@ -24,6 +24,14 @@ import './SubmitTSV.css';
  */
 
 /**
+ * @typedef {Object} SubmitHandlerArgs
+ * @property {string} args.file
+ * @property {string} args.fileType
+ * @property {string} args.fullProject
+ * @property {() => void} [args.callback]
+ */
+
+/**
  * Manage TSV/JSON submission
  * @param {Object} props
  * @param {string} props.project of form program-project
@@ -31,7 +39,7 @@ import './SubmitTSV.css';
  * @param {(file: string, fileType: string) => void} props.onFileChange triggered when user edits something in tsv/json AceEditor
  * @param {(project: string) => void} props.onFinish
  * @param {(file: string, fileType: string) => void} props.onUploadClick
- * @param {(project: string, callback?: () => void) => void} props.onSubmitClick
+ * @param {(args: SubmitHandlerArgs) => void} props.onSubmitClick
  */
 function SubmitTSV({
   project,
@@ -74,7 +82,12 @@ function SubmitTSV({
 
   const sessionMonitor = useSessionMonitor();
   function handleSubmitFile() {
-    onSubmitClick(project, () => sessionMonitor.updateUserActivity());
+    onSubmitClick({
+      file: submission.file,
+      fileType: submission.file_type,
+      fullProject: project,
+      callback: () => sessionMonitor.updateUserActivity(),
+    });
   }
 
   /** @param {string} value */

--- a/src/Submission/actions.thunk.js
+++ b/src/Submission/actions.thunk.js
@@ -12,7 +12,6 @@ import {
   receiveSubmission,
   receiveUnmappedFiles,
   receiveUnmappedFileStatistics,
-  resetSubmissionStatus,
 } from './actions';
 import { buildCountsQuery, FETCH_LIMIT } from './utils';
 
@@ -162,8 +161,6 @@ export const submitToServer =
    * @param {() => { submission: SubmissionState }} getState
    */
   (dispatch, getState) => {
-    dispatch(resetSubmissionStatus());
-
     /** @type {string[]} */
     const fileArray = [];
     const path = fullProject.split('-');

--- a/src/Submission/actions.thunk.js
+++ b/src/Submission/actions.thunk.js
@@ -6,16 +6,13 @@ import {
   submissionApiPath,
   useIndexdAuthz,
 } from '../localconf';
-import { predictFileType } from '../utils';
 import {
   receiveCounts,
   receiveDictionary,
   receiveSubmission,
   receiveUnmappedFiles,
   receiveUnmappedFileStatistics,
-  requestUpload,
   resetSubmissionStatus,
-  updateFile,
 } from './actions';
 import { buildCountsQuery, FETCH_LIMIT } from './utils';
 
@@ -247,27 +244,4 @@ export const submitToServer =
     }
 
     return recursiveFetch(fileArray);
-  };
-
-/**
- * @param {SubmissionState['file']} value
- * @param {SubmissionState['file_type']} type
- */
-export const uploadTSV =
-  (value, type) => (/** @type {Dispatch} */ dispatch) => {
-    dispatch(requestUpload({ file: value, file_type: type }));
-  };
-
-/**
- * @param {SubmissionState['file']} value
- * @param {string} [fileType]
- */
-export const updateFileContent =
-  (value, fileType) => (/** @type {Dispatch} */ dispatch) => {
-    dispatch(
-      updateFile({
-        file: value,
-        file_type: predictFileType(value, fileType),
-      })
-    );
   };

--- a/src/Submission/utils.js
+++ b/src/Submission/utils.js
@@ -1,3 +1,5 @@
+import { lineLimit } from '../localconf';
+
 /** @typedef {import('./types').SubmissionState} SubmissionState */
 
 /**
@@ -90,9 +92,8 @@ export const getDictionaryWithExcludeSystemProperties = (dictionary) => {
  * @param {Object} args
  * @param {string} args.file
  * @param {string} args.fileType
- * @param {number} args.lineLimit
  */
-export function getFileChunksToSubmit({ file, fileType, lineLimit }) {
+export function getFileChunksToSubmit({ file, fileType }) {
   /** @type {string[]} */
   const fileChunks = [];
 

--- a/src/Submission/utils.js
+++ b/src/Submission/utils.js
@@ -86,5 +86,49 @@ export const getDictionaryWithExcludeSystemProperties = (dictionary) => {
   return ret;
 };
 
+/**
+ * @param {Object} args
+ * @param {string} args.file
+ * @param {string} args.fileType
+ * @param {number} args.lineLimit
+ */
+export function getFileChunksToSubmit({ file, fileType, lineLimit }) {
+  /** @type {string[]} */
+  const fileChunks = [];
+
+  if (fileType === 'text/tab-separated-values') {
+    const fileSplited = file.split(/\r\n?|\n/g);
+    if (fileSplited.length > lineLimit && lineLimit > 0) {
+      let fileHeader = fileSplited[0];
+      fileHeader += '\n';
+      let count = lineLimit;
+      let fileChunk = fileHeader;
+
+      for (let i = 1; i < fileSplited.length; i += 1) {
+        if (fileSplited[i] !== '') {
+          fileChunk += fileSplited[i];
+          fileChunk += '\n';
+          count -= 1;
+        }
+        if (count === 0) {
+          fileChunks.push(fileChunk);
+          fileChunk = fileHeader;
+          count = lineLimit;
+        }
+      }
+      if (fileChunk !== fileHeader) {
+        fileChunks.push(fileChunk);
+      }
+    } else {
+      fileChunks.push(file);
+    }
+  } else {
+    // remove line break in json file
+    fileChunks.push(file.replace(/\r\n?|\n/g, ''));
+  }
+
+  return fileChunks;
+}
+
 export const FETCH_LIMIT = 1024;
 export const STARTING_DID = '00000000-0000-0000-0000-000000000000';

--- a/src/actions.thunk.js
+++ b/src/actions.thunk.js
@@ -81,14 +81,6 @@ export const checkJobStatus =
       });
   };
 
-/** @param {string} jobId */
-export const fetchJobResult = (jobId) => (/** @type {Dispatch} */ dispatch) =>
-  fetchWithCreds({
-    path: `${jobapiPath}output?UID=${jobId}`,
-    method: 'GET',
-    onError: () => dispatch(connectionError()),
-  }).then((data) => data);
-
 /* SLICE: PROJECT */
 /**
  * redux-thunk support asynchronous redux actions via 'thunks' -

--- a/src/actions.thunk.js
+++ b/src/actions.thunk.js
@@ -108,21 +108,13 @@ export const fetchProjects =
         });
 
 /* SLICE: USER */
-/** @param {import('./types').FetchHelperResult} result */
-export const handleFetchUser = ({ status, data }) => {
-  switch (status) {
-    case 200:
-      return receiveUser(data);
-    case 401:
-      return updatePopup({ authPopup: true });
-    default:
-      return fetchErrored(data.error);
-  }
-};
-
 export const fetchUser = () => (/** @type {Dispatch} */ dispatch) =>
-  fetchCreds({ onError: () => dispatch(connectionError()) }).then((res) =>
-    dispatch(handleFetchUser(res))
+  fetchCreds({ onError: () => dispatch(connectionError()) }).then(
+    ({ status, data }) => {
+      if (status === 200) return dispatch(receiveUser(data));
+      if (status === 401) return dispatch(updatePopup({ authPopup: true }));
+      return dispatch(fetchErrored(data.error));
+    }
   );
 
 /** @param {boolean} displayAuthPopup */

--- a/src/actions.thunk.js
+++ b/src/actions.thunk.js
@@ -7,7 +7,6 @@ import {
   receiveProjects,
   receiveUser,
   receiveUserAccess,
-  resetJob,
   updatePopup,
 } from './actions';
 import {
@@ -89,9 +88,6 @@ export const fetchJobResult = (jobId) => (/** @type {Dispatch} */ dispatch) =>
     method: 'GET',
     onError: () => dispatch(connectionError()),
   }).then((data) => data);
-
-export const resetJobState = () => (/** @type {Dispatch} */ dispatch) =>
-  dispatch(resetJob());
 
 /* SLICE: PROJECT */
 /**


### PR DESCRIPTION
Ticket: [PEDS-754](https://pcdc.atlassian.net/browse/PEDS-754)

This PR refactors & reorganizes the Redux code (reducers, actions, thunk actions) as a preparatory step for adopting Redux ToolKit. It is also a follow up to https://github.com/chicagopcdc/data-portal/pull/418 and https://github.com/chicagopcdc/data-portal/pull/419 and, shares the same overall objectives:

> * Use action creators for all actions
> * Make all actions to have the uniform `{ type, payload }` shape
> * Put thunk actions into separate `actions.thunk` files
> * Reorganize actions/thunk actions by "slice" where possible

In particular, the current PR aims to simplify thunk actions.