### PR TITLE
 Patch release 1.8.1 PEDS-828 PEDS-829

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.18.9",

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/SurvivalPlot.jsx
@@ -69,7 +69,7 @@ function Plot({ data, endTime, efsFlag, startTime, timeInterval }) {
           dataKey='time'
           type='number'
           label={{
-            value: 'Time from diagnosis (in year)',
+            value: 'Time from diagnosis (in years)',
             position: 'insideBottom',
             offset: -5,
           }}

--- a/src/UserPopup/index.jsx
+++ b/src/UserPopup/index.jsx
@@ -37,7 +37,7 @@ function updateDocsToReview(reviewStatus) {
 function userPopupSelector({ user }) {
   const isRegistered = user.authz?.['/portal']?.length > 0;
   const docsToBeReviewed = (user.docs_to_be_reviewed ?? []).filter(
-    (doc) => doc.required
+    (doc) => doc.required && doc.type !== 'survival-user-agreement'
   );
   return {
     docsToBeReviewed,


### PR DESCRIPTION
Tickets: [PEDS-760](https://pcdc.atlassian.net/browse/PEDS-760), [PEDS-762](https://pcdc.atlassian.net/browse/PEDS-762)

This PR bumps the project version to 1.8.1 and includes the following fixes & changes:

* Change survival plot's x-axis label to use plural ("in years")
* Exclude survival user agreement from documents to review from registration/review popups