### PR TITLE
Fix explorer page crashing when admin filter is used

### DIFF
--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -206,10 +206,11 @@ export const mergeTabOptions = (firstTabsOptions, secondTabsOptions) => {
 };
 
 /**
- * @param {{ histogram: AggsCount[] }} histogramResult
- * @param {{ histogram: AggsCount[] }} initHistogramRes
+ * @param {Object} args
+ * @param {{ histogram: AggsCount[] }} args.histogramResult
+ * @param {{ histogram: AggsCount[] }} args.initialHistogramResult
  */
-const getSingleFilterOption = (histogramResult, initHistogramRes) => {
+const getSingleFilterOption = ({ histogramResult, initialHistogramResult }) => {
   if (!histogramResult || !histogramResult.histogram) {
     throw new Error(
       `Error parsing field options ${JSON.stringify(histogramResult)}`
@@ -221,10 +222,10 @@ const getSingleFilterOption = (histogramResult, initHistogramRes) => {
     if (typeof item.key !== 'string') {
       let [minValue, maxValue] = item.key;
       if (
-        initHistogramRes &&
-        typeof initHistogramRes.histogram[0].key !== 'string'
+        initialHistogramResult &&
+        typeof initialHistogramResult.histogram[0].key !== 'string'
       )
-        [minValue, maxValue] = initHistogramRes.histogram[0].key;
+        [minValue, maxValue] = initialHistogramResult.histogram[0].key;
 
       options.push({
         filterType: 'range',
@@ -355,10 +356,12 @@ export const getFilterSections = ({
       // This allows selected options to appear below the search box once they are selected.
       let selectedOptions = [];
       if (tabsOptionsFiltered && tabsOptionsFiltered.histogram) {
-        selectedOptions = getSingleFilterOption(
-          tabsOptionsFiltered,
-          initialTabsOptions ? initialTabsOptions[field] : undefined
-        );
+        selectedOptions = getSingleFilterOption({
+          histogramResult: tabsOptionsFiltered,
+          initialHistogramResult: initialTabsOptions
+            ? initialTabsOptions[field]
+            : undefined,
+        });
       }
 
       return {
@@ -386,10 +389,12 @@ export const getFilterSections = ({
       );
     }
 
-    const defaultOptions = getSingleFilterOption(
-      tabsOptionsFiltered,
-      initialTabsOptions ? initialTabsOptions[field] : undefined
-    );
+    const defaultOptions = getSingleFilterOption({
+      histogramResult: tabsOptionsFiltered,
+      initialHistogramResult: initialTabsOptions
+        ? initialTabsOptions[field]
+        : undefined,
+    });
 
     const fieldIsArrayField = checkIsArrayField(field, arrayFields);
 

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -207,10 +207,15 @@ export const mergeTabOptions = (firstTabsOptions, secondTabsOptions) => {
 
 /**
  * @param {Object} args
+ * @param {OptionFilter['selectedValues']} [args.adminAppliedPreFilterValues]
  * @param {{ histogram: AggsCount[] }} args.histogramResult
  * @param {{ histogram: AggsCount[] }} args.initialHistogramResult
  */
-const getSingleFilterOption = ({ histogramResult, initialHistogramResult }) => {
+const getSingleFilterOption = ({
+  adminAppliedPreFilterValues,
+  histogramResult,
+  initialHistogramResult,
+}) => {
   if (!histogramResult || !histogramResult.histogram) {
     throw new Error(
       `Error parsing field options ${JSON.stringify(histogramResult)}`
@@ -241,6 +246,7 @@ const getSingleFilterOption = ({ histogramResult, initialHistogramResult }) => {
         filterType: 'singleSelect',
         count: item.count,
         accessible: item.accessible,
+        disabled: adminAppliedPreFilterValues?.includes(item.key),
       });
     }
   }
@@ -357,6 +363,8 @@ export const getFilterSections = ({
       let selectedOptions = [];
       if (tabsOptionsFiltered && tabsOptionsFiltered.histogram) {
         selectedOptions = getSingleFilterOption({
+          adminAppliedPreFilterValues:
+            adminAppliedPreFilters[field]?.selectedValues,
           histogramResult: tabsOptionsFiltered,
           initialHistogramResult: initialTabsOptions
             ? initialTabsOptions[field]
@@ -390,6 +398,8 @@ export const getFilterSections = ({
     }
 
     const defaultOptions = getSingleFilterOption({
+      adminAppliedPreFilterValues:
+        adminAppliedPreFilters[field]?.selectedValues,
       histogramResult: tabsOptionsFiltered,
       initialHistogramResult: initialTabsOptions
         ? initialTabsOptions[field]

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -1,4 +1,5 @@
 import flat from 'flat';
+import cloneDeep from 'lodash.clonedeep';
 import { FILTER_TYPE } from './const';
 import { queryGuppyForRawData } from './queries';
 
@@ -24,7 +25,8 @@ import { queryGuppyForRawData } from './queries';
  * */
 export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   /** @type {FilterState} */
-  const mergedFilterState = { value: {}, ...userFilter };
+  const mergedFilterState = cloneDeep(userFilter);
+  if (mergedFilterState.value === undefined) mergedFilterState.value = {};
 
   for (const [key, adminFilterValues] of Object.entries(
     adminAppliedPreFilter

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -24,13 +24,13 @@ import { queryGuppyForRawData } from './queries';
  * */
 export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   /** @type {FilterState} */
-  const mergedFilterState = { ...userFilter };
+  const mergedFilterState = { value: {}, ...userFilter };
 
   for (const [key, adminFilterValues] of Object.entries(
     adminAppliedPreFilter
   )) {
-    if (key in userFilter.value) {
-      const userFilterValues = userFilter.value[key];
+    if (key in mergedFilterState.value) {
+      const userFilterValues = mergedFilterState.value[key];
 
       if (userFilterValues.__type === FILTER_TYPE.OPTION) {
         const userFilterSubset = userFilterValues.selectedValues.filter((x) =>

--- a/src/GuppyComponents/__tests__/filters.test.js
+++ b/src/GuppyComponents/__tests__/filters.test.js
@@ -7,6 +7,23 @@ import {
 } from '../Utils/filters';
 import { FILTER_TYPE } from '../Utils/const';
 
+describe('can merge with empty user filter', () => {
+  const __type = FILTER_TYPE.OPTION;
+  const userFilter = {};
+  const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins'] } };
+
+  const mergedFilterExpected = {
+    value: {
+      project_id: { __type, selectedValues: ['jnkns-jenkins'] },
+    },
+  };
+
+  test('merge filters', async () => {
+    const mergedFilter = mergeFilters(userFilter, adminFilter);
+    expect(mergedFilter).toEqual(mergedFilterExpected);
+  });
+});
+
 describe('can merge simple selectedValue filters', () => {
   const __type = FILTER_TYPE.OPTION;
   const userFilter = {


### PR DESCRIPTION
This PR fixes the explorer page crashing when `adminAppliedPreFilter` configuration option is used.

This crash is caused by the recent change to filter state shape (https://github.com/chicagopcdc/data-portal/pull/435) not being properly accounted for when handling `adminAppliedPreFilter`. More specifically, `mergeFilter` fails when the current explorer filter state is an empty object because it expects the provided filter state to have `value` property. When missing, the app crashes. The fix ensures that the default `value` object is available and can be modified.

The PR makes another minor change to filter UI to disable select options that are found in `adminAppliedPreFilter`. See the following example for `"adminAppliedPreFilter" : { "consortium": { "selectedValues": ["INSTRuCT"] } }`

<image src="https://user-images.githubusercontent.com/22449454/181100349-4e89fe91-e58f-463d-981a-c7fe4c634bf5.png" width="500" />