### PR TITLE
Refactor explorer filter state shape PEDS-732

### DIFF
--- a/.storybook/stories/FilterDisplay.jsx
+++ b/.storybook/stories/FilterDisplay.jsx
@@ -2,20 +2,24 @@
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import FilterDisplay from '@src/components/FilterDisplay';
+import { FILTER_TYPE } from '@src/GuppyComponents/Utils/const';
 
 const simpleFilter = {
   __combineMode: 'AND',
-  foo: { selectedValues: ['x', 'y'] },
-  bar: { lowerBound: 0, upperBound: 1 },
+  __type: FILTER_TYPE.STANDARD,
+  foo: { __type: FILTER_TYPE.OPTION, selectedValues: ['x', 'y'] },
+  bar: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
 };
 
 const complexFilter = {
   __combineMode: 'OR',
-  foo: { selectedValues: ['x', 'y'] },
+  __type: FILTER_TYPE.STANDARD,
+  foo: { __type: FILTER_TYPE.OPTION, selectedValues: ['x', 'y'] },
   'lorem:ipsum': {
+    __type: FILTER_TYPE.ANCHORED,
     filter: {
-      bar: { lowerBound: 0, upperBound: 1 },
-      baz: { selectedValues: ['hello', 'world'] },
+      bar: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+      baz: { __type: FILTER_TYPE.OPTION, selectedValues: ['hello', 'world'] },
     },
   },
 };

--- a/docs/anchored_filters.md
+++ b/docs/anchored_filters.md
@@ -48,23 +48,31 @@ The following is the updated filter state data structure modeled in TypeScript:
 ```ts
 type OptionFilter = {
   __combineMode?: 'AND' | 'OR';
+  __type: 'OPTION';
   selectedValues: string[];
 };
 
 type RangeFilter = {
+  __type: 'RANGE';
   lowerBound: number;
   upperBound: number;
 };
 
-type SimpleFilterState = {
-  [fieldName: string]: OptionFilter | RangeFilter;
+type AnchoredFilterState = {
+  __type: 'ANCHORED';
+  value: {
+    [fieldName: string]: OptionFilter | RangeFilter;
+  };
 };
 
 type FilterState = {
-  [fieldNameOrAnchorLabel: string]:
-    | OptionFilter
-    | RangeFilter
-    | { filter: SimpleFilterState }; // for anchored filters
+  __combineMode?: 'AND' | 'OR';
+  value: {
+    [fieldNameOrAnchorLabel: string]:
+      | OptionFilter
+      | RangeFilter
+      | AnchoredFilterState; // for anchored filters
+  };
 };
 ```
 
