### PR TITLE
Fix bugs in multi explorers support PEDS-786

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -25,8 +25,7 @@ export default function useFilterSetWorkspace() {
     const initialActiveFilterSet = initialState.active.filterSet;
 
     // sync explorer filter set state with initial workspace active filter set
-    if ('id' in initialActiveFilterSet)
-      filterSets.use(initialActiveFilterSet.id);
+    filterSets.use(initialActiveFilterSet.id);
 
     // sync explorer filter state with non-empty initial workspace active filter
     if (!checkIfFilterEmpty(initialActiveFilterSet.filter))

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -52,16 +52,18 @@ export default function useFilterSetWorkspace() {
     storeWorkspaceState({ explorerId, state });
   }, [state]);
 
+  const isInitialRender1 = useRef(true);
   useEffect(() => {
-    // sync workspace active filter with explorer filter set state
-    if (filterSets.active?.id !== undefined)
+    // sync workspace active filter with explorer filter set state (skip initial render)
+    if (isInitialRender1.current) isInitialRender1.current = false;
+    else if (filterSets.active?.id !== undefined)
       dispatch({ type: 'LOAD', payload: { filterSet: filterSets.active } });
   }, [filterSets.active]);
 
-  const isInitialRender = useRef(true);
+  const isInitialRender2 = useRef(true);
   useEffect(() => {
     // sync workspace active filter with explorer filter state (skip initial render)
-    if (isInitialRender.current) isInitialRender.current = false;
+    if (isInitialRender2.current) isInitialRender2.current = false;
     else dispatch({ type: 'UPDATE', payload: { filter: explorerFilter } });
   }, [explorerFilter]);
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/useFilterSetWorkspace.js
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useExplorerConfig } from '../ExplorerConfigContext';
 import { useExplorerFilterSets } from '../ExplorerFilterSetsContext';
 import { useExplorerState } from '../ExplorerStateContext';
 import {
@@ -12,11 +13,12 @@ import {
 /** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 
 export default function useFilterSetWorkspace() {
+  const { explorerId } = useExplorerConfig();
   const { explorerFilter, handleFilterChange } = useExplorerState();
   const filterSets = useExplorerFilterSets();
 
   const initialState = useMemo(
-    () => initializeWorkspaceState(explorerFilter),
+    () => initializeWorkspaceState({ explorerFilter, explorerId }),
     []
   );
   useEffect(() => {
@@ -48,7 +50,7 @@ export default function useFilterSetWorkspace() {
     if (isFilterSetIdChanged) filterSets.use(id);
 
     // sync browser store with workspace state
-    storeWorkspaceState(state);
+    storeWorkspaceState({ explorerId, state });
   }, [state]);
 
   useEffect(() => {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -45,9 +45,10 @@ export function checkIfFilterEmpty(filter) {
 const workspaceStateSessionStorageKey = 'explorer:filterSetWorkspace';
 
 /** @returns {FilterSetWorkspaceState} */
-export function retrieveWorkspaceState() {
+export function retrieveWorkspaceState(explorerId) {
   try {
-    const str = window.sessionStorage.getItem(workspaceStateSessionStorageKey);
+    const storageKey = `${workspaceStateSessionStorageKey}:${explorerId}`;
+    const str = window.sessionStorage.getItem(storageKey);
     if (str === null) throw new Error('No stored query');
     return JSON.parse(str);
   } catch (e) {
@@ -59,21 +60,28 @@ export function retrieveWorkspaceState() {
   }
 }
 
-/** @param {ExplorerFilter} filter */
-export function initializeWorkspaceState(filter) {
-  if (checkIfFilterEmpty(filter)) return retrieveWorkspaceState();
+/**
+ * @param {Object} args
+ * @param {ExplorerFilter} args.explorerFilter
+ * @param {number} args.explorerId
+ */
+export function initializeWorkspaceState({ explorerFilter, explorerId }) {
+  if (checkIfFilterEmpty(explorerFilter))
+    return retrieveWorkspaceState(explorerId);
 
   const id = crypto.randomUUID();
-  const filterSet = { filter };
+  const filterSet = { filter: explorerFilter };
   return { active: { filterSet, id }, all: { [id]: filterSet } };
 }
 
-/** @param {FilterSetWorkspaceState} state */
-export function storeWorkspaceState(state) {
-  window.sessionStorage.setItem(
-    workspaceStateSessionStorageKey,
-    JSON.stringify(state)
-  );
+/**
+ * @param {Object} args
+ * @param {number} args.explorerId
+ * @param {FilterSetWorkspaceState} args.state
+ */
+export function storeWorkspaceState({ explorerId, state }) {
+  const storageKey = `${workspaceStateSessionStorageKey}:${explorerId}`;
+  window.sessionStorage.setItem(storageKey, JSON.stringify(state));
 }
 
 /**

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -67,6 +67,7 @@ let prevExplorerId;
  * @param {Object} args
  * @param {ExplorerFilter} args.explorerFilter
  * @param {number} args.explorerId
+ * @returns {FilterSetWorkspaceState}
  */
 export function initializeWorkspaceState({ explorerFilter, explorerId }) {
   const isSwitchingExplorer =

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -60,13 +60,20 @@ export function retrieveWorkspaceState(explorerId) {
   }
 }
 
+/** @type {number} */
+let prevExplorerId;
+
 /**
  * @param {Object} args
  * @param {ExplorerFilter} args.explorerFilter
  * @param {number} args.explorerId
  */
 export function initializeWorkspaceState({ explorerFilter, explorerId }) {
-  if (checkIfFilterEmpty(explorerFilter))
+  const isSwitchingExplorer =
+    prevExplorerId !== undefined && prevExplorerId !== explorerId;
+  prevExplorerId = explorerId;
+
+  if (isSwitchingExplorer || checkIfFilterEmpty(explorerFilter))
     return retrieveWorkspaceState(explorerId);
 
   const id = crypto.randomUUID();

--- a/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetsContext.jsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { fetchWithCreds } from '../utils.fetch';
 import { useExplorerConfig } from './ExplorerConfigContext';
@@ -131,9 +138,13 @@ export function ExplorerFilterSetsProvider({ children }) {
     return undefined;
   }
 
+  const prevExplorerId = useRef(explorerId);
   useEffect(() => {
-    fetchFilterSets(explorerId).then(setFilterSets).catch(handleCatch);
-  }, []);
+    if (prevExplorerId.current !== explorerId) {
+      prevExplorerId.current = explorerId;
+      fetchFilterSets(explorerId).then(setFilterSets).catch(handleCatch);
+    }
+  }, [explorerId]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
Ticket: [PEDS-786](https://pcdc.atlassian.net/browse/PEDS-786)

This PR addresses the following two issues in multi-explorers support for the explorer page:

* Workspace state is not properly compartmentalized for each explorer, leading to bugs caused by shared state across explorers
* Saved Filter Sets state is not promptly re-fetched on switching explorers, leading to displaying incorrect set of Saved Filter Sets on switching explorers.