### PR TITLE
Patch release 1.8.2 PEDS-830

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.18.9",

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ExplorerSurvivalAnalysis.css
@@ -4,7 +4,7 @@
   flex-wrap: wrap;
   justify-content: space-around;
   margin-top: 10px;
-  padding: 12px 12px 3rem;
+  padding: 12px 12px 5rem;
 }
 
 .explorer-survival-analysis__warning {

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/RiskTable.jsx
@@ -68,7 +68,7 @@ function Table({ data, endTime, startTime, timeInterval }) {
           type='number'
           domain={['dataMin', endTime]}
           label={{
-            value: 'Time (in year)',
+            value: 'Time from diagnosis (in years)',
             position: 'insideBottom',
             offset: -5,
           }}


### PR DESCRIPTION
Tickets: [PEDS-830](https://pcdc.atlassian.net/browse/PEDS-830)

This PR bumps the project version to 1.8.2 and includes the following fixes & changes:

* Fixes the issue of survival tool's button group element hiding the risk table x-axis label in certain states
* Matches the risk table x-axis label to that of survival plot