### PR TITLE
Show both count and percentage for bar charts on showPercentage

### DIFF
--- a/src/gen3-ui-component/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.css
+++ b/src/gen3-ui-component/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.css
@@ -36,6 +36,10 @@
   top: 1px;
 }
 
+.summary-horizontal-bar-chart__item-value.percentage {
+  line-height: 1;
+}
+
 .summary-horizontal-bar-chart__item-label,
 .summary-horizontal-bar-chart__item-value {
   user-select: none;
@@ -45,6 +49,7 @@
 
 .summary-horizontal-bar-chart__item-block-wrapper {
   display: flex;
+  align-items: center;
 }
 
 .summary-horizontal-bar-chart__item-block {

--- a/src/gen3-ui-component/components/charts/SummaryHorizontalBarChart/index.jsx
+++ b/src/gen3-ui-component/components/charts/SummaryHorizontalBarChart/index.jsx
@@ -80,9 +80,16 @@ function SummaryBarChart({
                       backgroundColor: getItemColor(index),
                     }}
                   />
-                  <div className='summary-horizontal-bar-chart__item-value'>
-                    {showPercentage ? `${item.percentage}%` : item.value}
-                  </div>
+                  {showPercentage ? (
+                    <div className='summary-horizontal-bar-chart__item-value percentage'>
+                      {item.value}
+                      <br />({item.percentage}%)
+                    </div>
+                  ) : (
+                    <div className='summary-horizontal-bar-chart__item-value'>
+                      {item.value}
+                    </div>
+                  )}
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
This PR modifies the effect of setting `showPercentage` configuration for bar charts to `true` so that the chart displays both count and percentage values, instead of percentage value only.

See the following screenshots of before/after comparison:

*Before*

<img width="600" alt="image" src="https://user-images.githubusercontent.com/22449454/181276319-7b72e45e-3371-465c-8d10-a56a6274dc4d.png">

*After*

<img width="600" alt="image" src="https://user-images.githubusercontent.com/22449454/181276128-8244aebf-b5c3-4514-86cb-e4be42794af4.png">