@@ -77,18 +85,23 @@ The anchor label is used only if anchor value is set to be a non-empty value (i.
 ```ts
 const filterState: FilterState = {
   sex: {
+    __type: 'OPTION',
     selectedValues: ['Female'],
   },
   'disease_phase:Initial Diagnosis': {
-    filter: {
+    __type: 'ANCHORED',
+    value: {
       'histologies.histology_grade': {
+        __type: 'OPTION',
         selectedValues: ['Differentiating'],
       },
     },
   },
   'disease_phase:Relapse': {
-    filter: {
+    __type: 'ANCHORED',
+    value: {
       'tumor_assessments.tumor_classification': {
+        __type: 'OPTION',
         selectedValues: ['Primary'],
       },
     },

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -20,7 +20,6 @@ import {
  * @property {object} [adminAppliedPreFilters]
  * @property {string} [anchorValue]
  * @property {string} [className]
- * @property {FilterState} [explorerFilter]
  * @property {FilterState} filter
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
@@ -39,12 +38,11 @@ function ConnectedFilter({
   adminAppliedPreFilters = {},
   anchorValue,
   className = '',
-  filter,
+  filter = {},
   filterConfig,
   guppyConfig,
   hidden = false,
   hideZero = false,
-  explorerFilter = {},
   initialTabsOptions = {},
   onAnchorValueChange,
   onFilterChange,
@@ -94,7 +92,7 @@ function ConnectedFilter({
       disabledTooltipMessage={
         'This resource is currently disabled because you are exploring restricted data. You are limited to exploring cohorts of a size greater than or equal to the access limit.'
       }
-      explorerFilter={explorerFilter}
+      filter={filter}
       filterConfig={filterConfig}
       lockedTooltipMessage={`You may only view summary information for this project. You do not have ${guppyConfig.dataType}-level access.`}
       onAnchorValueChange={onAnchorValueChange}
@@ -111,7 +109,6 @@ ConnectedFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object,
   anchorValue: PropTypes.string,
   className: PropTypes.string,
-  explorerFilter: PropTypes.object,
   filter: PropTypes.object.isRequired,
   filterConfig: PropTypes.shape({
     anchor: PropTypes.shape({

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -479,12 +479,7 @@ function GuppyWrapper({
 
   /** @param {FilterState} filter */
   function handleFilterChange(filter) {
-    const userFilter = /** @type {FilterState} */ ({
-      __combineMode: filterState.__combineMode ?? 'AND',
-      ...filter,
-    });
-    const mergedFilter = mergeFilters(userFilter, adminAppliedPreFilters);
-    onFilterChange?.(mergedFilter);
+    onFilterChange?.(mergeFilters(filter, adminAppliedPreFilters));
   }
 
   return children({

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -195,8 +195,9 @@ function GuppyWrapper({
         for (const [fieldName, value] of Object.entries(group))
           receivedAggsData[fieldName] = value;
       const unfilteredAggsData =
-        Object.keys(filter).length === 0 ? receivedAggsData : unfiltered;
-
+        Object.keys(filter.value ?? {}).length === 0
+          ? receivedAggsData
+          : unfiltered;
       return {
         aggsData: excludeSelfFilterFromAggsData(receivedAggsData, filter),
         initialTabsOptions:

--- a/src/GuppyComponents/Utils/const.js
+++ b/src/GuppyComponents/Utils/const.js
@@ -15,4 +15,13 @@ export const FILE_DELIMITERS = {
   csv: ',',
 };
 
+export const FILTER_TYPE = {
+  /** @type {'ANCHORED'} */
+  ANCHORED: 'ANCHORED',
+  /** @type {'OPTION'} */
+  OPTION: 'OPTION',
+  /** @type {'RANGE'} */
+  RANGE: 'RANGE',
+};
+
 export { guppyUrl as GUPPY_URL } from '../../localconf';

--- a/src/GuppyComponents/Utils/const.js
+++ b/src/GuppyComponents/Utils/const.js
@@ -22,6 +22,8 @@ export const FILTER_TYPE = {
   OPTION: 'OPTION',
   /** @type {'RANGE'} */
   RANGE: 'RANGE',
+  /** @type {'STANDARD'} */
+  STANDARD: 'STANDARD',
 };
 
 export { guppyUrl as GUPPY_URL } from '../../localconf';

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -118,7 +118,7 @@ export function updateCountsInInitialTabsOptions(
         }
       }
 
-      const filter = filtersApplied.value[fieldName];
+      const filter = filtersApplied.value?.[fieldName];
       if (filter !== undefined && 'selectedValues' in filter)
         for (const key of filter.selectedValues) {
           const found = updatedTabsOptions[fieldName].histogram.find(

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -28,16 +28,16 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   for (const [key, adminFilterValues] of Object.entries(
     adminAppliedPreFilter
   )) {
-    if (key in userFilter) {
-      const userFilterValues = userFilter[key];
+    if (key in userFilter.value) {
+      const userFilterValues = userFilter.value[key];
 
       if ('selectedValues' in userFilterValues) {
         const userFilterSubset = userFilterValues.selectedValues.filter((x) =>
           adminFilterValues.selectedValues.includes(x)
         );
 
-        mergedFilterState[key] = {
-          ...mergedFilterState[key],
+        mergedFilterState.value[key] = {
+          ...mergedFilterState.value[key],
           selectedValues:
             userFilterSubset.length > 0
               ? // The user-applied filter is more exclusive than the admin-applied filter.
@@ -47,7 +47,7 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
         };
       }
     } else {
-      mergedFilterState[key] = adminFilterValues;
+      mergedFilterState.value[key] = adminFilterValues;
     }
   }
 
@@ -118,7 +118,7 @@ export function updateCountsInInitialTabsOptions(
         }
       }
 
-      const filter = filtersApplied[fieldName];
+      const filter = filtersApplied.value[fieldName];
       if (filter !== undefined && 'selectedValues' in filter)
         for (const key of filter.selectedValues) {
           const found = updatedTabsOptions[fieldName].histogram.find(

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -1,4 +1,5 @@
 import flat from 'flat';
+import { FILTER_TYPE } from './const';
 import { queryGuppyForRawData } from './queries';
 
 /** @typedef {import('../types').AggsCount} AggsCount */
@@ -19,7 +20,7 @@ import { queryGuppyForRawData } from './queries';
  * amount of data shown when combined, but an admin filter should always decrease
  * or keep constant the amount of data shown when combined with a user filter).
  * @param {FilterState} userFilter
- * @param {{ [x: string]: OptionFilter }} adminAppliedPreFilter
+ * @param {{ [x: string]: { selectedValues?: string[] } }} adminAppliedPreFilter
  * */
 export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   /** @type {FilterState} */
@@ -38,6 +39,7 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
 
         mergedFilterState.value[key] = {
           ...mergedFilterState.value[key],
+          __type: FILTER_TYPE.OPTION,
           selectedValues:
             userFilterSubset.length > 0
               ? // The user-applied filter is more exclusive than the admin-applied filter.
@@ -47,7 +49,10 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
         };
       }
     } else {
-      mergedFilterState.value[key] = adminFilterValues;
+      mergedFilterState.value[key] = {
+        __type: FILTER_TYPE.OPTION,
+        ...adminFilterValues,
+      };
     }
   }
 

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -406,7 +406,7 @@ export const getFilterSections = ({
  * @param {FilterState} filterResults
  */
 export function excludeSelfFilterFromAggsData(aggsData, filterResults) {
-  if (!filterResults) return aggsData;
+  if (filterResults?.value === undefined) return aggsData;
 
   /** @type {SimpleAggsData} */
   const resultAggsData = {};
@@ -417,8 +417,8 @@ export function excludeSelfFilterFromAggsData(aggsData, filterResults) {
     if (histogram !== undefined) {
       const fieldName = flatFieldName.replace('.histogram', '');
       resultAggsData[fieldName] = { histogram };
-      if (fieldName in filterResults) {
-        const filterValue = filterResults[fieldName];
+      if (fieldName in filterResults.value) {
+        const filterValue = filterResults.value[fieldName];
         resultAggsData[fieldName].histogram =
           filterValue.__type === FILTER_TYPE.OPTION
             ? histogram.filter(

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -32,7 +32,7 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
     if (key in userFilter.value) {
       const userFilterValues = userFilter.value[key];
 
-      if ('selectedValues' in userFilterValues) {
+      if (userFilterValues.__type === FILTER_TYPE.OPTION) {
         const userFilterSubset = userFilterValues.selectedValues.filter((x) =>
           adminFilterValues.selectedValues.includes(x)
         );
@@ -124,7 +124,7 @@ export function updateCountsInInitialTabsOptions(
       }
 
       const filter = filtersApplied.value?.[fieldName];
-      if (filter !== undefined && 'selectedValues' in filter)
+      if (filter !== undefined && filter.__type === FILTER_TYPE.OPTION)
         for (const key of filter.selectedValues) {
           const found = updatedTabsOptions[fieldName].histogram.find(
             (o) => o.key === key
@@ -420,7 +420,7 @@ export function excludeSelfFilterFromAggsData(aggsData, filterResults) {
       if (fieldName in filterResults) {
         const filterValue = filterResults[fieldName];
         resultAggsData[fieldName].histogram =
-          'selectedValues' in filterValue
+          filterValue.__type === FILTER_TYPE.OPTION
             ? histogram.filter(
                 ({ key }) =>
                   typeof key === 'string' &&

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -646,8 +646,8 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
  */
 export function getGQLFilter(filterState) {
   if (
-    filterState?.__type === undefined ||
-    filterState?.value === undefined ||
+    filterState === undefined ||
+    !('value' in filterState) ||
     Object.keys(filterState.value).length === 0
   )
     return undefined;

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import flat from 'flat';
 import papaparse from 'papaparse';
-import { FILE_DELIMITERS, GUPPY_URL } from './const';
+import { FILE_DELIMITERS, FILTER_TYPE, GUPPY_URL } from './const';
 
 /** @typedef {import('../types').AnchorConfig} AnchorConfig */
 /** @typedef {import('../types').AnchoredFilterState} AnchoredFilterState */
@@ -12,6 +12,7 @@ import { FILE_DELIMITERS, GUPPY_URL } from './const';
 /** @typedef {import('../types').GqlNestedAnchoredFilter} GqlNestedAnchoredFilter */
 /** @typedef {import('../types').GqlSimpleAndFilter} GqlSimpleAndFilter */
 /** @typedef {import('../types').GqlSort} GqlSort */
+/** @typedef {import('../types').EmptyFilter} EmptyFilter */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
 /** @typedef {import('../types').RangeFilter} RangeFilter */
 
@@ -552,7 +553,7 @@ export function queryGuppyForRawData({
 
 /**
  * @param {string} fieldName
- * @param {RangeFilter | OptionFilter} filterValues
+ * @param {EmptyFilter | OptionFilter | RangeFilter} filterValues
  * @returns {GqlInFilter | GqlSimpleAndFilter | undefined}
  */
 function parseSimpleFilter(fieldName, filterValues) {
@@ -562,7 +563,7 @@ function parseSimpleFilter(fieldName, filterValues) {
   if (filterValues === undefined) throw invalidFilterError;
 
   // a range-type filter
-  if ('lowerBound' in filterValues) {
+  if (filterValues.__type === FILTER_TYPE.RANGE) {
     const { lowerBound, upperBound } = filterValues;
     if (typeof lowerBound === 'number' && typeof upperBound === 'number')
       return {
@@ -574,7 +575,7 @@ function parseSimpleFilter(fieldName, filterValues) {
   }
 
   // an option-type filter
-  if ('selectedValues' in filterValues || '__combineMode' in filterValues) {
+  if (filterValues.__type === FILTER_TYPE.OPTION) {
     const { selectedValues, __combineMode } = filterValues;
     if (selectedValues?.length > 0)
       return __combineMode === 'AND'
@@ -616,24 +617,22 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
   for (const [filterKey, filterValues] of Object.entries(filterState.value)) {
     const [path, fieldName] = filterKey.split('.');
 
-    if (typeof filterValues !== 'string') {
-      const simpleFilter = parseSimpleFilter(fieldName, filterValues);
+    const simpleFilter = parseSimpleFilter(fieldName, filterValues);
 
-      if (simpleFilter !== undefined) {
-        if (!(path in nestedFilterIndices)) {
-          nestedFilterIndices[path] = nestedFilterIndex;
-          nestedFilters.push(
-            /** @type {GqlNestedAnchoredFilter} */ ({
-              nested: { path, AND: [anchorFilter, { [combineMode]: [] }] },
-            })
-          );
-          nestedFilterIndex += 1;
-        }
-
-        nestedFilters[nestedFilterIndices[path]].nested.AND[1][
-          combineMode
-        ].push(simpleFilter);
+    if (simpleFilter !== undefined) {
+      if (!(path in nestedFilterIndices)) {
+        nestedFilterIndices[path] = nestedFilterIndex;
+        nestedFilters.push(
+          /** @type {GqlNestedAnchoredFilter} */ ({
+            nested: { path, AND: [anchorFilter, { [combineMode]: [] }] },
+          })
+        );
+        nestedFilterIndex += 1;
       }
+
+      nestedFilters[nestedFilterIndices[path]].nested.AND[1][combineMode].push(
+        simpleFilter
+      );
     }
   }
 
@@ -646,7 +645,10 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
  * @returns {GqlFilter}
  */
 export function getGQLFilter(filterState) {
-  if (filterState === undefined || Object.keys(filterState).length === 0)
+  if (
+    filterState?.value === undefined ||
+    Object.keys(filterState.value).length === 0
+  )
     return undefined;
 
   /** @type {(GqlInFilter | GqlSimpleAndFilter)[]} */
@@ -664,7 +666,7 @@ export function getGQLFilter(filterState) {
     const isNestedField = nestedFieldStr !== undefined;
     const fieldName = isNestedField ? nestedFieldStr : fieldStr;
 
-    if ('filter' in filterValues) {
+    if (filterValues.__type === FILTER_TYPE.ANCHORED) {
       const parsedAnchoredFilters = parseAnchoredFilters(
         fieldName,
         filterValues,

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -601,7 +601,7 @@ function parseSimpleFilter(fieldName, filterValues) {
  * @returns {GqlNestedAnchoredFilter[]}
  */
 function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
-  const filterState = anchoredFilterState.filter;
+  const filterState = anchoredFilterState;
   if (filterState === undefined || Object.keys(filterState).length === 0)
     return undefined;
 

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -641,11 +641,12 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
 
 /**
  * Convert filter obj into GQL filter format
- * @param {FilterState} filterState
+ * @param {EmptyFilter | FilterState} filterState
  * @returns {GqlFilter}
  */
 export function getGQLFilter(filterState) {
   if (
+    filterState?.__type === undefined ||
     filterState?.value === undefined ||
     Object.keys(filterState.value).length === 0
   )

--- a/src/GuppyComponents/__tests__/filters.test.js
+++ b/src/GuppyComponents/__tests__/filters.test.js
@@ -7,12 +7,14 @@ import {
 } from '../Utils/filters';
 
 describe('can merge simple selectedValue filters', () => {
-  const userFilter = { data_format: { selectedValues: ['VCF'] } };
+  const userFilter = { value: { data_format: { selectedValues: ['VCF'] } } };
   const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins'] } };
 
   const mergedFilterExpected = {
-    project_id: { selectedValues: ['jnkns-jenkins'] },
-    data_format: { selectedValues: ['VCF'] },
+    value: {
+      project_id: { selectedValues: ['jnkns-jenkins'] },
+      data_format: { selectedValues: ['VCF'] },
+    },
   };
 
   test('merge filters', async () => {
@@ -23,19 +25,23 @@ describe('can merge simple selectedValue filters', () => {
 
 describe('can merge admin-provided selectedValue filters with user-provided range filters', () => {
   const userFilter = {
-    bmi: { lowerBound: 28, upperBound: 99 },
-    age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ['Aligned Reads'] },
+    value: {
+      bmi: { lowerBound: 28, upperBound: 99 },
+      age: { lowerBound: 26, upperBound: 33 },
+      data_type: { selectedValues: ['Aligned Reads'] },
+    },
   };
   const adminFilter = {
     project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
   };
 
   const mergedFilterExpected = {
-    project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
-    bmi: { lowerBound: 28, upperBound: 99 },
-    age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ['Aligned Reads'] },
+    value: {
+      project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
+      bmi: { lowerBound: 28, upperBound: 99 },
+      age: { lowerBound: 26, upperBound: 33 },
+      data_type: { selectedValues: ['Aligned Reads'] },
+    },
   };
 
   test('merge filters', async () => {
@@ -46,18 +52,22 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
 
 describe('will select user-applied filter for a given key if it is more exclusive than admin filter', () => {
   const userFilter = {
-    project_id: { selectedValues: ['jnkns-jenkins2'] },
-    age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ['Aligned Reads'] },
+    value: {
+      project_id: { selectedValues: ['jnkns-jenkins2'] },
+      age: { lowerBound: 26, upperBound: 33 },
+      data_type: { selectedValues: ['Aligned Reads'] },
+    },
   };
   const adminFilter = {
     project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
   };
 
   const mergedFilterExpected = {
-    project_id: { selectedValues: ['jnkns-jenkins2'] },
-    age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ['Aligned Reads'] },
+    value: {
+      project_id: { selectedValues: ['jnkns-jenkins2'] },
+      age: { lowerBound: 26, upperBound: 33 },
+      data_type: { selectedValues: ['Aligned Reads'] },
+    },
   };
 
   test('merge filters', async () => {
@@ -91,7 +101,11 @@ describe('can update a small set of tabs with new counts', () => {
     extra_data: { histogram: [] },
   };
 
-  const filtersApplied = { annotated_sex: { selectedValues: ['silver'] } };
+  const filtersApplied = {
+    value: {
+      annotated_sex: { selectedValues: ['silver'] },
+    },
+  };
 
   // Silver has a count of zero, but it is in the filter, so it should remain visible
   const expectedUpdatedTabsOptions = {
@@ -129,7 +143,13 @@ describe('can update a small set of tabs with new counts, test with ranger slide
       ],
     },
     field2: {
-      histogram: [{ key: [0, 100], count: 100 }],
+      histogram: [
+        {
+          /** @type {[number, number]} */
+          key: [0, 100],
+          count: 100,
+        },
+      ],
     },
   };
 
@@ -140,6 +160,7 @@ describe('can update a small set of tabs with new counts, test with ranger slide
     field2: {
       histogram: [
         {
+          /** @type {[number, number]} */
           key: [4, 39],
           count: 49,
         },
@@ -148,12 +169,14 @@ describe('can update a small set of tabs with new counts, test with ranger slide
   };
 
   const filtersApplied = {
-    field1: {
-      selectedValues: ['option2'],
-    },
-    field2: {
-      lowerBound: 4,
-      upperBound: 39,
+    value: {
+      field1: {
+        selectedValues: ['option2'],
+      },
+      field2: {
+        lowerBound: 4,
+        upperBound: 39,
+      },
     },
   };
 

--- a/src/GuppyComponents/__tests__/filters.test.js
+++ b/src/GuppyComponents/__tests__/filters.test.js
@@ -5,15 +5,19 @@ import {
   updateCountsInInitialTabsOptions,
   sortTabsOptions,
 } from '../Utils/filters';
+import { FILTER_TYPE } from '../Utils/const';
 
 describe('can merge simple selectedValue filters', () => {
-  const userFilter = { value: { data_format: { selectedValues: ['VCF'] } } };
+  const __type = FILTER_TYPE.OPTION;
+  const userFilter = {
+    value: { data_format: { __type, selectedValues: ['VCF'] } },
+  };
   const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins'] } };
 
   const mergedFilterExpected = {
     value: {
-      project_id: { selectedValues: ['jnkns-jenkins'] },
-      data_format: { selectedValues: ['VCF'] },
+      project_id: { __type, selectedValues: ['jnkns-jenkins'] },
+      data_format: { __type, selectedValues: ['VCF'] },
     },
   };
 
@@ -26,9 +30,12 @@ describe('can merge simple selectedValue filters', () => {
 describe('can merge admin-provided selectedValue filters with user-provided range filters', () => {
   const userFilter = {
     value: {
-      bmi: { lowerBound: 28, upperBound: 99 },
-      age: { lowerBound: 26, upperBound: 33 },
-      data_type: { selectedValues: ['Aligned Reads'] },
+      bmi: { __type: FILTER_TYPE.RANGE, lowerBound: 28, upperBound: 99 },
+      age: { __type: FILTER_TYPE.RANGE, lowerBound: 26, upperBound: 33 },
+      data_type: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['Aligned Reads'],
+      },
     },
   };
   const adminFilter = {
@@ -37,10 +44,16 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
 
   const mergedFilterExpected = {
     value: {
-      project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
-      bmi: { lowerBound: 28, upperBound: 99 },
-      age: { lowerBound: 26, upperBound: 33 },
-      data_type: { selectedValues: ['Aligned Reads'] },
+      project_id: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'],
+      },
+      bmi: { __type: FILTER_TYPE.RANGE, lowerBound: 28, upperBound: 99 },
+      age: { __type: FILTER_TYPE.RANGE, lowerBound: 26, upperBound: 33 },
+      data_type: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['Aligned Reads'],
+      },
     },
   };
 
@@ -53,9 +66,15 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
 describe('will select user-applied filter for a given key if it is more exclusive than admin filter', () => {
   const userFilter = {
     value: {
-      project_id: { selectedValues: ['jnkns-jenkins2'] },
-      age: { lowerBound: 26, upperBound: 33 },
-      data_type: { selectedValues: ['Aligned Reads'] },
+      project_id: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['jnkns-jenkins2'],
+      },
+      age: { __type: FILTER_TYPE.RANGE, lowerBound: 26, upperBound: 33 },
+      data_type: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['Aligned Reads'],
+      },
     },
   };
   const adminFilter = {
@@ -64,9 +83,15 @@ describe('will select user-applied filter for a given key if it is more exclusiv
 
   const mergedFilterExpected = {
     value: {
-      project_id: { selectedValues: ['jnkns-jenkins2'] },
-      age: { lowerBound: 26, upperBound: 33 },
-      data_type: { selectedValues: ['Aligned Reads'] },
+      project_id: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['jnkns-jenkins2'],
+      },
+      age: { __type: FILTER_TYPE.RANGE, lowerBound: 26, upperBound: 33 },
+      data_type: {
+        __type: FILTER_TYPE.OPTION,
+        selectedValues: ['Aligned Reads'],
+      },
     },
   };
 
@@ -103,7 +128,7 @@ describe('can update a small set of tabs with new counts', () => {
 
   const filtersApplied = {
     value: {
-      annotated_sex: { selectedValues: ['silver'] },
+      annotated_sex: { __type: FILTER_TYPE.OPTION, selectedValues: ['silver'] },
     },
   };
 
@@ -171,9 +196,11 @@ describe('can update a small set of tabs with new counts, test with ranger slide
   const filtersApplied = {
     value: {
       field1: {
+        __type: FILTER_TYPE.OPTION,
         selectedValues: ['option2'],
       },
       field2: {
+        __type: FILTER_TYPE.RANGE,
         lowerBound: 4,
         upperBound: 39,
       },

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -191,17 +191,15 @@ describe('Get GQL filter from filter object from', () => {
       value: {
         'x:y': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              'a.b': {
-                __type: FILTER_TYPE.OPTION,
-                selectedValues: ['foo', 'bar'],
-              },
-              'c.d': {
-                __type: FILTER_TYPE.RANGE,
-                lowerBound: 0,
-                upperBound: 1,
-              },
+          value: {
+            'a.b': {
+              __type: FILTER_TYPE.OPTION,
+              selectedValues: ['foo', 'bar'],
+            },
+            'c.d': {
+              __type: FILTER_TYPE.RANGE,
+              lowerBound: 0,
+              upperBound: 1,
             },
           },
         },

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -3,16 +3,27 @@ import {
   getQueryInfoForAggregationOptionsData,
 } from '../Utils/queries';
 
+/** @typedef {import('../types').CombineMode} CombineMode */
+
 describe('Get GQL filter from filter object from', () => {
   test('a simple option filter', async () => {
-    const filterState = { a: { selectedValues: ['foo', 'bar'] } };
+    const filterState = {
+      value: {
+        a: { selectedValues: ['foo', 'bar'] },
+      },
+    };
     const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
     expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
 
   test('a simple option filter with combine mode OR', () => {
     const filterState = {
-      a: { __combineMode: 'OR', selectedValues: ['foo', 'bar'] },
+      value: {
+        a: {
+          __combineMode: /** @type {CombineMode} */ ('OR'),
+          selectedValues: ['foo', 'bar'],
+        },
+      },
     };
     const gqlFilter = { AND: [{ IN: { a: ['foo', 'bar'] } }] };
     expect(getGQLFilter(filterState)).toEqual(gqlFilter);
@@ -20,7 +31,12 @@ describe('Get GQL filter from filter object from', () => {
 
   test('a simple option filter with combine mode AND', () => {
     const filterState = {
-      a: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
+      value: {
+        a: {
+          __combineMode: /** @type {CombineMode} */ ('AND'),
+          selectedValues: ['foo', 'bar'],
+        },
+      },
     };
     const gqlFilter = {
       AND: [{ AND: [{ IN: { a: ['foo'] } }, { IN: { a: ['bar'] } }] }],
@@ -29,7 +45,11 @@ describe('Get GQL filter from filter object from', () => {
   });
 
   test('a simple range filter', () => {
-    const filterState = { a: { lowerBound: 0, upperBound: 1 } };
+    const filterState = {
+      value: {
+        a: { lowerBound: 0, upperBound: 1 },
+      },
+    };
     const gqlFilter = {
       AND: [{ AND: [{ GTE: { a: 0 } }, { LTE: { a: 1 } }] }],
     };
@@ -38,10 +58,15 @@ describe('Get GQL filter from filter object from', () => {
 
   test('simple filters', () => {
     const filterState = {
-      __combineMode: 'OR',
-      a: { selectedValues: ['foo', 'bar'] },
-      b: { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
-      c: { lowerBound: 0, upperBound: 1 },
+      __combineMode: /** @type {CombineMode} */ ('OR'),
+      value: {
+        a: { selectedValues: ['foo', 'bar'] },
+        b: {
+          __combineMode: /** @type {CombineMode} */ ('AND'),
+          selectedValues: ['foo', 'bar'],
+        },
+        c: { lowerBound: 0, upperBound: 1 },
+      },
     };
     const gqlFilter = {
       OR: [
@@ -54,7 +79,13 @@ describe('Get GQL filter from filter object from', () => {
   });
 
   test('a combine mode only filter', () => {
-    const filterState = { a: { __combineMode: 'OR' } };
+    const filterState = {
+      value: {
+        a: {
+          __combineMode: /** @type {CombineMode} */ ('OR'),
+        },
+      },
+    };
     const gqlFilter = { AND: [] };
     expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
@@ -62,7 +93,7 @@ describe('Get GQL filter from filter object from', () => {
   test('an invalid filter', () => {
     const fieldName = 'a';
     const filterValue = {};
-    const filterState = { [fieldName]: filterValue };
+    const filterState = { value: { [fieldName]: filterValue } };
     expect(() => getGQLFilter(filterState)).toThrow(
       `Invalid filter object for "${fieldName}": ${JSON.stringify(filterValue)}`
     );
@@ -70,8 +101,10 @@ describe('Get GQL filter from filter object from', () => {
 
   test('a nested filter', () => {
     const filterState = {
-      __combineMode: 'OR',
-      'a.b': { selectedValues: ['foo', 'bar'] },
+      __combineMode: /** @type {CombineMode} */ ('OR'),
+      value: {
+        'a.b': { selectedValues: ['foo', 'bar'] },
+      },
     };
     const gqlFilter = {
       OR: [{ nested: { path: 'a', OR: [{ IN: { b: ['foo', 'bar'] } }] } }],
@@ -81,8 +114,10 @@ describe('Get GQL filter from filter object from', () => {
 
   test('nested filters with same parent path', () => {
     const filterState = {
-      'a.b': { selectedValues: ['foo', 'bar'] },
-      'a.c': { lowerBound: 0, upperBound: 1 },
+      value: {
+        'a.b': { selectedValues: ['foo', 'bar'] },
+        'a.c': { lowerBound: 0, upperBound: 1 },
+      },
     };
     const gqlFilter = {
       AND: [
@@ -102,8 +137,10 @@ describe('Get GQL filter from filter object from', () => {
 
   test('nested filters with different parent paths', () => {
     const filterState = {
-      'a.b': { selectedValues: ['foo', 'bar'] },
-      'c.d': { lowerBound: 0, upperBound: 1 },
+      value: {
+        'a.b': { selectedValues: ['foo', 'bar'] },
+        'c.d': { lowerBound: 0, upperBound: 1 },
+      },
     };
     const gqlFilter = {
       AND: [
@@ -126,11 +163,15 @@ describe('Get GQL filter from filter object from', () => {
 
   test('an anchored filter state', () => {
     const filterState = {
-      __combineMode: 'OR',
-      'x:y': {
-        filter: {
-          'a.b': { selectedValues: ['foo', 'bar'] },
-          'c.d': { lowerBound: 0, upperBound: 1 },
+      __combineMode: /** @type {CombineMode} */ ('OR'),
+      value: {
+        'x:y': {
+          filter: {
+            value: {
+              'a.b': { selectedValues: ['foo', 'bar'] },
+              'c.d': { lowerBound: 0, upperBound: 1 },
+            },
+          },
         },
       },
     };
@@ -169,11 +210,16 @@ describe('Get GQL filter from filter object from', () => {
 
   test('various filters', () => {
     const filterState = {
-      a: { selectedValues: ['foo', 'bar'] },
-      'b.c': { __combineMode: 'AND', selectedValues: ['foo', 'bar'] },
-      'b.d': { lowerBound: 0, upperBound: 1 },
-      e: { __combineMode: 'OR' },
-      'f.g': { lowerBound: 0, upperBound: 1 },
+      value: {
+        a: { selectedValues: ['foo', 'bar'] },
+        'b.c': {
+          __combineMode: /** @type {CombineMode} */ ('AND'),
+          selectedValues: ['foo', 'bar'],
+        },
+        'b.d': { lowerBound: 0, upperBound: 1 },
+        e: { __combineMode: /** @type {CombineMode} */ ('OR') },
+        'f.g': { lowerBound: 0, upperBound: 1 },
+      },
     };
     const gqlFilter = {
       AND: [

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -11,8 +11,10 @@ export type RangeFilter = {
 };
 
 export type SimpleFilterState = {
-  [x: Exclude<string, '__combineMode'>]: OptionFilter | RangeFilter;
   __combineMode?: CombineMode;
+  value: {
+    [x: string]: OptionFilter | RangeFilter;
+  };
 };
 
 export type AnchoredFilterState = {
@@ -20,11 +22,10 @@ export type AnchoredFilterState = {
 };
 
 export type FilterState = {
-  [x: Exclude<string, '__combineMode'>]:
-    | OptionFilter
-    | RangeFilter
-    | AnchoredFilterState;
   __combineMode?: CombineMode;
+  value: {
+    [x: string]: OptionFilter | RangeFilter | AnchoredFilterState;
+  };
 };
 
 export type GqlInFilter = {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -23,7 +23,9 @@ export type SimpleFilterState = {
 
 export type AnchoredFilterState = {
   __type: 'ANCHORED';
-  filter: SimpleFilterState;
+  value?: {
+    [x: string]: EmptyFilter | OptionFilter | RangeFilter;
+  };
 };
 
 export type FilterState = {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -14,24 +14,27 @@ export type RangeFilter = {
   upperBound?: number;
 };
 
+export type BaseFilter = EmptyFilter | OptionFilter | RangeFilter;
+
 export type SimpleFilterState = {
   __combineMode?: CombineMode;
   value?: {
-    [x: string]: EmptyFilter | OptionFilter | RangeFilter;
+    [x: string]: BaseFilter;
   };
 };
 
 export type AnchoredFilterState = {
   __type: 'ANCHORED';
   value?: {
-    [x: string]: EmptyFilter | OptionFilter | RangeFilter;
+    [x: string]: BaseFilter;
   };
 };
 
 export type FilterState = {
   __combineMode?: CombineMode;
+  __type?: 'STANDARD';
   value?: {
-    [x: string]: EmptyFilter | OptionFilter | RangeFilter | AnchoredFilterState;
+    [x: string]: BaseFilter | AnchoredFilterState;
   };
 };
 

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -1,6 +1,8 @@
+type CombineMode = 'AND' | 'OR';
+
 export type OptionFilter = {
   selectedValues?: string[];
-  __combineMode?: 'AND' | 'OR';
+  __combineMode?: CombineMode;
 };
 
 export type RangeFilter = {
@@ -10,7 +12,7 @@ export type RangeFilter = {
 
 export type SimpleFilterState = {
   [x: Exclude<string, '__combineMode'>]: OptionFilter | RangeFilter;
-  __combineMode?: 'AND' | 'OR';
+  __combineMode?: CombineMode;
 };
 
 export type AnchoredFilterState = {
@@ -22,7 +24,7 @@ export type FilterState = {
     | OptionFilter
     | RangeFilter
     | AnchoredFilterState;
-  __combineMode?: 'AND' | 'OR';
+  __combineMode?: CombineMode;
 };
 
 export type GqlInFilter = {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -12,7 +12,7 @@ export type RangeFilter = {
 
 export type SimpleFilterState = {
   __combineMode?: CombineMode;
-  value: {
+  value?: {
     [x: string]: OptionFilter | RangeFilter;
   };
 };
@@ -23,7 +23,7 @@ export type AnchoredFilterState = {
 
 export type FilterState = {
   __combineMode?: CombineMode;
-  value: {
+  value?: {
     [x: string]: OptionFilter | RangeFilter | AnchoredFilterState;
   };
 };

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -1,11 +1,15 @@
 type CombineMode = 'AND' | 'OR';
 
+export type EmptyFilter = { __type?: never };
+
 export type OptionFilter = {
-  selectedValues?: string[];
   __combineMode?: CombineMode;
+  __type: 'OPTION';
+  selectedValues?: string[];
 };
 
 export type RangeFilter = {
+  __type: 'RANGE';
   lowerBound?: number;
   upperBound?: number;
 };
@@ -13,18 +17,19 @@ export type RangeFilter = {
 export type SimpleFilterState = {
   __combineMode?: CombineMode;
   value?: {
-    [x: string]: OptionFilter | RangeFilter;
+    [x: string]: EmptyFilter | OptionFilter | RangeFilter;
   };
 };
 
 export type AnchoredFilterState = {
+  __type: 'ANCHORED';
   filter: SimpleFilterState;
 };
 
 export type FilterState = {
   __combineMode?: CombineMode;
   value?: {
-    [x: string]: OptionFilter | RangeFilter | AnchoredFilterState;
+    [x: string]: EmptyFilter | OptionFilter | RangeFilter | AnchoredFilterState;
   };
 };
 

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -16,13 +16,6 @@ export type RangeFilter = {
 
 export type BaseFilter = EmptyFilter | OptionFilter | RangeFilter;
 
-export type SimpleFilterState = {
-  __combineMode?: CombineMode;
-  value?: {
-    [x: string]: BaseFilter;
-  };
-};
-
 export type AnchoredFilterState = {
   __type: 'ANCHORED';
   value?: {

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -265,7 +265,7 @@ class ExplorerButtonGroup extends Component {
         selectedValues: refIDList,
       },
     };
-    if (this.props.filter.data_format) {
+    if (this.props.filter.value.data_format) {
       // @ts-ignore
       filter.data_format = this.props.filter.data_format;
     }

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import ConnectedFilter from '../../GuppyComponents/ConnectedFilter';
-import {
-  updateExplorerFilter,
-  updatePatientIds,
-} from '../../redux/explorer/slice';
+import { updatePatientIds } from '../../redux/explorer/slice';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import './ExplorerFilter.css';
 
@@ -24,17 +21,12 @@ import './ExplorerFilter.css';
 /** @param {ExplorerFilterProps} props */
 function ExplorerFilter({ className = '', ...filterProps }) {
   const dispatch = useAppDispatch();
-  /** @param {RootState['explorer']['explorerFilter']} filter */
-  function handleFilterChange(filter) {
-    dispatch(updateExplorerFilter(filter));
-  }
   /** @param {RootState['explorer']['patientIds']} ids */
   function handlePatientIdsChange(ids) {
     dispatch(updatePatientIds(ids));
   }
   const {
     config: { adminAppliedPreFilters, filterConfig, guppyConfig },
-    explorerFilter,
     patientIds,
   } = useAppSelector((state) => state.explorer);
 
@@ -43,7 +35,6 @@ function ExplorerFilter({ className = '', ...filterProps }) {
     adminAppliedPreFilters,
     filterConfig,
     guppyConfig,
-    explorerFilter,
     patientIds,
     onPatientIdsChange: handlePatientIdsChange,
   };
@@ -65,7 +56,7 @@ function ExplorerFilter({ className = '', ...filterProps }) {
           <button
             type='button'
             className='explorer-filter__clear-button'
-            onClick={() => handleFilterChange(undefined)}
+            onClick={() => filterProps.onFilterChange(undefined)}
           >
             Clear all
           </button>

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -47,7 +47,8 @@ function ExplorerFilter({ className = '', ...filterProps }) {
     patientIds,
     onPatientIdsChange: handlePatientIdsChange,
   };
-  const hasExplorerFilter = Object.keys(filterProps.filter).length > 0;
+  const hasExplorerFilter =
+    Object.keys(filterProps.filter.value ?? {}).length > 0;
   const filterCombineMode = filterProps.filter.__combineMode ?? 'AND';
   function updateFilterCombineMode(e) {
     filterProps.onFilterChange({

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -6,11 +6,16 @@
  * @param {ExplorerFilter} args.filter
  */
 export function pluckFromFilter({ field, filter }) {
-  const newFilter = {};
-  for (const [key, value] of Object.entries(filter))
-    if (key !== field) newFilter[key] = value;
+  /** @type {ExplorerFilter} */
+  const newFilter = { ...filter };
+  if (Object.keys(newFilter).length === 0) return newFilter;
 
-  return /** @type {ExplorerFilter} */ (newFilter);
+  newFilter.value = {};
+  for (const [key, value] of Object.entries(filter.value))
+    if (key !== field) newFilter.value[key] = value;
+
+  if (Object.keys(newFilter.value).length === 0) delete newFilter.value;
+  return newFilter;
 }
 
 /**
@@ -20,20 +25,27 @@ export function pluckFromFilter({ field, filter }) {
  * @param {ExplorerFilter} args.filter
  */
 export function pluckFromAnchorFilter({ anchor, field, filter }) {
-  const newFilter = {};
-  for (const [key, value] of Object.entries(filter))
-    if (key !== anchor) newFilter[key] = value;
-    else if (typeof value === 'object' && 'filter' in value) {
+  /** @type {ExplorerFilter} */
+  const newFilter = { ...filter };
+  if (Object.keys(newFilter).length === 0) return newFilter;
+
+  newFilter.value = {};
+  for (const [key, value] of Object.entries(filter.value))
+    if (key !== anchor) newFilter.value[key] = value;
+    else if ('filter' in value) {
       const newAnchorFilter = pluckFromFilter({ field, filter: value.filter });
-      if (Object.keys(newAnchorFilter).length > 0)
-        newFilter[key] = { filter: newAnchorFilter };
+      if (Object.keys(newAnchorFilter.value ?? {}).length > 0)
+        newFilter.value[key] =
+          /** @type {import('../../GuppyComponents/types').AnchoredFilterState} */ ({
+            filter: newAnchorFilter,
+          });
     }
 
-  return /** @type {ExplorerFilter} */ (newFilter);
+  if (Object.keys(newFilter.value).length === 0) delete newFilter.value;
+  return newFilter;
 }
 
 /** @param {ExplorerFilter} filter */
 export function checkIfFilterEmpty(filter) {
-  const { __combineMode, ..._filter } = filter;
-  return Object.keys(_filter).length === 0;
+  return Object.keys(filter.value ?? {}).length === 0;
 }

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -1,3 +1,7 @@
+import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
+
+export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
+
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 
 /**
@@ -32,11 +36,12 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
   newFilter.value = {};
   for (const [key, value] of Object.entries(filter.value))
     if (key !== anchor) newFilter.value[key] = value;
-    else if ('filter' in value) {
+    else if (value.__type === FILTER_TYPE.ANCHORED) {
       const newAnchorFilter = pluckFromFilter({ field, filter: value.filter });
       if (Object.keys(newAnchorFilter.value ?? {}).length > 0)
         newFilter.value[key] =
           /** @type {import('../../GuppyComponents/types').AnchoredFilterState} */ ({
+            __type: FILTER_TYPE.ANCHORED,
             filter: newAnchorFilter,
           });
     }

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -2,15 +2,16 @@ import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
 export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
+/** @typedef {import('../../GuppyComponents/types').AnchoredFilterState} AnchoredFilterState */
+/** @typedef {import('../../GuppyComponents/types').FilterState} FilterState */
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
-
 /**
+ * @template T
  * @param {Object} args
  * @param {string} args.field
- * @param {ExplorerFilter} args.filter
+ * @param {T extends AnchoredFilterState ? AnchoredFilterState : ExplorerFilter} args.filter
  */
-export function pluckFromFilter({ field, filter }) {
-  /** @type {ExplorerFilter} */
+function _pluckFromFilter({ field, filter }) {
   const newFilter = { ...filter };
   if (Object.keys(newFilter).length === 0) return newFilter;
 
@@ -21,6 +22,9 @@ export function pluckFromFilter({ field, filter }) {
   if (Object.keys(newFilter.value).length === 0) delete newFilter.value;
   return newFilter;
 }
+
+/** @type {typeof _pluckFromFilter<ExplorerFilter>} */
+export const pluckFromFilter = _pluckFromFilter;
 
 /**
  * @param {Object} args
@@ -37,13 +41,12 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
   for (const [key, value] of Object.entries(filter.value))
     if (key !== anchor) newFilter.value[key] = value;
     else if (value.__type === FILTER_TYPE.ANCHORED) {
-      const newAnchorFilter = pluckFromFilter({ field, filter: value });
+      const newAnchorFilter =
+        /** @type {typeof _pluckFromFilter<AnchoredFilterState>} */ (
+          _pluckFromFilter
+        )({ field, filter: value });
       if (Object.keys(newAnchorFilter.value ?? {}).length > 0)
-        newFilter.value[key] =
-          /** @type {import('../../GuppyComponents/types').AnchoredFilterState} */ ({
-            __type: FILTER_TYPE.ANCHORED,
-            value: newAnchorFilter.value,
-          });
+        newFilter.value[key] = newAnchorFilter;
     }
 
   if (Object.keys(newFilter.value).length === 0) delete newFilter.value;

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -37,12 +37,12 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
   for (const [key, value] of Object.entries(filter.value))
     if (key !== anchor) newFilter.value[key] = value;
     else if (value.__type === FILTER_TYPE.ANCHORED) {
-      const newAnchorFilter = pluckFromFilter({ field, filter: value.filter });
+      const newAnchorFilter = pluckFromFilter({ field, filter: value });
       if (Object.keys(newAnchorFilter.value ?? {}).length > 0)
         newFilter.value[key] =
           /** @type {import('../../GuppyComponents/types').AnchoredFilterState} */ ({
             __type: FILTER_TYPE.ANCHORED,
-            filter: newAnchorFilter,
+            value: newAnchorFilter.value,
           });
     }
 

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
@@ -1,4 +1,4 @@
-import { pluckFromFilter, pluckFromAnchorFilter } from './utils';
+import { FILTER_TYPE, pluckFromFilter, pluckFromAnchorFilter } from './utils';
 
 describe('pluckFromFilter', () => {
   test('no filter', () => {
@@ -61,7 +61,14 @@ describe('pluckFromAnchorFilter', () => {
     const received1 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { value: { 'x:y': { filter: { value: { foo: {} } } } } },
+      filter: {
+        value: {
+          'x:y': {
+            __type: FILTER_TYPE.ANCHORED,
+            filter: { value: { foo: {} } },
+          },
+        },
+      },
     });
     const expected1 = {};
     expect(received1).toStrictEqual(expected1);
@@ -69,15 +76,34 @@ describe('pluckFromAnchorFilter', () => {
     const received2 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { value: { 'x:y': { filter: { value: { foo: {}, bar: {} } } } } },
+      filter: {
+        value: {
+          'x:y': {
+            __type: FILTER_TYPE.ANCHORED,
+            filter: { value: { foo: {}, bar: {} } },
+          },
+        },
+      },
     });
-    const expected2 = { value: { 'x:y': { filter: { value: { bar: {} } } } } };
+    const expected2 = {
+      value: {
+        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+      },
+    };
     expect(received2).toStrictEqual(expected2);
 
     const received3 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { value: { foo: {}, 'x:y': { filter: { value: { foo: {} } } } } },
+      filter: {
+        value: {
+          foo: {},
+          'x:y': {
+            __type: FILTER_TYPE.ANCHORED,
+            filter: { value: { foo: {} } },
+          },
+        },
+      },
     });
     const expected3 = { value: { foo: {} } };
     expect(received3).toStrictEqual(expected3);
@@ -86,18 +112,40 @@ describe('pluckFromAnchorFilter', () => {
     const received1 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { value: { 'x:y': { filter: { value: { bar: {} } } } } },
+      filter: {
+        value: {
+          'x:y': {
+            __type: FILTER_TYPE.ANCHORED,
+            filter: { value: { bar: {} } },
+          },
+        },
+      },
     });
-    const expected1 = { value: { 'x:y': { filter: { value: { bar: {} } } } } };
+    const expected1 = {
+      value: {
+        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+      },
+    };
     expect(received1).toStrictEqual(expected1);
 
     const received2 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { value: { foo: {}, 'x:y': { filter: { value: { bar: {} } } } } },
+      filter: {
+        value: {
+          foo: {},
+          'x:y': {
+            __type: FILTER_TYPE.ANCHORED,
+            filter: { value: { bar: {} } },
+          },
+        },
+      },
     });
     const expected2 = {
-      value: { foo: {}, 'x:y': { filter: { value: { bar: {} } } } },
+      value: {
+        foo: {},
+        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+      },
     };
     expect(received2).toStrictEqual(expected2);
   });

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
@@ -9,31 +9,31 @@ describe('pluckFromFilter', () => {
   test('matching', () => {
     const received1 = pluckFromFilter({
       field: 'foo',
-      filter: { foo: {} },
+      filter: { value: { foo: {} } },
     });
     const expected1 = {};
     expect(received1).toStrictEqual(expected1);
 
     const received2 = pluckFromFilter({
       field: 'bar',
-      filter: { foo: {}, bar: {} },
+      filter: { value: { foo: {}, bar: {} } },
     });
-    const expected2 = { foo: {} };
+    const expected2 = { value: { foo: {} } };
     expect(received2).toStrictEqual(expected2);
   });
   test('missing', () => {
     const received1 = pluckFromFilter({
       field: 'bar',
-      filter: { foo: {} },
+      filter: { value: { foo: {} } },
     });
-    const expected1 = { foo: {} };
+    const expected1 = { value: { foo: {} } };
     expect(received1).toStrictEqual(expected1);
 
     const received2 = pluckFromFilter({
       field: 'baz',
-      filter: { foo: {}, bar: {} },
+      filter: { value: { foo: {}, bar: {} } },
     });
-    const expected2 = { foo: {}, bar: {} };
+    const expected2 = { value: { foo: {}, bar: {} } };
     expect(received2).toStrictEqual(expected2);
   });
 });
@@ -52,16 +52,16 @@ describe('pluckFromAnchorFilter', () => {
     const received = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { foo: {} },
+      filter: { value: { foo: {} } },
     });
-    const expected = { foo: {} };
+    const expected = { value: { foo: {} } };
     expect(received).toStrictEqual(expected);
   });
   test('matching', () => {
     const received1 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { 'x:y': { filter: { foo: {} } } },
+      filter: { value: { 'x:y': { filter: { value: { foo: {} } } } } },
     });
     const expected1 = {};
     expect(received1).toStrictEqual(expected1);
@@ -69,34 +69,36 @@ describe('pluckFromAnchorFilter', () => {
     const received2 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { 'x:y': { filter: { foo: {}, bar: {} } } },
+      filter: { value: { 'x:y': { filter: { value: { foo: {}, bar: {} } } } } },
     });
-    const expected2 = { 'x:y': { filter: { bar: {} } } };
+    const expected2 = { value: { 'x:y': { filter: { value: { bar: {} } } } } };
     expect(received2).toStrictEqual(expected2);
 
     const received3 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { foo: {}, 'x:y': { filter: { foo: {} } } },
+      filter: { value: { foo: {}, 'x:y': { filter: { value: { foo: {} } } } } },
     });
-    const expected3 = { foo: {} };
+    const expected3 = { value: { foo: {} } };
     expect(received3).toStrictEqual(expected3);
   });
   test('missing', () => {
     const received1 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { 'x:y': { filter: { bar: {} } } },
+      filter: { value: { 'x:y': { filter: { value: { bar: {} } } } } },
     });
-    const expected1 = { 'x:y': { filter: { bar: {} } } };
+    const expected1 = { value: { 'x:y': { filter: { value: { bar: {} } } } } };
     expect(received1).toStrictEqual(expected1);
 
     const received2 = pluckFromAnchorFilter({
       anchor: 'x:y',
       field: 'foo',
-      filter: { foo: {}, 'x:y': { filter: { bar: {} } } },
+      filter: { value: { foo: {}, 'x:y': { filter: { value: { bar: {} } } } } },
     });
-    const expected2 = { foo: {}, 'x:y': { filter: { bar: {} } } };
+    const expected2 = {
+      value: { foo: {}, 'x:y': { filter: { value: { bar: {} } } } },
+    };
     expect(received2).toStrictEqual(expected2);
   });
 });

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.test.js
@@ -65,7 +65,7 @@ describe('pluckFromAnchorFilter', () => {
         value: {
           'x:y': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: { value: { foo: {} } },
+            value: { foo: {} },
           },
         },
       },
@@ -80,14 +80,14 @@ describe('pluckFromAnchorFilter', () => {
         value: {
           'x:y': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: { value: { foo: {}, bar: {} } },
+            value: { foo: {}, bar: {} },
           },
         },
       },
     });
     const expected2 = {
       value: {
-        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+        'x:y': { __type: FILTER_TYPE.ANCHORED, value: { bar: {} } },
       },
     };
     expect(received2).toStrictEqual(expected2);
@@ -100,7 +100,7 @@ describe('pluckFromAnchorFilter', () => {
           foo: {},
           'x:y': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: { value: { foo: {} } },
+            value: { foo: {} },
           },
         },
       },
@@ -116,14 +116,14 @@ describe('pluckFromAnchorFilter', () => {
         value: {
           'x:y': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: { value: { bar: {} } },
+            value: { bar: {} },
           },
         },
       },
     });
     const expected1 = {
       value: {
-        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+        'x:y': { __type: FILTER_TYPE.ANCHORED, value: { bar: {} } },
       },
     };
     expect(received1).toStrictEqual(expected1);
@@ -136,7 +136,7 @@ describe('pluckFromAnchorFilter', () => {
           foo: {},
           'x:y': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: { value: { bar: {} } },
+            value: { bar: {} },
           },
         },
       },
@@ -144,7 +144,7 @@ describe('pluckFromAnchorFilter', () => {
     const expected2 = {
       value: {
         foo: {},
-        'x:y': { __type: FILTER_TYPE.ANCHORED, filter: { value: { bar: {} } } },
+        'x:y': { __type: FILTER_TYPE.ANCHORED, value: { bar: {} } },
       },
     };
     expect(received2).toStrictEqual(expected2);

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -15,6 +15,7 @@ import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
 import ReduxExplorerButtonGroup from '../ExplorerButtonGroup/ReduxExplorerButtonGroup';
 import './ExplorerVisualization.css';
+import { FILTER_TYPE } from '../ExplorerFilterSetWorkspace/utils';
 
 /** @typedef {import('../types').ChartConfig} ChartConfig */
 /** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
@@ -74,11 +75,11 @@ function getChartData({
       const { histogram } = aggsChartData[field];
       switch (type) {
         case 'count': {
-          const optionFilter = filter[field];
+          const optionFilter = filter.value[field];
           countItems.push({
             label: title,
             value:
-              'selectedValues' in optionFilter
+              optionFilter.__type === FILTER_TYPE.OPTION
                 ? optionFilter.selectedValues.length
                 : histogram.length,
           });

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -78,7 +78,7 @@ function FilterDisplay({
   onCloseFilter,
 }) {
   const filterElements = /** @type {JSX.Element[]} */ ([]);
-  const { __combineMode, ...__filter } = filter;
+  const { __combineMode, value: __filter } = filter;
   const filterCombineMode = combineMode ?? __combineMode ?? 'AND';
 
   const handleClickCombineMode =

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
+import { FILTER_TYPE } from '../GuppyComponents/Utils/const';
 import './FilterDisplay.css';
 
 /**
@@ -107,7 +108,7 @@ function FilterDisplay({
       : undefined;
 
   for (const [key, value] of Object.entries(__filter))
-    if ('filter' in value) {
+    if (value.__type === FILTER_TYPE.ANCHORED) {
       const [anchorField, anchorValue] = key.split(':');
       filterElements.push(
         <Pill key={key} className='pill anchor'>
@@ -119,7 +120,7 @@ function FilterDisplay({
             ({' '}
             <FilterDisplay
               anchorInfo={[anchorField, anchorValue]}
-              filter={value.filter}
+              filter={value}
               filterInfo={filterInfo}
               combineMode={__combineMode}
               onClickCombineMode={onClickCombineMode}
@@ -130,7 +131,7 @@ function FilterDisplay({
           </span>
         </Pill>
       );
-    } else if ('selectedValues' in value) {
+    } else if (value.__type === FILTER_TYPE.OPTION) {
       filterElements.push(
         <Pill
           key={key}
@@ -160,7 +161,7 @@ function FilterDisplay({
           </span>
         </Pill>
       );
-    } else if ('lowerBound' in value) {
+    } else if (value.__type === FILTER_TYPE.RANGE) {
       filterElements.push(
         <Pill
           key={key}

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -1,4 +1,5 @@
 import {
+  FILTER_TYPE,
   getExpandedStatus,
   getFilterResultsByAnchor,
   getFilterStatus,
@@ -37,16 +38,16 @@ describe('Get filter results by anchor label', () => {
     const received = getFilterResultsByAnchor({
       filterResults: {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          y: { lowerBound: 0, upperBound: 1 },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
     });
     const expected = {
       '': {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          y: { lowerBound: 0, upperBound: 1 },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
     };
@@ -62,16 +63,16 @@ describe('Get filter results by anchor label', () => {
       anchorConfig,
       filterResults: {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          y: { lowerBound: 0, upperBound: 1 },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
     });
     const expected = {
       '': {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          y: { lowerBound: 0, upperBound: 1 },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
       'a:a0': { value: {} },
@@ -85,10 +86,11 @@ describe('Get filter results by anchor label', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'] },
-                y: { lowerBound: 0, upperBound: 1 },
+                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
+                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
               },
             },
           },
@@ -99,8 +101,8 @@ describe('Get filter results by anchor label', () => {
       '': { value: {} },
       'a:a0': {
         value: {
-          x: { selectedValues: ['foo'] },
-          y: { lowerBound: 0, upperBound: 1 },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
       'a:a1': { value: {} },
@@ -113,14 +115,18 @@ describe('Get filter results by anchor label', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
-              value: { x: { selectedValues: ['foo'] } },
+              value: {
+                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
+              },
             },
           },
           'a:a1': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                y: { lowerBound: 0, upperBound: 1 },
+                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
               },
             },
           },
@@ -131,12 +137,12 @@ describe('Get filter results by anchor label', () => {
       '': { value: {} },
       'a:a0': {
         value: {
-          x: { selectedValues: ['foo'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
         },
       },
       'a:a1': {
         value: {
-          y: { lowerBound: 0, upperBound: 1 },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         },
       },
     };
@@ -146,14 +152,20 @@ describe('Get filter results by anchor label', () => {
 
 describe('Get filter status from filter results', () => {
   test('Single tab, single option filter', () => {
-    const filterResults = { value: { x: { selectedValues: ['foo', 'bar'] } } };
+    const filterResults = {
+      value: {
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+      },
+    };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
     const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[{ foo: true, bar: true }]];
     expect(filerStatus).toEqual(expected);
   });
   test('Single tab, single range filter', () => {
-    const filterResults = { value: { x: { lowerBound: 0, upperBound: 1 } } };
+    const filterResults = {
+      value: { x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 } },
+    };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
     const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[[0, 1]]];
@@ -162,8 +174,8 @@ describe('Get filter status from filter results', () => {
   test('Single tab, multiple filters', () => {
     const filterResults = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+        y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
       },
     };
     const filterTabs = [{ title: 'a', fields: ['x', 'y'] }];
@@ -174,9 +186,9 @@ describe('Get filter status from filter results', () => {
   test('Multiple tabs', () => {
     const filterResults = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
-        z: { selectedValues: ['baz'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+        y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+        z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
       },
     };
     const filterTabs = [
@@ -196,13 +208,19 @@ describe('Get filter status from filter results', () => {
     const filterResults = {
       value: {
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
-            value: { x: { selectedValues: ['foo', 'bar'] } },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+            },
           },
         },
         'a:a1': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
-            value: { y: { lowerBound: 0, upperBound: 1 } },
+            value: {
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+            },
           },
         },
       },
@@ -231,15 +249,19 @@ describe('Get filter status from filter results', () => {
     const filterResults = {
       value: {
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
-            value: { x: { selectedValues: ['foo', 'bar'] } },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+            },
           },
         },
         'a:a1': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
-              y: { lowerBound: 0, upperBound: 1 },
-              z: { selectedValues: ['baz'] },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
             },
           },
         },
@@ -276,19 +298,21 @@ describe('Get filter status from filter results', () => {
     };
     const filterResults = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
-              y: { lowerBound: 0, upperBound: 1 },
-              z: { selectedValues: ['baz'] },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
             },
           },
         },
         'a:a1': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
-              z: { selectedValues: ['baz'] },
+              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
             },
           },
         },
@@ -334,9 +358,9 @@ describe('Clear a single filter section', () => {
   function helper({
     filterResults = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
-        z: { selectedValues: ['baz'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+        y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+        z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
       },
     },
     filterStatus = [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]],
@@ -366,8 +390,8 @@ describe('Clear a single filter section', () => {
       filterStatus: [[{}, { baz: true }], [[0, 1]]],
       filterResults: {
         value: {
-          y: { lowerBound: 0, upperBound: 1 },
-          z: { selectedValues: ['baz'] },
+          y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+          z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
         },
       },
     };
@@ -382,8 +406,8 @@ describe('Clear a single filter section', () => {
       filterStatus: [[{ foo: true, bar: true }, { baz: true }], [{}]],
       filterResults: {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          z: { selectedValues: ['baz'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
         },
       },
     };
@@ -393,11 +417,14 @@ describe('Clear a single filter section', () => {
     const cleared = helper({
       filterResults: {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          z: { selectedValues: ['baz'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
-              value: { y: { lowerBound: 0, upperBound: 1 } },
+              value: {
+                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+              },
             },
           },
         },
@@ -417,8 +444,8 @@ describe('Clear a single filter section', () => {
       ],
       filterResults: {
         value: {
-          x: { selectedValues: ['foo', 'bar'] },
-          z: { selectedValues: ['baz'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
         },
       },
     };
@@ -430,15 +457,15 @@ describe('Remove empty filter in filter results', () => {
   test('Single empty filter', () => {
     const removed = removeEmptyFilter({
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         y: {},
-        z: { __combineMode: 'AND' },
+        z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
       },
     });
     const expected = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
-        z: { __combineMode: 'AND' },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+        z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
       },
     };
     expect(removed).toEqual(expected);
@@ -447,13 +474,13 @@ describe('Remove empty filter in filter results', () => {
     const removed = removeEmptyFilter({
       value: {
         x: {},
-        y: { lowerBound: 0, upperBound: 1 },
+        y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
         z: {},
       },
     });
     const expected = {
       value: {
-        y: { lowerBound: 0, upperBound: 1 },
+        y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
       },
     };
     expect(removed).toEqual(expected);
@@ -462,11 +489,12 @@ describe('Remove empty filter in filter results', () => {
     const removed = removeEmptyFilter({
       value: {
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
               x: {},
-              y: { lowerBound: 0, upperBound: 1 },
-              z: { __combineMode: 'AND' },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+              z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
             },
           },
         },
@@ -475,10 +503,11 @@ describe('Remove empty filter in filter results', () => {
     const expected = {
       value: {
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
-              y: { lowerBound: 0, upperBound: 1 },
-              z: { __combineMode: 'AND' },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+              z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
             },
           },
         },
@@ -490,6 +519,7 @@ describe('Remove empty filter in filter results', () => {
     const removed = removeEmptyFilter({
       value: {
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
               x: {},
@@ -505,13 +535,14 @@ describe('Remove empty filter in filter results', () => {
   test('Empty filters with and without anchor', () => {
     const removed = removeEmptyFilter({
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         y: {},
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
               x: {},
-              y: { lowerBound: 0, upperBound: 1 },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -519,11 +550,12 @@ describe('Remove empty filter in filter results', () => {
     });
     const expected = {
       value: {
-        x: { selectedValues: ['foo', 'bar'] },
+        x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         'a:a0': {
+          __type: FILTER_TYPE.ANCHORED,
           filter: {
             value: {
-              y: { lowerBound: 0, upperBound: 1 },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -561,7 +593,7 @@ describe('Check if a tab has active filter', () => {
   });
 });
 
-describe('Toggles combine mode in option filter', () => {
+describe.only('Toggles combine mode in option filter', () => {
   /**
    * @param {Object} args
    * @param {FilterStatus} args.filterStatus
@@ -591,7 +623,7 @@ describe('Toggles combine mode in option filter', () => {
       filterStatus: [[{ foo: true }]],
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
         },
       },
       combineModeValue: 'OR',
@@ -599,7 +631,11 @@ describe('Toggles combine mode in option filter', () => {
     const expected = {
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'], __combineMode: 'OR' },
+          x: {
+            __combineMode: 'OR',
+            __type: FILTER_TYPE.OPTION,
+            selectedValues: ['foo'],
+          },
         },
       },
       filterStatus: [[{ foo: true, __combineMode: 'OR' }]],
@@ -611,7 +647,11 @@ describe('Toggles combine mode in option filter', () => {
       filterStatus: [[{ foo: true, __combineMode: 'OR' }]],
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'], __combineMode: 'OR' },
+          x: {
+            __combineMode: 'OR',
+            __type: FILTER_TYPE.OPTION,
+            selectedValues: ['foo'],
+          },
         },
       },
       combineModeValue: 'AND',
@@ -619,7 +659,11 @@ describe('Toggles combine mode in option filter', () => {
     const expected = {
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'], __combineMode: 'AND' },
+          x: {
+            __combineMode: 'AND',
+            __type: FILTER_TYPE.OPTION,
+            selectedValues: ['foo'],
+          },
         },
       },
       filterStatus: [[{ foo: true, __combineMode: 'AND' }]],
@@ -632,9 +676,10 @@ describe('Toggles combine mode in option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'] },
+                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
               },
             },
           },
@@ -647,9 +692,14 @@ describe('Toggles combine mode in option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'], __combineMode: 'AND' },
+                x: {
+                  __combineMode: 'AND',
+                  __type: FILTER_TYPE.OPTION,
+                  selectedValues: ['foo'],
+                },
               },
             },
           },
@@ -672,9 +722,10 @@ describe('Toggles combine mode in option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { __combineMode: 'AND' },
+                x: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
               },
             },
           },
@@ -692,9 +743,14 @@ describe('Toggles combine mode in option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'], __combineMode: 'OR' },
+                x: {
+                  __combineMode: 'OR',
+                  __type: FILTER_TYPE.OPTION,
+                  selectedValues: ['foo'],
+                },
               },
             },
           },
@@ -707,9 +763,14 @@ describe('Toggles combine mode in option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'], __combineMode: 'AND' },
+                x: {
+                  __combineMode: 'AND',
+                  __type: FILTER_TYPE.OPTION,
+                  selectedValues: ['foo'],
+                },
               },
             },
           },
@@ -737,7 +798,7 @@ describe('Update a range filter', () => {
     filterStatus = [[[0, 1]]],
     filterResults = {
       value: {
-        x: { lowerBound: 0, upperBound: 1 },
+        x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
       },
     },
     anchorLabel,
@@ -765,7 +826,9 @@ describe('Update a range filter', () => {
     });
     const expected = {
       filterResults: {
-        value: { x: { lowerBound: 1, upperBound: 2 } },
+        value: {
+          x: { __type: FILTER_TYPE.RANGE, lowerBound: 1, upperBound: 2 },
+        },
       },
       filterStatus: [[[1, 2]]],
     };
@@ -788,9 +851,10 @@ describe('Update a range filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { lowerBound: 0, upperBound: 1 },
+                x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
               },
             },
           },
@@ -804,9 +868,10 @@ describe('Update a range filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { lowerBound: 1, upperBound: 2 },
+                x: { __type: FILTER_TYPE.RANGE, lowerBound: 1, upperBound: 2 },
               },
             },
           },
@@ -844,9 +909,10 @@ describe('Update a range filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { lowerBound: 0, upperBound: 1 },
+                x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
               },
             },
           },
@@ -892,7 +958,7 @@ describe('Update an option filter', () => {
     const expected = {
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
         },
       },
       filterStatus: [[{ foo: true }]],
@@ -904,7 +970,7 @@ describe('Update an option filter', () => {
       filterStatus: [[{ foo: true }]],
       filterResults: {
         value: {
-          x: { selectedValues: ['foo'] },
+          x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
         },
       },
       selectedValue: 'foo',
@@ -926,9 +992,10 @@ describe('Update an option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'] },
+                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
               },
             },
           },
@@ -944,9 +1011,10 @@ describe('Update an option filter', () => {
       filterResults: {
         value: {
           'a:a0': {
+            __type: FILTER_TYPE.ANCHORED,
             filter: {
               value: {
-                x: { selectedValues: ['foo'] },
+                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
               },
             },
           },

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -36,14 +36,18 @@ describe('Get filter results by anchor label', () => {
   test('Missing anchor config', () => {
     const received = getFilterResultsByAnchor({
       filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
       },
     });
     const expected = {
       '': {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
       },
     };
     expect(received).toEqual(expected);
@@ -57,17 +61,21 @@ describe('Get filter results by anchor label', () => {
     const received = getFilterResultsByAnchor({
       anchorConfig,
       filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
       },
     });
     const expected = {
       '': {
-        x: { selectedValues: ['foo', 'bar'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
       },
-      'a:a0': {},
-      'a:a1': {},
+      'a:a0': { value: {} },
+      'a:a1': { value: {} },
     };
     expect(received).toEqual(expected);
   });
@@ -75,21 +83,27 @@ describe('Get filter results by anchor label', () => {
     const received = getFilterResultsByAnchor({
       anchorConfig,
       filterResults: {
-        'a:a0': {
-          filter: {
-            x: { selectedValues: ['foo'] },
-            y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'] },
+                y: { lowerBound: 0, upperBound: 1 },
+              },
+            },
           },
         },
       },
     });
     const expected = {
-      '': {},
+      '': { value: {} },
       'a:a0': {
-        x: { selectedValues: ['foo'] },
-        y: { lowerBound: 0, upperBound: 1 },
+        value: {
+          x: { selectedValues: ['foo'] },
+          y: { lowerBound: 0, upperBound: 1 },
+        },
       },
-      'a:a1': {},
+      'a:a1': { value: {} },
     };
     expect(received).toEqual(expected);
   });
@@ -97,14 +111,34 @@ describe('Get filter results by anchor label', () => {
     const received = getFilterResultsByAnchor({
       anchorConfig,
       filterResults: {
-        'a:a0': { filter: { x: { selectedValues: ['foo'] } } },
-        'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: { x: { selectedValues: ['foo'] } },
+            },
+          },
+          'a:a1': {
+            filter: {
+              value: {
+                y: { lowerBound: 0, upperBound: 1 },
+              },
+            },
+          },
+        },
       },
     });
     const expected = {
-      '': {},
-      'a:a0': { x: { selectedValues: ['foo'] } },
-      'a:a1': { y: { lowerBound: 0, upperBound: 1 } },
+      '': { value: {} },
+      'a:a0': {
+        value: {
+          x: { selectedValues: ['foo'] },
+        },
+      },
+      'a:a1': {
+        value: {
+          y: { lowerBound: 0, upperBound: 1 },
+        },
+      },
     };
     expect(received).toEqual(expected);
   });
@@ -112,14 +146,14 @@ describe('Get filter results by anchor label', () => {
 
 describe('Get filter status from filter results', () => {
   test('Single tab, single option filter', () => {
-    const filterResults = { x: { selectedValues: ['foo', 'bar'] } };
+    const filterResults = { value: { x: { selectedValues: ['foo', 'bar'] } } };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
     const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[{ foo: true, bar: true }]];
     expect(filerStatus).toEqual(expected);
   });
   test('Single tab, single range filter', () => {
-    const filterResults = { x: { lowerBound: 0, upperBound: 1 } };
+    const filterResults = { value: { x: { lowerBound: 0, upperBound: 1 } } };
     const filterTabs = [{ title: 'a', fields: ['x'] }];
     const filerStatus = getFilterStatus({ filterResults, filterTabs });
     const expected = [[[0, 1]]];
@@ -127,8 +161,10 @@ describe('Get filter status from filter results', () => {
   });
   test('Single tab, multiple filters', () => {
     const filterResults = {
-      x: { selectedValues: ['foo', 'bar'] },
-      y: { lowerBound: 0, upperBound: 1 },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+      },
     };
     const filterTabs = [{ title: 'a', fields: ['x', 'y'] }];
     const filerStatus = getFilterStatus({ filterResults, filterTabs });
@@ -137,9 +173,11 @@ describe('Get filter status from filter results', () => {
   });
   test('Multiple tabs', () => {
     const filterResults = {
-      x: { selectedValues: ['foo', 'bar'] },
-      y: { lowerBound: 0, upperBound: 1 },
-      z: { selectedValues: ['baz'] },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+        z: { selectedValues: ['baz'] },
+      },
     };
     const filterTabs = [
       { title: 'a', fields: ['x', 'z'] },
@@ -156,8 +194,18 @@ describe('Get filter status from filter results', () => {
       tabs: ['t'],
     };
     const filterResults = {
-      'a:a0': { filter: { x: { selectedValues: ['foo', 'bar'] } } },
-      'a:a1': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+      value: {
+        'a:a0': {
+          filter: {
+            value: { x: { selectedValues: ['foo', 'bar'] } },
+          },
+        },
+        'a:a1': {
+          filter: {
+            value: { y: { lowerBound: 0, upperBound: 1 } },
+          },
+        },
+      },
     };
     const filterTabs = [{ title: 't', fields: ['x', 'y'] }];
     const filerStatus = getFilterStatus({
@@ -181,11 +229,19 @@ describe('Get filter status from filter results', () => {
       tabs: ['t0', 't1'],
     };
     const filterResults = {
-      'a:a0': { filter: { x: { selectedValues: ['foo', 'bar'] } } },
-      'a:a1': {
-        filter: {
-          y: { lowerBound: 0, upperBound: 1 },
-          z: { selectedValues: ['baz'] },
+      value: {
+        'a:a0': {
+          filter: {
+            value: { x: { selectedValues: ['foo', 'bar'] } },
+          },
+        },
+        'a:a1': {
+          filter: {
+            value: {
+              y: { lowerBound: 0, upperBound: 1 },
+              z: { selectedValues: ['baz'] },
+            },
+          },
         },
       },
     };
@@ -219,16 +275,22 @@ describe('Get filter status from filter results', () => {
       tabs: ['t1', 't2'],
     };
     const filterResults = {
-      x: { selectedValues: ['foo', 'bar'] },
-      'a:a0': {
-        filter: {
-          y: { lowerBound: 0, upperBound: 1 },
-          z: { selectedValues: ['baz'] },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        'a:a0': {
+          filter: {
+            value: {
+              y: { lowerBound: 0, upperBound: 1 },
+              z: { selectedValues: ['baz'] },
+            },
+          },
         },
-      },
-      'a:a1': {
-        filter: {
-          z: { selectedValues: ['baz'] },
+        'a:a1': {
+          filter: {
+            value: {
+              z: { selectedValues: ['baz'] },
+            },
+          },
         },
       },
     };
@@ -271,9 +333,11 @@ describe('Clear a single filter section', () => {
    */
   function helper({
     filterResults = {
-      x: { selectedValues: ['foo', 'bar'] },
-      y: { lowerBound: 0, upperBound: 1 },
-      z: { selectedValues: ['baz'] },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: { lowerBound: 0, upperBound: 1 },
+        z: { selectedValues: ['baz'] },
+      },
     },
     filterStatus = [[{ foo: true, bar: true }, { baz: true }], [[0, 1]]],
     filterTabs = [
@@ -301,8 +365,10 @@ describe('Clear a single filter section', () => {
     const expected = {
       filterStatus: [[{}, { baz: true }], [[0, 1]]],
       filterResults: {
-        y: { lowerBound: 0, upperBound: 1 },
-        z: { selectedValues: ['baz'] },
+        value: {
+          y: { lowerBound: 0, upperBound: 1 },
+          z: { selectedValues: ['baz'] },
+        },
       },
     };
     expect(cleared).toEqual(expected);
@@ -315,8 +381,10 @@ describe('Clear a single filter section', () => {
     const expected = {
       filterStatus: [[{ foo: true, bar: true }, { baz: true }], [{}]],
       filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        z: { selectedValues: ['baz'] },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          z: { selectedValues: ['baz'] },
+        },
       },
     };
     expect(cleared).toEqual(expected);
@@ -324,9 +392,15 @@ describe('Clear a single filter section', () => {
   test('Anchored filter', () => {
     const cleared = helper({
       filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        z: { selectedValues: ['baz'] },
-        'a:a0': { filter: { y: { lowerBound: 0, upperBound: 1 } } },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          z: { selectedValues: ['baz'] },
+          'a:a0': {
+            filter: {
+              value: { y: { lowerBound: 0, upperBound: 1 } },
+            },
+          },
+        },
       },
       filterStatus: [
         [{ foo: true, bar: true }, { baz: true }],
@@ -342,8 +416,10 @@ describe('Clear a single filter section', () => {
         { '': [{}], 'a:a0': [{}] },
       ],
       filterResults: {
-        x: { selectedValues: ['foo', 'bar'] },
-        z: { selectedValues: ['baz'] },
+        value: {
+          x: { selectedValues: ['foo', 'bar'] },
+          z: { selectedValues: ['baz'] },
+        },
       },
     };
     expect(cleared).toEqual(expected);
@@ -353,42 +429,58 @@ describe('Clear a single filter section', () => {
 describe('Remove empty filter in filter results', () => {
   test('Single empty filter', () => {
     const removed = removeEmptyFilter({
-      x: { selectedValues: ['foo', 'bar'] },
-      y: {},
-      z: { __combineMode: 'AND' },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: {},
+        z: { __combineMode: 'AND' },
+      },
     });
     const expected = {
-      x: { selectedValues: ['foo', 'bar'] },
-      z: { __combineMode: 'AND' },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        z: { __combineMode: 'AND' },
+      },
     };
     expect(removed).toEqual(expected);
   });
   test('Multiple empty filters', () => {
     const removed = removeEmptyFilter({
-      x: {},
-      y: { lowerBound: 0, upperBound: 1 },
-      z: {},
+      value: {
+        x: {},
+        y: { lowerBound: 0, upperBound: 1 },
+        z: {},
+      },
     });
     const expected = {
-      y: { lowerBound: 0, upperBound: 1 },
+      value: {
+        y: { lowerBound: 0, upperBound: 1 },
+      },
     };
     expect(removed).toEqual(expected);
   });
   test('Single empty filter with anchor', () => {
     const removed = removeEmptyFilter({
-      'a:a0': {
-        filter: {
-          x: {},
-          y: { lowerBound: 0, upperBound: 1 },
-          z: { __combineMode: 'AND' },
+      value: {
+        'a:a0': {
+          filter: {
+            value: {
+              x: {},
+              y: { lowerBound: 0, upperBound: 1 },
+              z: { __combineMode: 'AND' },
+            },
+          },
         },
       },
     });
     const expected = {
-      'a:a0': {
-        filter: {
-          y: { lowerBound: 0, upperBound: 1 },
-          z: { __combineMode: 'AND' },
+      value: {
+        'a:a0': {
+          filter: {
+            value: {
+              y: { lowerBound: 0, upperBound: 1 },
+              z: { __combineMode: 'AND' },
+            },
+          },
         },
       },
     };
@@ -396,32 +488,44 @@ describe('Remove empty filter in filter results', () => {
   });
   test('Empty filters only with anchor', () => {
     const removed = removeEmptyFilter({
-      'a:a0': {
-        filter: {
-          x: {},
-          y: {},
+      value: {
+        'a:a0': {
+          filter: {
+            value: {
+              x: {},
+              y: {},
+            },
+          },
         },
       },
     });
-    const expected = {};
+    const expected = { value: {} };
     expect(removed).toEqual(expected);
   });
   test('Empty filters with and without anchor', () => {
     const removed = removeEmptyFilter({
-      x: { selectedValues: ['foo', 'bar'] },
-      y: {},
-      'a:a0': {
-        filter: {
-          x: {},
-          y: { lowerBound: 0, upperBound: 1 },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        y: {},
+        'a:a0': {
+          filter: {
+            value: {
+              x: {},
+              y: { lowerBound: 0, upperBound: 1 },
+            },
+          },
         },
       },
     });
     const expected = {
-      x: { selectedValues: ['foo', 'bar'] },
-      'a:a0': {
-        filter: {
-          y: { lowerBound: 0, upperBound: 1 },
+      value: {
+        x: { selectedValues: ['foo', 'bar'] },
+        'a:a0': {
+          filter: {
+            value: {
+              y: { lowerBound: 0, upperBound: 1 },
+            },
+          },
         },
       },
     };
@@ -485,11 +589,19 @@ describe('Toggles combine mode in option filter', () => {
   test('Missing combine mode', () => {
     const updated = helper({
       filterStatus: [[{ foo: true }]],
-      filterResults: { x: { selectedValues: ['foo'] } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'] },
+        },
+      },
       combineModeValue: 'OR',
     });
     const expected = {
-      filterResults: { x: { selectedValues: ['foo'], __combineMode: 'OR' } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'], __combineMode: 'OR' },
+        },
+      },
       filterStatus: [[{ foo: true, __combineMode: 'OR' }]],
     };
     expect(updated).toEqual(expected);
@@ -497,11 +609,19 @@ describe('Toggles combine mode in option filter', () => {
   test('Existing combine mode', () => {
     const updated = helper({
       filterStatus: [[{ foo: true, __combineMode: 'OR' }]],
-      filterResults: { x: { selectedValues: ['foo'], __combineMode: 'OR' } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'], __combineMode: 'OR' },
+        },
+      },
       combineModeValue: 'AND',
     });
     const expected = {
-      filterResults: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'], __combineMode: 'AND' },
+        },
+      },
       filterStatus: [[{ foo: true, __combineMode: 'AND' }]],
     };
     expect(updated).toEqual(expected);
@@ -509,14 +629,30 @@ describe('Toggles combine mode in option filter', () => {
   test('Missing combine mode in anchored filter', () => {
     const updated = helper({
       filterStatus: [{ '': [{}], 'a:a0': [{ foo: true }] }],
-      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      filterResults: {
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'] },
+              },
+            },
+          },
+        },
+      },
       anchorLabel: 'a:a0',
       combineModeValue: 'AND',
     });
     const expected = {
       filterResults: {
-        'a:a0': {
-          filter: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'], __combineMode: 'AND' },
+              },
+            },
+          },
         },
       },
       filterStatus: [
@@ -528,12 +664,22 @@ describe('Toggles combine mode in option filter', () => {
   test('Missing anchored filter', () => {
     const updated = helper({
       filterStatus: [{ '': [{}], 'a:a0': [{}] }],
-      filterResults: {},
+      filterResults: { value: {} },
       anchorLabel: 'a:a0',
       combineModeValue: 'AND',
     });
     const expected = {
-      filterResults: { 'a:a0': { filter: { x: { __combineMode: 'AND' } } } },
+      filterResults: {
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { __combineMode: 'AND' },
+              },
+            },
+          },
+        },
+      },
       filterStatus: [{ '': [{}], 'a:a0': [{ __combineMode: 'AND' }] }],
     };
     expect(updated).toEqual(expected);
@@ -544,8 +690,14 @@ describe('Toggles combine mode in option filter', () => {
         { '': [{}], 'a:a0': [{ foo: true, __combineMode: 'OR' }] },
       ],
       filterResults: {
-        'a:a0': {
-          filter: { x: { selectedValues: ['foo'], __combineMode: 'OR' } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'], __combineMode: 'OR' },
+              },
+            },
+          },
         },
       },
       anchorLabel: 'a:a0',
@@ -553,8 +705,14 @@ describe('Toggles combine mode in option filter', () => {
     });
     const expected = {
       filterResults: {
-        'a:a0': {
-          filter: { x: { selectedValues: ['foo'], __combineMode: 'AND' } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'], __combineMode: 'AND' },
+              },
+            },
+          },
         },
       },
       filterStatus: [
@@ -577,7 +735,11 @@ describe('Update a range filter', () => {
    */
   function helper({
     filterStatus = [[[0, 1]]],
-    filterResults = { x: { lowerBound: 0, upperBound: 1 } },
+    filterResults = {
+      value: {
+        x: { lowerBound: 0, upperBound: 1 },
+      },
+    },
     anchorLabel,
     lowerBound,
     upperBound,
@@ -602,7 +764,9 @@ describe('Update a range filter', () => {
       upperBound: 2,
     });
     const expected = {
-      filterResults: { x: { lowerBound: 1, upperBound: 2 } },
+      filterResults: {
+        value: { x: { lowerBound: 1, upperBound: 2 } },
+      },
       filterStatus: [[[1, 2]]],
     };
     expect(updated).toEqual(expected);
@@ -613,7 +777,7 @@ describe('Update a range filter', () => {
       upperBound: maxValue,
     });
     const expected = {
-      filterResults: {},
+      filterResults: { value: {} },
       filterStatus: [[[minValue, maxValue]]],
     };
     expect(updated).toEqual(expected);
@@ -622,7 +786,15 @@ describe('Update a range filter', () => {
     const updated = helper({
       filterStatus: [{ 'a:a0': [[0, 1]] }],
       filterResults: {
-        'a:a0': { filter: { x: { lowerBound: 0, upperBound: 1 } } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { lowerBound: 0, upperBound: 1 },
+              },
+            },
+          },
+        },
       },
       anchorLabel: 'a:a0',
       lowerBound: 1,
@@ -630,7 +802,15 @@ describe('Update a range filter', () => {
     });
     const expected = {
       filterResults: {
-        'a:a0': { filter: { x: { lowerBound: 1, upperBound: 2 } } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { lowerBound: 1, upperBound: 2 },
+              },
+            },
+          },
+        },
       },
       filterStatus: [{ 'a:a0': [[1, 2]] }],
     };
@@ -639,14 +819,20 @@ describe('Update a range filter', () => {
   test('Simple update in missing anchored filter', () => {
     const updated = helper({
       filterStatus: [{ 'a:a0': [{}] }],
-      filterResults: {},
+      filterResults: { value: {} },
       anchorLabel: 'a:a0',
       lowerBound: 1,
       upperBound: 2,
     });
     const expected = {
       filterResults: {
-        'a:a0': { filter: { x: { lowerBound: 1, upperBound: 2 } } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: { x: { lowerBound: 1, upperBound: 2 } },
+            },
+          },
+        },
       },
       filterStatus: [{ 'a:a0': [[1, 2]] }],
     };
@@ -656,14 +842,22 @@ describe('Update a range filter', () => {
     const updated = helper({
       filterStatus: [{ 'a:a0': [[0, 1]] }],
       filterResults: {
-        'a:a0': { filter: { x: { lowerBound: 0, upperBound: 1 } } },
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { lowerBound: 0, upperBound: 1 },
+              },
+            },
+          },
+        },
       },
       anchorLabel: 'a:a0',
       lowerBound: minValue,
       upperBound: maxValue,
     });
     const expected = {
-      filterResults: {},
+      filterResults: { value: {} },
       filterStatus: [{ 'a:a0': [[minValue, maxValue]] }],
     };
     expect(updated).toEqual(expected);
@@ -692,11 +886,15 @@ describe('Update an option filter', () => {
   test('Select value', () => {
     const updated = helper({
       filterStatus: [[{}]],
-      filterResults: {},
+      filterResults: { value: {} },
       selectedValue: 'foo',
     });
     const expected = {
-      filterResults: { x: { selectedValues: ['foo'] } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'] },
+        },
+      },
       filterStatus: [[{ foo: true }]],
     };
     expect(updated).toEqual(expected);
@@ -704,11 +902,15 @@ describe('Update an option filter', () => {
   test('Unselect value', () => {
     const updated = helper({
       filterStatus: [[{ foo: true }]],
-      filterResults: { x: { selectedValues: ['foo'] } },
+      filterResults: {
+        value: {
+          x: { selectedValues: ['foo'] },
+        },
+      },
       selectedValue: 'foo',
     });
     const expected = {
-      filterResults: {},
+      filterResults: { value: {} },
       filterStatus: [[{ foo: false }]],
     };
     expect(updated).toEqual(expected);
@@ -716,12 +918,22 @@ describe('Update an option filter', () => {
   test('Select value in anchored filter', () => {
     const updated = helper({
       filterStatus: [{ 'a:a0': [{}] }],
-      filterResults: {},
+      filterResults: { value: {} },
       anchorLabel: 'a:a0',
       selectedValue: 'foo',
     });
     const expected = {
-      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      filterResults: {
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'] },
+              },
+            },
+          },
+        },
+      },
       filterStatus: [{ 'a:a0': [{ foo: true }] }],
     };
     expect(updated).toEqual(expected);
@@ -729,12 +941,22 @@ describe('Update an option filter', () => {
   test('Unselect value in anchored filter', () => {
     const updated = helper({
       filterStatus: [{ 'a:a0': [{ foo: true }] }],
-      filterResults: { 'a:a0': { filter: { x: { selectedValues: ['foo'] } } } },
+      filterResults: {
+        value: {
+          'a:a0': {
+            filter: {
+              value: {
+                x: { selectedValues: ['foo'] },
+              },
+            },
+          },
+        },
+      },
       anchorLabel: 'a:a0',
       selectedValue: 'foo',
     });
     const expected = {
-      filterResults: {},
+      filterResults: { value: {} },
       filterStatus: [{ 'a:a0': [{ foo: false }] }],
     };
     expect(updated).toEqual(expected);

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -87,11 +87,9 @@ describe('Get filter results by anchor label', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
-                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -116,18 +114,14 @@ describe('Get filter results by anchor label', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
             },
           },
           'a:a1': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              },
+            value: {
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -209,18 +203,14 @@ describe('Get filter status from filter results', () => {
       value: {
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
-            },
+          value: {
+            x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
           },
         },
         'a:a1': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-            },
+          value: {
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
           },
         },
       },
@@ -250,19 +240,15 @@ describe('Get filter status from filter results', () => {
       value: {
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
-            },
+          value: {
+            x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
           },
         },
         'a:a1': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
-            },
+          value: {
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+            z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
           },
         },
       },
@@ -301,19 +287,15 @@ describe('Get filter status from filter results', () => {
         x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
-            },
+          value: {
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+            z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
           },
         },
         'a:a1': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
-            },
+          value: {
+            z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
           },
         },
       },
@@ -421,10 +403,8 @@ describe('Clear a single filter section', () => {
           z: { __type: FILTER_TYPE.OPTION, selectedValues: ['baz'] },
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              },
+            value: {
+              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -490,12 +470,10 @@ describe('Remove empty filter in filter results', () => {
       value: {
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              x: {},
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
-            },
+          value: {
+            x: {},
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+            z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
           },
         },
       },
@@ -504,11 +482,9 @@ describe('Remove empty filter in filter results', () => {
       value: {
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
-            },
+          value: {
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+            z: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
           },
         },
       },
@@ -520,11 +496,9 @@ describe('Remove empty filter in filter results', () => {
       value: {
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              x: {},
-              y: {},
-            },
+          value: {
+            x: {},
+            y: {},
           },
         },
       },
@@ -539,11 +513,9 @@ describe('Remove empty filter in filter results', () => {
         y: {},
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              x: {},
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-            },
+          value: {
+            x: {},
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
           },
         },
       },
@@ -553,10 +525,8 @@ describe('Remove empty filter in filter results', () => {
         x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
         'a:a0': {
           __type: FILTER_TYPE.ANCHORED,
-          filter: {
-            value: {
-              y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-            },
+          value: {
+            y: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
           },
         },
       },
@@ -593,7 +563,7 @@ describe('Check if a tab has active filter', () => {
   });
 });
 
-describe.only('Toggles combine mode in option filter', () => {
+describe('Toggles combine mode in option filter', () => {
   /**
    * @param {Object} args
    * @param {FilterStatus} args.filterStatus
@@ -677,10 +647,8 @@ describe.only('Toggles combine mode in option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
             },
           },
         },
@@ -693,13 +661,11 @@ describe.only('Toggles combine mode in option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: {
-                  __combineMode: 'AND',
-                  __type: FILTER_TYPE.OPTION,
-                  selectedValues: ['foo'],
-                },
+            value: {
+              x: {
+                __combineMode: 'AND',
+                __type: FILTER_TYPE.OPTION,
+                selectedValues: ['foo'],
               },
             },
           },
@@ -723,10 +689,8 @@ describe.only('Toggles combine mode in option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
-              },
+            value: {
+              x: { __combineMode: 'AND', __type: FILTER_TYPE.OPTION },
             },
           },
         },
@@ -744,13 +708,11 @@ describe.only('Toggles combine mode in option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: {
-                  __combineMode: 'OR',
-                  __type: FILTER_TYPE.OPTION,
-                  selectedValues: ['foo'],
-                },
+            value: {
+              x: {
+                __combineMode: 'OR',
+                __type: FILTER_TYPE.OPTION,
+                selectedValues: ['foo'],
               },
             },
           },
@@ -764,13 +726,11 @@ describe.only('Toggles combine mode in option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: {
-                  __combineMode: 'AND',
-                  __type: FILTER_TYPE.OPTION,
-                  selectedValues: ['foo'],
-                },
+            value: {
+              x: {
+                __combineMode: 'AND',
+                __type: FILTER_TYPE.OPTION,
+                selectedValues: ['foo'],
               },
             },
           },
@@ -852,10 +812,8 @@ describe('Update a range filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -869,10 +827,8 @@ describe('Update a range filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.RANGE, lowerBound: 1, upperBound: 2 },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.RANGE, lowerBound: 1, upperBound: 2 },
             },
           },
         },
@@ -893,8 +849,9 @@ describe('Update a range filter', () => {
       filterResults: {
         value: {
           'a:a0': {
-            filter: {
-              value: { x: { lowerBound: 1, upperBound: 2 } },
+            __type: FILTER_TYPE.ANCHORED,
+            value: {
+              x: { __type: FILTER_TYPE.RANGE, lowerBound: 1, upperBound: 2 },
             },
           },
         },
@@ -910,10 +867,8 @@ describe('Update a range filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
             },
           },
         },
@@ -993,10 +948,8 @@ describe('Update an option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
             },
           },
         },
@@ -1012,10 +965,8 @@ describe('Update an option filter', () => {
         value: {
           'a:a0': {
             __type: FILTER_TYPE.ANCHORED,
-            filter: {
-              value: {
-                x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
-              },
+            value: {
+              x: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo'] },
             },
           },
         },

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -8,6 +8,7 @@ import FilterSection from '../FilterSection';
 import PatientIdFilter from '../PatientIdFilter';
 import {
   clearFilterSection,
+  FILTER_TYPE,
   getExpandedStatus,
   getFilterStatus,
   getSelectedAnchors,
@@ -182,7 +183,7 @@ function FilterGroup({
     const field = filterTabs[tabIndex].fields[sectionIndex];
     const filterValues = filterResults[field];
     if (
-      'selectedValues' in filterValues &&
+      filterValues.__type === FILTER_TYPE.OPTION &&
       filterValues.selectedValues.length > 0
     )
       onFilterChange(updated.filterResults);

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -32,6 +32,7 @@ function findFilterElement(label) {
     }
 }
 
+/** @typedef {import('../types').EmptyFilter} EmptyFilter */
 /** @typedef {import('../types').FilterChangeHandler} FilterChangeHandler */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').FilterState} FilterState */
@@ -42,7 +43,7 @@ function findFilterElement(label) {
  * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {string} [disabledTooltipMessage]
- * @property {FilterState} [explorerFilter]
+ * @property {EmptyFilter | FilterState} [explorerFilter]
  * @property {FilterConfig} filterConfig
  * @property {boolean} [hideZero]
  * @property {string} [lockedTooltipMessage]
@@ -53,7 +54,6 @@ function findFilterElement(label) {
  * @property {FilterSectionConfig[][]} tabs
  */
 
-/** @type {FilterState} */
 const defaultExplorerFilter = {};
 
 /** @param {FilterGroupProps} props */

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -43,7 +43,7 @@ function findFilterElement(label) {
  * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {string} [disabledTooltipMessage]
- * @property {EmptyFilter | FilterState} [explorerFilter]
+ * @property {EmptyFilter | FilterState} [filter]
  * @property {FilterConfig} filterConfig
  * @property {boolean} [hideZero]
  * @property {string} [lockedTooltipMessage]
@@ -63,7 +63,7 @@ function FilterGroup({
   disabledTooltipMessage,
   filterConfig,
   hideZero = true,
-  explorerFilter = defaultExplorerFilter,
+  filter = defaultExplorerFilter,
   lockedTooltipMessage,
   onAnchorValueChange = () => {},
   onFilterChange = () => {},
@@ -99,11 +99,11 @@ function FilterGroup({
     getExpandedStatus(filterTabs, false)
   );
 
-  const [filterResults, setFilterResults] = useState(explorerFilter);
+  const [filterResults, setFilterResults] = useState(filter);
   const [filterStatus, setFilterStatus] = useState(
     getFilterStatus({
       anchorConfig: filterConfig.anchor,
-      filterResults: explorerFilter,
+      filterResults: filter,
       filterTabs,
     })
   );
@@ -116,14 +116,14 @@ function FilterGroup({
 
     const newFilterStatus = getFilterStatus({
       anchorConfig: filterConfig.anchor,
-      filterResults: explorerFilter,
+      filterResults: filter,
       filterTabs,
     });
-    const newFilterResults = explorerFilter;
+    const newFilterResults = filter;
 
     setFilterStatus(newFilterStatus);
     setFilterResults(newFilterResults);
-  }, [explorerFilter]);
+  }, [filter]);
 
   const filterTabStatus = showAnchorFilter
     ? filterStatus[tabIndex][anchorLabel]
@@ -378,7 +378,7 @@ FilterGroup.propTypes = {
   anchorValue: PropTypes.string,
   className: PropTypes.string,
   disabledTooltipMessage: PropTypes.string,
-  explorerFilter: PropTypes.object,
+  filter: PropTypes.object,
   filterConfig: PropTypes.shape({
     anchor: PropTypes.shape({
       field: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -11,7 +11,6 @@ export { FILTER_TYPE } from '../../../../GuppyComponents/Utils/const';
 /** @typedef {import('../types').FilterStatus} FilterStatus */
 /** @typedef {import('../types').FilterTabsOption} FilterTabsOption */
 /** @typedef {import('../types').FilterTabStatus} FilterTabStatus */
-/** @typedef {import('../types').SimpleFilterState} SimpleFilterState */
 /** @typedef {import('../types').BaseFilter} BaseFilter */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
 
@@ -53,7 +52,7 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
 
 /**
  * @param {string[]} fields
- * @param {SimpleFilterState} filterResults
+ * @param {FilterState} filterResults
  * @returns {FilterTabStatus}
  */
 function getFilterTabStatus(fields, filterResults) {

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -61,13 +61,13 @@ function getFilterTabStatus(fields, filterResults) {
   return fields.map((field) => {
     if (field in filterResults.value) {
       const filterValues = filterResults.value[field];
-      if ('selectedValues' in filterValues) {
+      if (filterValues.__type === FILTER_TYPE.OPTION) {
         const status = {};
         for (const selected of filterValues.selectedValues)
           status[selected] = true;
         return status;
       }
-      if ('lowerBound' in filterValues) {
+      if (filterValues.__type === FILTER_TYPE.RANGE) {
         return [filterValues.lowerBound, filterValues.upperBound];
       }
     }

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -32,7 +32,7 @@ export function getExpandedStatus(filterTabs, expandedStatusControl) {
  * @param {FilterState} args.filterResults
  */
 export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
-  /** @type {{ [anchorLabel: string]: SimpleFilterState }} */
+  /** @type {{ [anchorLabel: string]: AnchoredFilterState['value'] }} */
   const filterResultsByAnchor = { '': { value: {} } };
 
   if (anchorConfig !== undefined)
@@ -44,7 +44,7 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
   if (filterResults.value !== undefined)
     for (const [filterKey, filterValues] of Object.entries(filterResults.value))
       if (filterValues.__type === FILTER_TYPE.ANCHORED) {
-        filterResultsByAnchor[filterKey] = filterValues.filter;
+        filterResultsByAnchor[filterKey].value = filterValues.value;
       } else {
         filterResultsByAnchor[''].value[filterKey] = filterValues;
       }
@@ -107,13 +107,13 @@ export function removeEmptyFilter(filterResults) {
   for (const field of Object.keys(filterResults.value)) {
     const filterValues = filterResults.value[field];
     if (filterValues.__type === FILTER_TYPE.ANCHORED) {
-      const newAnchoredFilterResults = /** @type {SimpleFilterState} */ (
-        removeEmptyFilter(filterValues.filter)
+      const newAnchoredFilterResults = /** @type {AnchoredFilterState} */ (
+        removeEmptyFilter(filterValues)
       );
       if (Object.keys(newAnchoredFilterResults.value).length > 0)
         newFilterResults.value[field] = {
           __type: FILTER_TYPE.ANCHORED,
-          filter: newAnchoredFilterResults,
+          value: newAnchoredFilterResults.value,
         };
     } else {
       const hasRangeFilter = filterValues.__type === FILTER_TYPE.RANGE;
@@ -163,9 +163,11 @@ export function clearFilterSection({
   if (anchorLabel === undefined || anchorLabel === '') {
     newFilterResults.value[fieldName] = /** @type {BasicFilter} */ ({});
   } else {
+    console.log('newFilterResults', newFilterResults);
+
     /** @type {AnchoredFilterState} */ (
       newFilterResults.value[anchorLabel]
-    ).filter.value[fieldName] = /** @type {BasicFilter} */ ({});
+    ).value[fieldName] = /** @type {BasicFilter} */ ({});
   }
   newFilterResults = removeEmptyFilter(newFilterResults);
 
@@ -237,22 +239,22 @@ export function updateCombineMode({
     if (!(anchorLabel in newFilterResults.value))
       newFilterResults.value[anchorLabel] = {
         __type: FILTER_TYPE.ANCHORED,
-        filter: { value: {} },
+        value: {},
       };
-    if (!('filter' in newFilterResults.value[anchorLabel]))
+    if (newFilterResults.value[anchorLabel].__type !== FILTER_TYPE.ANCHORED)
       /** @type {AnchoredFilterState} */ (
         newFilterResults.value[anchorLabel]
-      ).filter.value = {};
+      ).value = {};
     const newAnchoredFilterResults = /** @type {AnchoredFilterState} */ (
       newFilterResults.value[anchorLabel]
     );
-    if (newAnchoredFilterResults.filter.value[fieldName] === undefined) {
-      newAnchoredFilterResults.filter.value[fieldName] = {
+    if (newAnchoredFilterResults.value[fieldName] === undefined) {
+      newAnchoredFilterResults.value[fieldName] = {
         [combineModeFieldName]: combineModeValue,
         __type: FILTER_TYPE.OPTION,
       };
     } else {
-      newAnchoredFilterResults.filter.value[fieldName][combineModeFieldName] =
+      newAnchoredFilterResults.value[fieldName][combineModeFieldName] =
         combineModeValue;
     }
   }
@@ -322,15 +324,15 @@ export function updateRangeValue({
     if (!(anchorLabel in newFilterResults.value))
       newFilterResults.value[anchorLabel] = {
         __type: FILTER_TYPE.ANCHORED,
-        filter: { value: {} },
+        value: {},
       };
     if (newFilterResults.value[anchorLabel].__type !== FILTER_TYPE.ANCHORED)
       /** @type {AnchoredFilterState} */ (
         newFilterResults.value[anchorLabel]
-      ).filter.value = {};
+      ).value = {};
     const newAnchoredFilterResults = /** @type {AnchoredFilterState} */ (
       newFilterResults.value[anchorLabel]
-    ).filter;
+    );
     newAnchoredFilterResults.value[fieldName] = {
       __type: FILTER_TYPE.RANGE,
       lowerBound,
@@ -418,15 +420,15 @@ export function updateSelectedValue({
     if (!(anchorLabel in newFilterResults.value))
       newFilterResults.value[anchorLabel] = {
         __type: FILTER_TYPE.ANCHORED,
-        filter: { value: {} },
+        value: {},
       };
     if (newFilterResults.value[anchorLabel].__type !== FILTER_TYPE.ANCHORED)
       /** @type {AnchoredFilterState} */ (
         newFilterResults.value[anchorLabel]
-      ).filter.value = {};
+      ).value = {};
     const newAnchoredFilterResults = /** @type {AnchoredFilterState} */ (
       newFilterResults.value[anchorLabel]
-    ).filter;
+    );
     if (newAnchoredFilterResults.value[fieldName] === undefined)
       newAnchoredFilterResults.value[fieldName] = {
         __type: FILTER_TYPE.OPTION,

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -38,13 +38,14 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
         value: {},
       };
 
-  for (const [filterKey, filterValues] of Object.entries(filterResults.value))
-    if (typeof filterValues !== 'string')
-      if ('filter' in filterValues) {
-        filterResultsByAnchor[filterKey] = filterValues.filter;
-      } else {
-        filterResultsByAnchor[''].value[filterKey] = filterValues;
-      }
+  if (filterResults.value !== undefined)
+    for (const [filterKey, filterValues] of Object.entries(filterResults.value))
+      if (typeof filterValues !== 'string')
+        if ('filter' in filterValues) {
+          filterResultsByAnchor[filterKey] = filterValues.filter;
+        } else {
+          filterResultsByAnchor[''].value[filterKey] = filterValues;
+        }
 
   return filterResultsByAnchor;
 }
@@ -292,6 +293,7 @@ export function updateRangeValue({
 
   // update filter results
   let newFilterResults = cloneDeep(filterResults);
+  if (newFilterResults.value === undefined) newFilterResults.value = {};
   const fieldName = filterTabs[tabIndex].fields[sectionIndex];
   if (anchorLabel === undefined || anchorLabel === '') {
     newFilterResults.value[fieldName] = { lowerBound, upperBound };
@@ -367,6 +369,7 @@ export function updateSelectedValue({
 
   // update filter results
   let newFilterResults = cloneDeep(filterResults);
+  if (newFilterResults.value === undefined) newFilterResults.value = {};
   const fieldName = filterTabs[tabIndex].fields[sectionIndex];
   if (anchorLabel === undefined || anchorLabel === '') {
     if (newFilterResults.value[fieldName] === undefined)

--- a/src/gen3-ui-component/components/filters/types.d.ts
+++ b/src/gen3-ui-component/components/filters/types.d.ts
@@ -7,8 +7,9 @@ export type {
   FilterConfig,
   FilterState,
   FilterTabsOption,
+  BaseFilter,
+  EmptyFilter,
   OptionFilter,
-  RangeFilter,
   SimpleFilterState,
 } from '../../../GuppyComponents/types';
 

--- a/src/gen3-ui-component/components/filters/types.d.ts
+++ b/src/gen3-ui-component/components/filters/types.d.ts
@@ -10,7 +10,6 @@ export type {
   BaseFilter,
   EmptyFilter,
   OptionFilter,
-  SimpleFilterState,
 } from '../../../GuppyComponents/types';
 
 export type EmptyFilterStatus = {};

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 import { explorerConfig } from '../../localconf';
 import {
   createFilterSet,
@@ -158,7 +159,12 @@ const slice = createSlice({
     },
     /** @param {PayloadAction<ExplorerState['explorerFilter']>} action */
     updateExplorerFilter(state, action) {
-      const newFilter = action.payload;
+      const newFilter = {
+        /** @type {ExplorerFilter['__combineMode']} */
+        __combineMode: 'AND',
+        __type: FILTER_TYPE.STANDARD,
+        ...action.payload,
+      };
       const fields = Object.keys(newFilter.value ?? {});
       if (fields.length > 0) {
         const allSearchFieldSet = new Set();

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -158,30 +158,22 @@ const slice = createSlice({
     },
     /** @param {PayloadAction<ExplorerState['explorerFilter']>} action */
     updateExplorerFilter(state, action) {
-      const filter = action.payload;
-
-      let newFilter = /** @type {ExplorerFilter} */ ({});
-      if (filter && Object.keys(filter).length > 0) {
+      const newFilter = action.payload;
+      const fields = Object.keys(newFilter.value ?? {});
+      if (fields.length > 0) {
         const allSearchFieldSet = new Set();
         for (const { searchFields } of state.config.filterConfig.tabs)
           for (const field of searchFields ?? []) allSearchFieldSet.add(field);
 
-        if (allSearchFieldSet.size === 0) {
-          newFilter = /** @type {ExplorerFilter} */ ({
-            __combineMode: state.explorerFilter.__combineMode,
-            ...filter,
-          });
-        } else {
-          const filterWithoutSearchFields = /** @type {ExplorerFilter} */ ({});
-          for (const field of Object.keys(filter))
+        if (allSearchFieldSet.size > 0) {
+          /** @type {ExplorerFilter['value']} */
+          const filterWithoutSearchFields = {};
+          for (const field of fields)
             if (!allSearchFieldSet.has(field))
-              filterWithoutSearchFields[field] = filter[field];
+              filterWithoutSearchFields[field] = newFilter.value[field];
 
           if (Object.keys(filterWithoutSearchFields).length > 0)
-            newFilter = /** @type {ExplorerFilter} */ ({
-              __combineMode: state.explorerFilter.__combineMode,
-              ...filterWithoutSearchFields,
-            });
+            newFilter.value = filterWithoutSearchFields;
         }
       }
 


### PR DESCRIPTION
Ticket: [PEDS-732](https://pcdc.atlassian.net/browse/PEDS-732)

This PR implements more standardized shape for filter values. The most notable change here is the use of `__type` discriminator for various kinds of filter value object as well as using `value` object for a collection of base (i.e. option and range) filters.

See the following screenshot of [the diff](
https://github.com/chicagopcdc/data-portal/pull/435/files#diff-e77b845e881c7f401a93e48c962bf772a40dadba2af996c0b47ae349375621a0) for the core filter types:

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/22449454/180569172-243b0b88-6d7e-497d-a893-6d1783735b19.png">

This is technically a breaking change since all the logic to parse and handle filter values have changed along with the the shape of filter values. To minimize actual UI breakage, the PR also ships a "polyfill" so that old saved filter sets can be used without changing (https://github.com/chicagopcdc/data-portal/pull/435/commits/1ebd72862d313c9c4595dfa3e43aa279875bda39).

This change is made in anticipation of the upcoming "composed filter set" feature, which can now be easily distinguished by using its own `__type` value.