### PR TITLE
Add GraphQL filter object to filter sets request payload PEDS-816

### DIFF
--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -1,3 +1,5 @@
+import { GqlFilter } from '../GuppyComponents/types';
+
 export type {
   FilterConfig,
   FilterState as ExplorerFilter,
@@ -73,6 +75,7 @@ export type ExplorerFilterSetDTO = {
   description: string;
   explorerId?: number;
   filters: ExplorerFilter;
+  gqlFilter: GqlFilter;
   id?: number;
   name: string;
 };

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -1,6 +1,7 @@
 import { explorerConfig } from '../../localconf';
 import { capitalizeFirstLetter } from '../../utils';
 import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
+import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 
 /** @typedef {import('../../GuppyComponents/types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../../GuppyComponents/types').FilterConfig} FilterConfig */
@@ -14,7 +15,7 @@ import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
  * @returns {ExplorerFilterSetDTO}
  */
 export function convertToFilterSetDTO({ filter: filters, ...rest }) {
-  return { ...rest, filters };
+  return { ...rest, filters, gqlFilter: getGQLFilter(filters) };
 }
 
 /** @returns {ExplorerFilterSet['filter']['value']} */


### PR DESCRIPTION
Ticket: [PEDS-816](https://pcdc.atlassian.net/browse/PEDS-816)

This PR adds the GraphQL-formatted filter object for the filter set's filter value to payload for the POST request to `/amanuensis/filter-sets` endpoint. The new value is available as `gqlFilter`.

This is motivated by the `amanuensis`'s need for GraphQL-formatted filter object to handle multi-consortium data requests. By including the GraphQL-formatted filter object to the payload, we can avoid duplicating the formatting logic (i.e. `getGQLFilter()`) on the backend.