### PR TITLE
Fix stale survival analysis results for updated filter sets PEDS-806

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -83,26 +83,25 @@ function validateNumberInput(e, setStateAction) {
  * @param {number} prop.timeInterval
  */
 function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
-  const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
-  const [startTime, setStartTime] = useState(0);
-  const [endTime, setEndTime] = useState(undefined);
-  const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
-
-  const [selectFilterSetId, setSelectFilterSetId] = useState(null);
   const savedFilterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
   const staleFilterSetIdSet = useAppSelector(
     (state) => new Set(state.explorer.survivalAnalysisResult.staleFilterSetIds)
   );
+
+  const [localTimeInterval, setLocalTimeInterval] = useState(timeInterval);
+  const [startTime, setStartTime] = useState(0);
+  const [endTime, setEndTime] = useState(undefined);
+  const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
+  const [selectFilterSetId, setSelectFilterSetId] = useState(null);
   const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
-  const usedFilterSetIdSet = new Set(usedFilterSetIds);
 
   const filterSetOptions = [];
   const usedFilterSets = [];
   for (const filterSet of [defaultFilterSet, ...savedFilterSets]) {
     const { name: label, id: value } = filterSet;
-    const isUsed = usedFilterSetIdSet.has(value);
+    const isUsed = usedFilterSetIds.includes(value);
     filterSetOptions.push({ label, value, isDisabled: isUsed });
 
     if (isUsed) {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -91,10 +91,10 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
 
   const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
   const [usedFilterSets, setUsedFilterSets] = useState(emptyFilterSets);
-  const filterSets = useAppSelector(
+  const savedFilterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
-  const filterSetOptions = [defaultFilterSet, ...filterSets].map(
+  const filterSetOptions = [defaultFilterSet, ...savedFilterSets].map(
     (filterSet) => ({
       label: filterSet.name,
       value: filterSet,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -106,23 +106,16 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
   useEffect(() => {
     if (countByFilterSet === undefined) setIsInputChanged(true);
   }, [countByFilterSet]);
-  const [shouldSubmit, setShouldSubmit] = useState(false);
-  useEffect(() => {
-    if (shouldSubmit) {
-      onSubmit({
-        timeInterval: localTimeInterval,
-        startTime,
-        endTime: endTime || undefined,
-        efsFlag: survivalType.value === 'efs',
-        usedFilterSets,
-      });
-      setShouldSubmit(false);
-    }
-  }, [shouldSubmit]);
 
   const submitUserInput = () => {
     setIsInputChanged(false);
-    setShouldSubmit(true);
+    onSubmit({
+      timeInterval: localTimeInterval,
+      startTime,
+      endTime: endTime || undefined,
+      efsFlag: survivalType.value === 'efs',
+      usedFilterSets,
+    });
   };
 
   const resetUserInput = () => {
@@ -132,7 +125,6 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
     setSurvivalType(survivalTypeOptions[0]);
     setUsedFilterSets(emptyFilterSets);
     setIsInputChanged(false);
-    setShouldSubmit(true);
   };
 
   return (

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -89,20 +89,27 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
   const [selectFilterSetId, setSelectFilterSetId] = useState(null);
-  const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
   const savedFilterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
-  const usedFilterSets = [defaultFilterSet, ...savedFilterSets].filter(
-    ({ id }) => usedFilterSetIds.includes(id)
+  const staleFilterSetIdSet = useAppSelector(
+    (state) => new Set(state.explorer.survivalAnalysisResult.staleFilterSetIds)
   );
-  const filterSetOptions = [defaultFilterSet, ...savedFilterSets].map(
-    (filterSet) => ({
-      label: filterSet.name,
-      value: filterSet.id,
-      isDisabled: usedFilterSetIds.some((id) => id === filterSet.id),
-    })
-  );
+  const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
+  const usedFilterSetIdSet = new Set(usedFilterSetIds);
+
+  const filterSetOptions = [];
+  const usedFilterSets = [];
+  for (const filterSet of [defaultFilterSet, ...savedFilterSets]) {
+    const { name: label, id: value } = filterSet;
+    const isUsed = usedFilterSetIdSet.has(value);
+    filterSetOptions.push({ label, value, isDisabled: isUsed });
+
+    if (isUsed) {
+      const isStale = staleFilterSetIdSet.has(value);
+      usedFilterSets.push({ ...filterSet, isStale });
+    }
+  }
 
   const [isInputChanged, setIsInputChanged] = useState(false);
   useEffect(() => {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -90,13 +90,13 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
 
   const [selectFilterSetId, setSelectFilterSetId] = useState(null);
   const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
-  const filterSets = useAppSelector(
+  const savedFilterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
-  const usedFilterSets = [defaultFilterSet, ...filterSets].filter(({ id }) =>
-    usedFilterSetIds.includes(id)
+  const usedFilterSets = [defaultFilterSet, ...savedFilterSets].filter(
+    ({ id }) => usedFilterSetIds.includes(id)
   );
-  const filterSetOptions = [defaultFilterSet, ...filterSets].map(
+  const filterSetOptions = [defaultFilterSet, ...savedFilterSets].map(
     (filterSet) => ({
       label: filterSet.name,
       value: filterSet.id,

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -243,7 +243,10 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
           label='Apply'
           buttonType='primary'
           onClick={submitUserInput}
-          enabled={isInputChanged && usedFilterSets.length > 0}
+          enabled={
+            usedFilterSets.length > 0 &&
+            (isInputChanged || staleFilterSetIdSet.size > 0)
+          }
         />
       </div>
     </form>

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -52,9 +52,8 @@ const survivalTypeOptions = [
   { label: 'Event-Free Survival (EFS)', value: 'efs' },
 ];
 
-/** @type {ExplorerFilterSet[]} */
-const emptyFilterSets = [];
-
+/** @type {ExplorerFilterSet['id'][]} */
+const emptyFilterSetIds = [];
 /** @type {ExplorerFilterSet} */
 export const defaultFilterSet = {
   name: '*** All Subjects ***',
@@ -89,16 +88,19 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
   const [endTime, setEndTime] = useState(undefined);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
 
-  const [selectFilterSetOption, setSelectFilterSetOption] = useState(null);
-  const [usedFilterSets, setUsedFilterSets] = useState(emptyFilterSets);
-  const savedFilterSets = useAppSelector(
+  const [selectFilterSetId, setSelectFilterSetId] = useState(null);
+  const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
+  const filterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
-  const filterSetOptions = [defaultFilterSet, ...savedFilterSets].map(
+  const usedFilterSets = [defaultFilterSet, ...filterSets].filter(({ id }) =>
+    usedFilterSetIds.includes(id)
+  );
+  const filterSetOptions = [defaultFilterSet, ...filterSets].map(
     (filterSet) => ({
       label: filterSet.name,
-      value: filterSet,
-      isDisabled: usedFilterSets.some(({ id }) => id === filterSet.id),
+      value: filterSet.id,
+      isDisabled: usedFilterSetIds.some((id) => id === filterSet.id),
     })
   );
 
@@ -123,7 +125,7 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
     setStartTime(0);
     setEndTime(undefined);
     setSurvivalType(survivalTypeOptions[0]);
-    setUsedFilterSets(emptyFilterSets);
+    setUsedFilterSetIds([]);
     setIsInputChanged(false);
   };
 
@@ -191,21 +193,18 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
           inputId='survival-filter-sets'
           placeholder='Select Filter Set to analyze'
           options={filterSetOptions}
-          onChange={setSelectFilterSetOption}
+          onChange={({ value }) => setSelectFilterSetId(value)}
           maxMenuHeight={160}
-          value={selectFilterSetOption}
+          value={selectFilterSetId}
           theme={overrideSelectTheme}
         />
         <Button
           label='Add'
           buttonType='default'
-          enabled={selectFilterSetOption !== null}
+          enabled={selectFilterSetId !== null}
           onClick={() => {
-            setUsedFilterSets((prevFilterSets) => [
-              ...prevFilterSets,
-              selectFilterSetOption.value,
-            ]);
-            setSelectFilterSetOption(null);
+            setUsedFilterSetIds((ids) => [...ids, selectFilterSetId]);
+            setSelectFilterSetId(null);
             setIsInputChanged(true);
           }}
         />
@@ -223,8 +222,8 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
             filterSet={filterSet}
             label={`${i + 1}. ${filterSet.name}`}
             onClose={() => {
-              setUsedFilterSets((prevFilterSets) =>
-                prevFilterSets.filter(({ id }) => id !== filterSet.id)
+              setUsedFilterSetIds((ids) =>
+                ids.filter((id) => id !== filterSet.id)
               );
               setIsInputChanged(true);
             }}

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -36,7 +36,7 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
               arrowContent={<div className='rc-tooltip-arrow-inner' />}
               mouseLeaveDelay={0}
               overlay={
-                'This Filter Set has been updated and its survival analysis result may be stale'
+                'This Filter Set has been updated and its survival analysis result may be stale. Click "Apply" button at the bottom to update the result.'
               }
               placement='top'
               trigger={['hover', 'focus']}
@@ -55,7 +55,7 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
             <Tooltip
               arrowContent={<div className='rc-tooltip-arrow-inner' />}
               mouseLeaveDelay={0}
-              overlay={`${count.fitted} of ${count.total} subjects for this Filter Set is used to calculate survival rates`}
+              overlay={`${count.fitted} of ${count.total} subjects for this Filter Set is used to calculate survival rates.`}
               placement='top'
               trigger={['hover', 'focus']}
             >

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -31,39 +31,39 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
           {label}
         </button>
         {filterSet.isStale ? (
-          <Tooltip
-            arrowContent={<div className='rc-tooltip-arrow-inner' />}
-            mouseLeaveDelay={0}
-            overlay={
-              'This Filter Set has been updated and its survival analysis result may be stale'
-            }
-            placement='top'
-            trigger={['hover', 'focus']}
-          >
-            <button type='button'>
+          <button type='button'>
+            <Tooltip
+              arrowContent={<div className='rc-tooltip-arrow-inner' />}
+              mouseLeaveDelay={0}
+              overlay={
+                'This Filter Set has been updated and its survival analysis result may be stale'
+              }
+              placement='top'
+              trigger={['hover', 'focus']}
+            >
               <FontAwesomeIcon
                 icon='triangle-exclamation'
                 color='var(--pcdc-color__secondary)'
               />
-            </button>
-          </Tooltip>
+            </Tooltip>
+          </button>
         ) : null}
         {count === undefined ? (
           <em>N/A</em>
         ) : (
-          <Tooltip
-            arrowContent={<div className='rc-tooltip-arrow-inner' />}
-            mouseLeaveDelay={0}
-            overlay={`${count.fitted} of ${count.total} subjects for this Filter Set is used to calculate survival rates`}
-            placement='top'
-            trigger={['hover', 'focus']}
-          >
-            <button type='button'>
+          <button type='button'>
+            <Tooltip
+              arrowContent={<div className='rc-tooltip-arrow-inner' />}
+              mouseLeaveDelay={0}
+              overlay={`${count.fitted} of ${count.total} subjects for this Filter Set is used to calculate survival rates`}
+              placement='top'
+              trigger={['hover', 'focus']}
+            >
               <em>
                 {count.fitted}/{count.total}
               </em>
-            </button>
-          </Tooltip>
+            </Tooltip>
+          </button>
         )}
         <button aria-label='Clear' type='button' onClick={onClose}>
           <i className='g3-icon g3-icon--sm g3-icon--cross' />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/FilterSetCard.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SimpleInputField from '../../components/SimpleInputField';
 import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 
@@ -9,7 +10,7 @@ import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 /**
  * @typedef {Object} FilterSetCardProps
  * @property {{ fitted: number; total: number }} [count]
- * @property {ExplorerFilterSet} filterSet
+ * @property {ExplorerFilterSet & { isStale: boolean }} filterSet
  * @property {string} label
  * @property {React.MouseEventHandler<HTMLButtonElement>} onClose
  */
@@ -29,6 +30,24 @@ export default function FilterSetCard({ count, filterSet, label, onClose }) {
           />
           {label}
         </button>
+        {filterSet.isStale ? (
+          <Tooltip
+            arrowContent={<div className='rc-tooltip-arrow-inner' />}
+            mouseLeaveDelay={0}
+            overlay={
+              'This Filter Set has been updated and its survival analysis result may be stale'
+            }
+            placement='top'
+            trigger={['hover', 'focus']}
+          >
+            <button type='button'>
+              <FontAwesomeIcon
+                icon='triangle-exclamation'
+                color='var(--pcdc-color__secondary)'
+              />
+            </button>
+          </Tooltip>
+        ) : null}
         {count === undefined ? (
           <em>N/A</em>
         ) : (

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -88,7 +88,7 @@ export const updateSurvivalResult = createAsyncThunk(
         });
     }
 
-    if (filterSets.length === 0) return cache;
+    if (filterSets.length === 0) return { data: cache };
 
     try {
       const newResult = await survivalAnalysisAPI.fetchResult({
@@ -98,7 +98,7 @@ export const updateSurvivalResult = createAsyncThunk(
         result: explorer.config.survivalAnalysisConfig.result,
         usedFilterSetIds,
       });
-      return { ...cache, ...newResult };
+      return { data: { ...cache, ...newResult } };
     } catch (e) {
       return rejectWithValue(e);
     }

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -64,7 +64,7 @@ export const updateSurvivalResult = createAsyncThunk(
    * @param {{
    *  efsFlag: boolean;
    *  shouldRefetch?: boolean
-   *  usedFilterSets: ExplorerFilterSet[];
+   *  usedFilterSets: (ExplorerFilterSet & { isStale?: boolean })[];
    * }} args
    */
   async (args, { getState, rejectWithValue }) => {
@@ -76,9 +76,11 @@ export const updateSurvivalResult = createAsyncThunk(
     const filterSets = [];
     const usedFilterSetIds = [];
     for (const [index, filterSet] of args.usedFilterSets.entries()) {
-      const { filter, id, name } = filterSet;
+      const { filter, id, name, isStale } = filterSet;
       usedFilterSetIds.push(id);
-      if (result !== null && id in result && !args.shouldRefetch)
+
+      const shouldRefetch = args.shouldRefetch || isStale;
+      if (result !== null && id in result && !shouldRefetch)
         cache[id] = { ...result[id], name: `${index + 1}. ${name}` };
       else
         filterSets.push({

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -88,7 +88,7 @@ export const updateSurvivalResult = createAsyncThunk(
         });
     }
 
-    if (filterSets.length === 0) return { data: cache };
+    if (filterSets.length === 0) return { data: cache, usedFilterSetIds };
 
     try {
       const newResult = await survivalAnalysisAPI.fetchResult({
@@ -98,7 +98,7 @@ export const updateSurvivalResult = createAsyncThunk(
         result: explorer.config.survivalAnalysisConfig.result,
         usedFilterSetIds,
       });
-      return { data: { ...cache, ...newResult } };
+      return { data: { ...cache, ...newResult }, usedFilterSetIds };
     } catch (e) {
       return rejectWithValue(e);
     }

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -280,7 +280,7 @@ const slice = createSlice({
         state.savedFilterSets.isError = true;
       })
       .addCase(updateSurvivalResult.fulfilled, (state, action) => {
-        const result = action.payload;
+        const result = action.payload.data;
         state.survivalAnalysisResult.data = result;
         state.survivalAnalysisResult.isPending = false;
         state.survivalAnalysisResult.parsed = parseSurvivalResult({

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -54,6 +54,7 @@ const slice = createSlice({
         config: initialConfig.survivalAnalysisConfig,
         result: null,
       }),
+      staleFilterSetIds: [],
       usedFilterSetIds: [],
     },
     workspaces: initialWorkspaces,
@@ -276,6 +277,11 @@ const slice = createSlice({
         // sync with workspaces
         const { activeId } = state.workspaces[state.explorerId];
         state.workspaces[state.explorerId].all[activeId] = filterSet;
+
+        // sync with survival result
+        const { id } = filterSet;
+        if (state.survivalAnalysisResult.usedFilterSetIds.includes(id))
+          state.survivalAnalysisResult.staleFilterSetIds.push(id);
       })
       .addCase(updateFilterSet.rejected, (state) => {
         state.savedFilterSets.isError = true;
@@ -288,6 +294,7 @@ const slice = createSlice({
           config: state.config.survivalAnalysisConfig,
           result: data,
         });
+        state.survivalAnalysisResult.staleFilterSetIds = [];
         state.survivalAnalysisResult.usedFilterSetIds = usedFilterSetIds;
       })
       .addCase(updateSurvivalResult.pending, (state) => {
@@ -299,6 +306,7 @@ const slice = createSlice({
         state.survivalAnalysisResult.error = Error(String(action.payload));
         state.survivalAnalysisResult.isPending = false;
         state.survivalAnalysisResult.parsed = {};
+        state.survivalAnalysisResult.staleFilterSetIds = [];
         state.survivalAnalysisResult.usedFilterSetIds = [];
       });
   },

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -54,6 +54,7 @@ const slice = createSlice({
         config: initialConfig.survivalAnalysisConfig,
         result: null,
       }),
+      usedFilterSetIds: [],
     },
     workspaces: initialWorkspaces,
   }),
@@ -280,13 +281,14 @@ const slice = createSlice({
         state.savedFilterSets.isError = true;
       })
       .addCase(updateSurvivalResult.fulfilled, (state, action) => {
-        const result = action.payload.data;
-        state.survivalAnalysisResult.data = result;
+        const { data, usedFilterSetIds } = action.payload;
+        state.survivalAnalysisResult.data = data;
         state.survivalAnalysisResult.isPending = false;
         state.survivalAnalysisResult.parsed = parseSurvivalResult({
           config: state.config.survivalAnalysisConfig,
-          result,
+          result: data,
         });
+        state.survivalAnalysisResult.usedFilterSetIds = usedFilterSetIds;
       })
       .addCase(updateSurvivalResult.pending, (state) => {
         state.survivalAnalysisResult.error = null;
@@ -297,6 +299,7 @@ const slice = createSlice({
         state.survivalAnalysisResult.error = Error(String(action.payload));
         state.survivalAnalysisResult.isPending = false;
         state.survivalAnalysisResult.parsed = {};
+        state.survivalAnalysisResult.usedFilterSetIds = [];
       });
   },
 });

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -65,6 +65,7 @@ export type ExplorerState = {
     error: Error;
     isPending: boolean;
     parsed: ParsedSurvivalAnalysisResult;
+    staleFilterSetIds: number[];
     usedFilterSetIds: number[];
   };
   workspaces: {

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -65,6 +65,7 @@ export type ExplorerState = {
     error: Error;
     isPending: boolean;
     parsed: ParsedSurvivalAnalysisResult;
+    usedFilterSetIds: number[];
   };
   workspaces: {
     [explorerId: ExplorerState['explorerId']]: ExplorerWorkspace;


### PR DESCRIPTION
Ticket: [PEDS-806](https://pcdc.atlassian.net/browse/PEDS-806)

This PR fixes the issue of stale survival  analysis results for updated filter sets. This happens when users use saved filter sets on survival analysis tool and generates results, and then update those filter sets using Workspace. The results do not automatically refresh and therefore become stale.

The current UI for survival analysis tool does not have a way to indicate which used filter set has been updated and therefore potentially mislead users to think that they're seeing the correct result when it's stale. The fix includes:

* Provide a visual feedback if a saved filter set has been updated, which includes a description on what's happening and clear call to action to remedy the situation
* Enable "Apply" button if any of the used filter sets has been updated
*  Refresh the result for updated filter sets on "Apply" (i.e. ignore cached result)

See the following screen recording for a demo:

https://user-images.githubusercontent.com/22449454/179611530-6600710c-549d-439d-a44a-6f3305c38a97.mov

Note that the current fix overfetches i.e. requests new survival analysis result even if the filter content of the update filter set has not changed. Given other higher-priority tasks, I'm leaving the current fix as is and will follow up with another PR to prevent overfetching.
