### PR TITLE
Refactor explorer contexts

### DIFF
--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -2,20 +2,11 @@ import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSearchParams } from 'react-router-dom';
 import { explorerConfig } from '../localconf';
-import { capitalizeFirstLetter } from '../utils';
 import { getCurrentConfig } from './utils';
 
 /** @type {number[]} */
 const explorerIds = [];
-/** @type {{ label: string; value: string }[]} */
-const explorerOptions = [];
-for (const { guppyConfig, id, label } of explorerConfig) {
-  explorerIds.push(id);
-  explorerOptions.push({
-    label: capitalizeFirstLetter(label || guppyConfig.dataType),
-    value: String(id),
-  });
-}
+for (const { id } of explorerConfig) explorerIds.push(id);
 
 /** @typedef {import('./types').AlteredExplorerConfig} AlteredExplorerConfig */
 
@@ -23,7 +14,6 @@ for (const { guppyConfig, id, label } of explorerConfig) {
  * @typedef {Object} ExplorerConfigContext
  * @property {AlteredExplorerConfig} current
  * @property {number} explorerId
- * @property {{ label: string; value: string }[]} explorerOptions
  * @property {() => void} handleBrowserNavigationForConfig
  * @property {(id: number) => void} updateExplorerId
  */
@@ -64,7 +54,6 @@ export function ExplorerConfigProvider({ children }) {
     () => ({
       current: getCurrentConfig(explorerId),
       explorerId,
-      explorerOptions,
       handleBrowserNavigationForConfig,
       updateExplorerId,
     }),

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -5,7 +5,9 @@ import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import { getCurrentConfig } from './utils';
 
+/** @type {number[]} */
 const explorerIds = [];
+/** @type {{ label: string; value: string }[]} */
 const explorerOptions = [];
 for (const { guppyConfig, id, label } of explorerConfig) {
   explorerIds.push(id);

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -5,6 +5,16 @@ import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import { createFilterInfo, isSurvivalAnalysisEnabled } from './utils';
 
+const explorerIds = [];
+const explorerOptions = [];
+for (const { guppyConfig, id, label } of explorerConfig) {
+  explorerIds.push(id);
+  explorerOptions.push({
+    label: capitalizeFirstLetter(label || guppyConfig.dataType),
+    value: String(id),
+  });
+}
+
 /** @typedef {import('./types').AlteredExplorerConfig} AlteredExplorerConfig */
 
 /**
@@ -21,17 +31,6 @@ const ExplorerConfigContext = createContext(null);
 
 export function ExplorerConfigProvider({ children }) {
   const [searchParams, setSearchParams] = useSearchParams();
-
-  const explorerOptions = [];
-  const explorerIds = [];
-  for (const { guppyConfig, id, label } of explorerConfig) {
-    explorerIds.push(id);
-    explorerOptions.push({
-      label: capitalizeFirstLetter(label || guppyConfig.dataType),
-      value: String(id),
-    });
-  }
-
   const [initialExplorerId, hasValidInitialSearchParamId] = useMemo(() => {
     const hasSearchParamId = searchParams.has('id');
     const searchParamId = hasSearchParamId

--- a/src/GuppyDataExplorer/ExplorerConfigContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerConfigContext.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSearchParams } from 'react-router-dom';
 import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
-import { createFilterInfo, isSurvivalAnalysisEnabled } from './utils';
+import { getCurrentConfig } from './utils';
 
 const explorerIds = [];
 const explorerOptions = [];
@@ -58,43 +58,15 @@ export function ExplorerConfigProvider({ children }) {
     if (explorerIds.includes(searchParamId)) setExporerId(searchParamId);
   }
 
-  const config = explorerConfig.find(({ id }) => id === explorerId);
-
   const value = useMemo(
     () => ({
-      current: {
-        adminAppliedPreFilters: config.adminAppliedPreFilters,
-        buttonConfig: {
-          buttons: config.buttons,
-          dropdowns: config.dropdowns,
-          sevenBridgesExportURL: config.sevenBridgesExportURL,
-          terraExportURL: config.terraExportURL,
-          terraTemplate: config.terraTemplate,
-        },
-        chartConfig: config.charts,
-        filterConfig: {
-          ...config.filters,
-          info: createFilterInfo(
-            config.filters,
-            config.guppyConfig.fieldMapping
-          ),
-        },
-        getAccessButtonLink: config.getAccessButtonLink,
-        guppyConfig: config.guppyConfig,
-        hideGetAccessButton: config.hideGetAccessButton,
-        patientIdsConfig: config.patientIds,
-        survivalAnalysisConfig: {
-          ...config.survivalAnalysis,
-          enabled: isSurvivalAnalysisEnabled(config.survivalAnalysis),
-        },
-        tableConfig: config.table,
-      },
+      current: getCurrentConfig(explorerId),
       explorerId,
       explorerOptions,
       handleBrowserNavigationForConfig,
       updateExplorerId,
     }),
-    [config, explorerId, explorerOptions]
+    [explorerId]
   );
 
   return (

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -24,7 +24,7 @@ function ExplorerFilter({ className = '', ...filterProps }) {
   const {
     explorerFilter,
     patientIds,
-    handleFilterClear,
+    handleFilterChange,
     handlePatientIdsChange,
   } = useExplorerState();
   const connectedFilterProps = {
@@ -53,7 +53,7 @@ function ExplorerFilter({ className = '', ...filterProps }) {
           <button
             type='button'
             className='explorer-filter__clear-button'
-            onClick={handleFilterClear}
+            onClick={() => handleFilterChange(undefined)}
           >
             Clear all
           </button>

--- a/src/GuppyDataExplorer/ExplorerSelect/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerSelect/index.jsx
@@ -1,10 +1,19 @@
 import Select from 'react-select';
+import { explorerConfig } from '../../localconf';
+import { capitalizeFirstLetter, overrideSelectTheme } from '../../utils';
 import { useExplorerConfig } from '../ExplorerConfigContext';
-import { overrideSelectTheme } from '../../utils';
 import './ExplorerSelect.css';
 
+/** @type {{ label: string; value: string }[]} */
+const explorerOptions = [];
+for (const { guppyConfig, id, label } of explorerConfig)
+  explorerOptions.push({
+    label: capitalizeFirstLetter(label || guppyConfig.dataType),
+    value: String(id),
+  });
+
 export default function ExplorerTabs() {
-  const { explorerId, explorerOptions, updateExplorerId } = useExplorerConfig();
+  const { explorerId, updateExplorerId } = useExplorerConfig();
   const currentExplorer = explorerOptions.find(
     (o) => o.value === String(explorerId)
   );

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -10,7 +10,6 @@ import { useExplorerConfig } from './ExplorerConfigContext';
  * @property {ExplorerFilter} explorerFilter
  * @property {string[]} patientIds
  * @property {(filter: ExplorerFilter) => void} handleFilterChange
- * @property {() => void} handleFilterClear
  * @property {(patientIds: string[]) => void} handlePatientIdsChange
  */
 
@@ -59,10 +58,6 @@ export function ExplorerStateProvider({ children }) {
     setExplorerFilter(newFilter);
   }
 
-  function handleFilterClear() {
-    handleFilterChange(undefined);
-  }
-
   function handlePatientIdsChange(/** @type {string[]} */ ids) {
     if (patientIdsConfig?.filter !== undefined) setPatientIds(ids);
   }
@@ -72,7 +67,6 @@ export function ExplorerStateProvider({ children }) {
       explorerFilter,
       patientIds,
       handleFilterChange,
-      handleFilterClear,
       handlePatientIdsChange,
     }),
     [explorerFilter, patientIds]

--- a/src/GuppyDataExplorer/ExplorerStateContext.jsx
+++ b/src/GuppyDataExplorer/ExplorerStateContext.jsx
@@ -25,11 +25,6 @@ export function ExplorerStateProvider({ children }) {
     /** @type {{ filter?: ExplorerFilter }} */ (useLocation().state)?.filter ??
     /** @type {ExplorerFilter} */ ({});
   const [explorerFilter, setExplorerFilter] = useState(initialExplorerFilter);
-
-  /** @type {string[]} */
-  const initielPatientIds = patientIdsConfig?.filter ? [] : undefined;
-  const [patientIds, setPatientIds] = useState(initielPatientIds);
-
   function handleFilterChange(/** @type {ExplorerFilter} */ filter) {
     let newFilter = /** @type {ExplorerFilter} */ ({});
     if (filter && Object.keys(filter).length > 0) {
@@ -58,6 +53,9 @@ export function ExplorerStateProvider({ children }) {
     setExplorerFilter(newFilter);
   }
 
+  /** @type {string[]} */
+  const initielPatientIds = patientIdsConfig?.filter ? [] : undefined;
+  const [patientIds, setPatientIds] = useState(initielPatientIds);
   function handlePatientIdsChange(/** @type {string[]} */ ids) {
     if (patientIdsConfig?.filter !== undefined) setPatientIds(ids);
   }

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { contactEmail, explorerConfig } from '../localconf';
@@ -41,14 +40,8 @@ function ExplorerDashboard({ dataVersion, portalVersion }) {
       tableConfig,
     },
     explorerId,
-    handleBrowserNavigationForConfig,
   } = useExplorerConfig();
   const { explorerFilter, patientIds, handleFilterChange } = useExplorerState();
-  useEffect(() => {
-    window.addEventListener('popstate', handleBrowserNavigationForConfig);
-    return () =>
-      window.removeEventListener('popstate', handleBrowserNavigationForConfig);
-  }, []);
 
   return (
     <GuppyWrapper

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -6,6 +6,7 @@
 /** @typedef {import('./types').SingleButtonConfig} SingleButtonConfig */
 /** @typedef {import('./types').SurvivalAnalysisConfig} SurvivalAnalysisConfig */
 
+import { explorerConfig } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 
 /**
@@ -196,4 +197,33 @@ export function isSurvivalAnalysisEnabled(config) {
         return true;
 
   return false;
+}
+
+/** @param {number} explorerId */
+export function getCurrentConfig(explorerId) {
+  const config = explorerConfig.find(({ id }) => id === explorerId);
+  return {
+    adminAppliedPreFilters: config.adminAppliedPreFilters,
+    buttonConfig: {
+      buttons: config.buttons,
+      dropdowns: config.dropdowns,
+      sevenBridgesExportURL: config.sevenBridgesExportURL,
+      terraExportURL: config.terraExportURL,
+      terraTemplate: config.terraTemplate,
+    },
+    chartConfig: config.charts,
+    filterConfig: {
+      ...config.filters,
+      info: createFilterInfo(config.filters, config.guppyConfig.fieldMapping),
+    },
+    getAccessButtonLink: config.getAccessButtonLink,
+    guppyConfig: config.guppyConfig,
+    hideGetAccessButton: config.hideGetAccessButton,
+    patientIdsConfig: config.patientIds,
+    survivalAnalysisConfig: {
+      ...config.survivalAnalysis,
+      enabled: isSurvivalAnalysisEnabled(config.survivalAnalysis),
+    },
+    tableConfig: config.table,
+  };
 }


### PR DESCRIPTION
This PR includes some refactoring efforts for `<ExplorerConfigContext>` and `<ExplorerStateContext>` in preparation for the planned migration of relevant states to Redux store. The efforts are mostly focused on simplifying each context.

The PR also includes a fix for broken `explorerId` update on browser navigation due to stale closure.