### PR TITLE
Migrate off of unmaintained react-virtualized PEDS-832

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12566,11 +12566,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -23245,19 +23240,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "react-select": "^5.4.0",
     "react-select-async-paginate": "^0.6.2",
     "react-table": "^7.8.0",
-    "react-virtualized": "^9.22.3",
     "recharts": "^2.1.13",
     "relay-compiler": "^12.0.0",
     "relay-runtime": "^12.0.0",

--- a/src/Submission/MapFiles.css
+++ b/src/Submission/MapFiles.css
@@ -60,6 +60,8 @@
   margin: 10px 0 40px 0;
   border-collapse: collapse;
   outline: none;
+  max-height: 500px;
+  overflow-y: scroll;
 }
 
 .map-files__table-header {
@@ -76,7 +78,7 @@
 
 .map-files__table-row > * {
   word-break: break-all;
-  padding: 10px 20px 10px 0;
+  padding: 10px 20px;
 }
 
 .map-files__table-checkbox {

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -269,10 +269,10 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
           </h2>
         ) : null}
         {sortedDates.map((date, groupIndex) => {
-          /** @type {SubmissionFile[]} */
+          /** @type {(SubmissionFile & { status: boolean })[]} */
           const files = filesByDate[date].map((file) => ({
             ...file,
-            status: isFileReady(file) ? 'Ready' : 'generating',
+            status: isFileReady(file),
           }));
           const selectStatus = {
             all: isSelectAll({

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -108,6 +108,12 @@ export function removeFromMap(map, index, setKey) {
   return tempMap;
 }
 
+/**
+ * @param {Object} args
+ * @param {number} args.index
+ * @param {SubmissionFileMap} args.allFilesByGroup
+ * @param {SubmissionFileMap} args.selectedFilesByGroup
+ */
 export function isSelectAll({ index, allFilesByGroup, selectedFilesByGroup }) {
   return selectedFilesByGroup[index]
     ? getSetSize(allFilesByGroup[index]) ===
@@ -191,7 +197,6 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
   }
 
   /**
-   *
    * @param {number} index
    * @param {SubmissionFile} file
    */

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -4,21 +4,15 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import cloneDeep from 'lodash.clonedeep';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { AutoSizer, Column, Table } from 'react-virtualized';
-import 'react-virtualized/styles.css'; // only needs to be imported once
 import Button from '../gen3-ui-component/components/Button';
 import BackLink from '../components/BackLink';
 import StickyToolbar from '../components/StickyToolbar';
-import CheckBox from '../components/CheckBox';
 import Spinner from '../components/Spinner';
-import StatusReadyIcon from '../img/icons/status_ready.svg';
 import CloseIcon from '../img/icons/cross.svg';
-import { humanFileSize } from '../utils.js';
+import MapFilesTable from './MapFilesTable';
 import './MapFiles.css';
 
 const SET_KEY = 'did';
-const ROW_HEIGHT = 70;
-const HEADER_HEIGHT = 70;
 
 dayjs.extend(customParseFormat);
 
@@ -288,7 +282,6 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
             ...file,
             status: isFileReady(file) ? 'Ready' : 'generating',
           }));
-          const minTableHeight = files.length * ROW_HEIGHT + HEADER_HEIGHT;
           const selectStatus = {
             all: isSelectAll({
               index: groupIndex,
@@ -303,86 +296,15 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
           return (
             <Fragment key={groupIndex}>
               <div className='h2-typo'>{getTableHeaderText(files)}</div>
-              <AutoSizer disableHeight>
-                {({ width }) => (
-                  <Table
-                    className='map-files__table'
-                    width={width}
-                    height={minTableHeight < 500 ? minTableHeight : 500}
-                    headerHeight={ROW_HEIGHT}
-                    rowHeight={ROW_HEIGHT}
-                    rowCount={files.length}
-                    rowGetter={({ index }) => files[index]}
-                    rowClassName='map-files__table-row'
-                  >
-                    <Column
-                      width={100}
-                      label='Select All'
-                      dataKey='selectAll'
-                      headerRenderer={() => (
-                        <CheckBox
-                          id={`${groupIndex}`}
-                          isSelected={selectStatus.all}
-                          onChange={() => toggleSelectAll(groupIndex)}
-                        />
-                      )}
-                      cellRenderer={({ rowIndex }) => (
-                        <CheckBox
-                          id={`${files[rowIndex].did}`}
-                          item={files[rowIndex]}
-                          isSelected={selectStatus.files[rowIndex]}
-                          onChange={() =>
-                            toggleCheckBox(groupIndex, files[rowIndex])
-                          }
-                          isEnabled={files[rowIndex].status === 'Ready'}
-                          disabledText={
-                            'This file is not ready to be mapped yet.'
-                          }
-                        />
-                      )}
-                    />
-                    <Column label='File Name' dataKey='file_name' width={400} />
-                    <Column
-                      label='Size'
-                      dataKey='size'
-                      width={100}
-                      cellRenderer={({ cellData }) => (
-                        <div>{cellData ? humanFileSize(cellData) : '0 B'}</div>
-                      )}
-                    />
-                    <Column
-                      label='Uploaded Date'
-                      dataKey='created_date'
-                      width={300}
-                      cellRenderer={({ cellData }) => (
-                        <div>
-                          {dayjs(cellData).format(
-                            'MM/DD/YY, hh:mm:ss a [UTC]Z'
-                          )}
-                        </div>
-                      )}
-                    />
-                    <Column
-                      label='Status'
-                      dataKey='status'
-                      width={400}
-                      cellRenderer={({ cellData }) => {
-                        const className = `map-files__status--${cellData.toLowerCase()}`;
-                        return (
-                          <div className={className}>
-                            {cellData === 'Ready' ? <StatusReadyIcon /> : null}
-                            <div className='h2-typo'>
-                              {cellData === 'Ready'
-                                ? cellData
-                                : `${cellData}...`}
-                            </div>
-                          </div>
-                        );
-                      }}
-                    />
-                  </Table>
-                )}
-              </AutoSizer>
+              <MapFilesTable
+                files={files}
+                groupIndex={groupIndex}
+                onToggleCheckbox={(rowIndex) =>
+                  toggleCheckBox(groupIndex, files[rowIndex])
+                }
+                onToggleSelectAll={() => toggleSelectAll(groupIndex)}
+                selectStatus={selectStatus}
+              />
             </Fragment>
           );
         })}

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import cloneDeep from 'lodash.clonedeep';
@@ -43,14 +43,6 @@ function createSet(key, values) {
 /** @param {SubmissionFileSet} set */
 function getSetSize(set) {
   return Object.keys(set).length;
-}
-
-/** @param {SubmissionFile[]} files */
-function getTableHeaderText(files) {
-  const date = dayjs(files[0].created_date).format('MM/DD/YY');
-  return `uploaded on ${date}, ${files.length} ${
-    files.length > 1 ? 'files' : 'file'
-  }`;
 }
 
 /** @param {SubmissionFile[]} unmappedFiles */
@@ -294,18 +286,16 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
           };
 
           return (
-            <Fragment key={groupIndex}>
-              <div className='h2-typo'>{getTableHeaderText(files)}</div>
-              <MapFilesTable
-                files={files}
-                groupIndex={groupIndex}
-                onToggleCheckbox={(rowIndex) =>
-                  toggleCheckBox(groupIndex, files[rowIndex])
-                }
-                onToggleSelectAll={() => toggleSelectAll(groupIndex)}
-                selectStatus={selectStatus}
-              />
-            </Fragment>
+            <MapFilesTable
+              key={groupIndex}
+              files={files}
+              groupIndex={groupIndex}
+              onToggleCheckbox={(rowIndex) =>
+                toggleCheckBox(groupIndex, files[rowIndex])
+              }
+              onToggleSelectAll={() => toggleSelectAll(groupIndex)}
+              selectStatus={selectStatus}
+            />
           );
         })}
       </div>

--- a/src/Submission/MapFiles.jsx
+++ b/src/Submission/MapFiles.jsx
@@ -283,11 +283,23 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
           </h2>
         ) : null}
         {sortedDates.map((date, groupIndex) => {
+          /** @type {SubmissionFile[]} */
           const files = filesByDate[date].map((file) => ({
             ...file,
             status: isFileReady(file) ? 'Ready' : 'generating',
           }));
           const minTableHeight = files.length * ROW_HEIGHT + HEADER_HEIGHT;
+          const selectStatus = {
+            all: isSelectAll({
+              index: groupIndex,
+              allFilesByGroup,
+              selectedFilesByGroup,
+            }),
+            files: files.map(({ did }) =>
+              isSelected({ index: groupIndex, did, selectedFilesByGroup })
+            ),
+          };
+
           return (
             <Fragment key={groupIndex}>
               <div className='h2-typo'>{getTableHeaderText(files)}</div>
@@ -310,11 +322,7 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
                       headerRenderer={() => (
                         <CheckBox
                           id={`${groupIndex}`}
-                          isSelected={isSelectAll({
-                            index: groupIndex,
-                            allFilesByGroup,
-                            selectedFilesByGroup,
-                          })}
+                          isSelected={selectStatus.all}
                           onChange={() => toggleSelectAll(groupIndex)}
                         />
                       )}
@@ -322,11 +330,7 @@ function MapFiles({ mapSelectedFiles, unmappedFiles = defaultUnmapedFiles }) {
                         <CheckBox
                           id={`${files[rowIndex].did}`}
                           item={files[rowIndex]}
-                          isSelected={isSelected({
-                            index: groupIndex,
-                            did: files[rowIndex].did,
-                            selectedFilesByGroup,
-                          })}
+                          isSelected={selectStatus.files[rowIndex]}
                           onChange={() =>
                             toggleCheckBox(groupIndex, files[rowIndex])
                           }

--- a/src/Submission/MapFilesTable.jsx
+++ b/src/Submission/MapFilesTable.jsx
@@ -1,15 +1,10 @@
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import PropTypes from 'prop-types';
-import { AutoSizer, Column, Table } from 'react-virtualized';
-import 'react-virtualized/styles.css'; // only needs to be imported once
 import CheckBox from '../components/CheckBox';
 import StatusReadyIcon from '../img/icons/status_ready.svg';
 import { humanFileSize } from '../utils.js';
 import './MapFiles.css';
-
-const HEADER_HEIGHT = 70;
-const ROW_HEIGHT = 70;
 
 dayjs.extend(customParseFormat);
 
@@ -31,84 +26,58 @@ function MapFilesTable({
   const title = `Uploaded on ${dayjs(files[0].created_date).format(
     'MM/DD/YY'
   )}, ${files.length} ${files.length > 1 ? 'files' : 'file'}`;
+  const headers = ['File Name', 'Size', 'Uploaded Date', 'Status'];
+  const rows = files.map((file) => [
+    file.file_name,
+    file.size ? humanFileSize(file.size) : '0 B',
+    dayjs(file.created_date).format('MM/DD/YY, hh:mm:ss a [UTC]Z'),
+    <div
+      className={`map-files__status--${file.status ? 'ready' : 'generating'}`}
+    >
+      {file.status ? <StatusReadyIcon /> : null}
+      <div className='h2-typo'>{file.status ? 'Ready' : 'generating...'}</div>
+    </div>,
+  ]);
 
   return (
-    <>
+    <div className='map-files__table'>
       <div className='h2-typo'>{title}</div>
-      <AutoSizer disableHeight>
-        {({ width }) => (
-          <Table
-            className='map-files__table'
-            width={width}
-            height={Math.min(500, files.length * ROW_HEIGHT + HEADER_HEIGHT)}
-            headerHeight={ROW_HEIGHT}
-            rowHeight={ROW_HEIGHT}
-            rowCount={files.length}
-            rowGetter={({ index }) => files[index]}
-            rowClassName='map-files__table-row'
-          >
-            <Column
-              width={100}
-              label='Select All'
-              dataKey='selectAll'
-              headerRenderer={() => (
+      <table className='map-files__table'>
+        <thead>
+          <tr className='map-files__table-row'>
+            <th scope='col' className='map-files__table-checkbox'>
+              <CheckBox
+                id={`${groupIndex}`}
+                isSelected={selectStatus.all}
+                onChange={onToggleSelectAll}
+              />
+            </th>
+            {headers.map((header) => (
+              <th scope='col'>{header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((cols, index) => (
+            <tr className='map-files__table-row'>
+              <th scope='row' className='map-files__table-checkbox'>
                 <CheckBox
-                  id={`${groupIndex}`}
-                  isSelected={selectStatus.all}
-                  onChange={onToggleSelectAll}
-                />
-              )}
-              cellRenderer={({ rowIndex }) => (
-                <CheckBox
-                  id={`${files[rowIndex].did}`}
-                  item={files[rowIndex]}
-                  isSelected={selectStatus.files[rowIndex]}
-                  onChange={() => onToggleCheckbox(rowIndex)}
-                  isEnabled={files[rowIndex].status}
+                  id={`${files[index].did}`}
+                  item={files[index]}
+                  isSelected={selectStatus.files[index]}
+                  onChange={() => onToggleCheckbox(index)}
+                  isEnabled={files[index].status}
                   disabledText={'This file is not ready to be mapped yet.'}
                 />
-              )}
-            />
-            <Column label='File Name' dataKey='file_name' width={400} />
-            <Column
-              label='Size'
-              dataKey='size'
-              width={100}
-              cellRenderer={({ cellData }) => (
-                <div>{cellData ? humanFileSize(cellData) : '0 B'}</div>
-              )}
-            />
-            <Column
-              label='Uploaded Date'
-              dataKey='created_date'
-              width={300}
-              cellRenderer={({ cellData }) => (
-                <div>
-                  {dayjs(cellData).format('MM/DD/YY, hh:mm:ss a [UTC]Z')}
-                </div>
-              )}
-            />
-            <Column
-              label='Status'
-              dataKey='status'
-              width={400}
-              cellRenderer={({ cellData }) => (
-                <div
-                  className={`map-files__status--${
-                    cellData ? 'ready' : 'generating'
-                  }`}
-                >
-                  {cellData ? <StatusReadyIcon /> : null}
-                  <div className='h2-typo'>
-                    {cellData ? 'Ready' : `generating...`}
-                  </div>
-                </div>
-              )}
-            />
-          </Table>
-        )}
-      </AutoSizer>
-    </>
+              </th>
+              {cols.map((col) => (
+                <td>{col}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/Submission/MapFilesTable.jsx
+++ b/src/Submission/MapFilesTable.jsx
@@ -15,7 +15,7 @@ dayjs.extend(customParseFormat);
 
 /**
  * @param {Object} props
- * @param {Array} props.files
+ * @param {(import('./types').SubmissionFile & { status: boolean })[]} props.files
  * @param {number} props.groupIndex
  * @param {(rowIndex: number) => void} props.onToggleCheckbox
  * @param {() => void} props.onToggleSelectAll
@@ -64,7 +64,7 @@ function MapFilesTable({
                   item={files[rowIndex]}
                   isSelected={selectStatus.files[rowIndex]}
                   onChange={() => onToggleCheckbox(rowIndex)}
-                  isEnabled={files[rowIndex].status === 'Ready'}
+                  isEnabled={files[rowIndex].status}
                   disabledText={'This file is not ready to be mapped yet.'}
                 />
               )}
@@ -92,17 +92,18 @@ function MapFilesTable({
               label='Status'
               dataKey='status'
               width={400}
-              cellRenderer={({ cellData }) => {
-                const className = `map-files__status--${cellData.toLowerCase()}`;
-                return (
-                  <div className={className}>
-                    {cellData === 'Ready' ? <StatusReadyIcon /> : null}
-                    <div className='h2-typo'>
-                      {cellData === 'Ready' ? cellData : `${cellData}...`}
-                    </div>
+              cellRenderer={({ cellData }) => (
+                <div
+                  className={`map-files__status--${
+                    cellData ? 'ready' : 'generating'
+                  }`}
+                >
+                  {cellData ? <StatusReadyIcon /> : null}
+                  <div className='h2-typo'>
+                    {cellData ? 'Ready' : `generating...`}
                   </div>
-                );
-              }}
+                </div>
+              )}
             />
           </Table>
         )}

--- a/src/Submission/MapFilesTable.jsx
+++ b/src/Submission/MapFilesTable.jsx
@@ -28,77 +28,86 @@ function MapFilesTable({
   onToggleSelectAll,
   selectStatus,
 }) {
+  const title = `Uploaded on ${dayjs(files[0].created_date).format(
+    'MM/DD/YY'
+  )}, ${files.length} ${files.length > 1 ? 'files' : 'file'}`;
+
   return (
-    <AutoSizer disableHeight>
-      {({ width }) => (
-        <Table
-          className='map-files__table'
-          width={width}
-          height={Math.min(500, files.length * ROW_HEIGHT + HEADER_HEIGHT)}
-          headerHeight={ROW_HEIGHT}
-          rowHeight={ROW_HEIGHT}
-          rowCount={files.length}
-          rowGetter={({ index }) => files[index]}
-          rowClassName='map-files__table-row'
-        >
-          <Column
-            width={100}
-            label='Select All'
-            dataKey='selectAll'
-            headerRenderer={() => (
-              <CheckBox
-                id={`${groupIndex}`}
-                isSelected={selectStatus.all}
-                onChange={onToggleSelectAll}
-              />
-            )}
-            cellRenderer={({ rowIndex }) => (
-              <CheckBox
-                id={`${files[rowIndex].did}`}
-                item={files[rowIndex]}
-                isSelected={selectStatus.files[rowIndex]}
-                onChange={() => onToggleCheckbox(rowIndex)}
-                isEnabled={files[rowIndex].status === 'Ready'}
-                disabledText={'This file is not ready to be mapped yet.'}
-              />
-            )}
-          />
-          <Column label='File Name' dataKey='file_name' width={400} />
-          <Column
-            label='Size'
-            dataKey='size'
-            width={100}
-            cellRenderer={({ cellData }) => (
-              <div>{cellData ? humanFileSize(cellData) : '0 B'}</div>
-            )}
-          />
-          <Column
-            label='Uploaded Date'
-            dataKey='created_date'
-            width={300}
-            cellRenderer={({ cellData }) => (
-              <div>{dayjs(cellData).format('MM/DD/YY, hh:mm:ss a [UTC]Z')}</div>
-            )}
-          />
-          <Column
-            label='Status'
-            dataKey='status'
-            width={400}
-            cellRenderer={({ cellData }) => {
-              const className = `map-files__status--${cellData.toLowerCase()}`;
-              return (
-                <div className={className}>
-                  {cellData === 'Ready' ? <StatusReadyIcon /> : null}
-                  <div className='h2-typo'>
-                    {cellData === 'Ready' ? cellData : `${cellData}...`}
-                  </div>
+    <>
+      <div className='h2-typo'>{title}</div>
+      <AutoSizer disableHeight>
+        {({ width }) => (
+          <Table
+            className='map-files__table'
+            width={width}
+            height={Math.min(500, files.length * ROW_HEIGHT + HEADER_HEIGHT)}
+            headerHeight={ROW_HEIGHT}
+            rowHeight={ROW_HEIGHT}
+            rowCount={files.length}
+            rowGetter={({ index }) => files[index]}
+            rowClassName='map-files__table-row'
+          >
+            <Column
+              width={100}
+              label='Select All'
+              dataKey='selectAll'
+              headerRenderer={() => (
+                <CheckBox
+                  id={`${groupIndex}`}
+                  isSelected={selectStatus.all}
+                  onChange={onToggleSelectAll}
+                />
+              )}
+              cellRenderer={({ rowIndex }) => (
+                <CheckBox
+                  id={`${files[rowIndex].did}`}
+                  item={files[rowIndex]}
+                  isSelected={selectStatus.files[rowIndex]}
+                  onChange={() => onToggleCheckbox(rowIndex)}
+                  isEnabled={files[rowIndex].status === 'Ready'}
+                  disabledText={'This file is not ready to be mapped yet.'}
+                />
+              )}
+            />
+            <Column label='File Name' dataKey='file_name' width={400} />
+            <Column
+              label='Size'
+              dataKey='size'
+              width={100}
+              cellRenderer={({ cellData }) => (
+                <div>{cellData ? humanFileSize(cellData) : '0 B'}</div>
+              )}
+            />
+            <Column
+              label='Uploaded Date'
+              dataKey='created_date'
+              width={300}
+              cellRenderer={({ cellData }) => (
+                <div>
+                  {dayjs(cellData).format('MM/DD/YY, hh:mm:ss a [UTC]Z')}
                 </div>
-              );
-            }}
-          />
-        </Table>
-      )}
-    </AutoSizer>
+              )}
+            />
+            <Column
+              label='Status'
+              dataKey='status'
+              width={400}
+              cellRenderer={({ cellData }) => {
+                const className = `map-files__status--${cellData.toLowerCase()}`;
+                return (
+                  <div className={className}>
+                    {cellData === 'Ready' ? <StatusReadyIcon /> : null}
+                    <div className='h2-typo'>
+                      {cellData === 'Ready' ? cellData : `${cellData}...`}
+                    </div>
+                  </div>
+                );
+              }}
+            />
+          </Table>
+        )}
+      </AutoSizer>
+    </>
   );
 }
 

--- a/src/Submission/MapFilesTable.jsx
+++ b/src/Submission/MapFilesTable.jsx
@@ -1,0 +1,116 @@
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import PropTypes from 'prop-types';
+import { AutoSizer, Column, Table } from 'react-virtualized';
+import 'react-virtualized/styles.css'; // only needs to be imported once
+import CheckBox from '../components/CheckBox';
+import StatusReadyIcon from '../img/icons/status_ready.svg';
+import { humanFileSize } from '../utils.js';
+import './MapFiles.css';
+
+const HEADER_HEIGHT = 70;
+const ROW_HEIGHT = 70;
+
+dayjs.extend(customParseFormat);
+
+/**
+ * @param {Object} props
+ * @param {Array} props.files
+ * @param {number} props.groupIndex
+ * @param {(rowIndex: number) => void} props.onToggleCheckbox
+ * @param {() => void} props.onToggleSelectAll
+ * @param {{ all: boolean; files: boolean[] }} props.selectStatus
+ */
+function MapFilesTable({
+  files,
+  groupIndex,
+  onToggleCheckbox,
+  onToggleSelectAll,
+  selectStatus,
+}) {
+  return (
+    <AutoSizer disableHeight>
+      {({ width }) => (
+        <Table
+          className='map-files__table'
+          width={width}
+          height={Math.min(500, files.length * ROW_HEIGHT + HEADER_HEIGHT)}
+          headerHeight={ROW_HEIGHT}
+          rowHeight={ROW_HEIGHT}
+          rowCount={files.length}
+          rowGetter={({ index }) => files[index]}
+          rowClassName='map-files__table-row'
+        >
+          <Column
+            width={100}
+            label='Select All'
+            dataKey='selectAll'
+            headerRenderer={() => (
+              <CheckBox
+                id={`${groupIndex}`}
+                isSelected={selectStatus.all}
+                onChange={onToggleSelectAll}
+              />
+            )}
+            cellRenderer={({ rowIndex }) => (
+              <CheckBox
+                id={`${files[rowIndex].did}`}
+                item={files[rowIndex]}
+                isSelected={selectStatus.files[rowIndex]}
+                onChange={() => onToggleCheckbox(rowIndex)}
+                isEnabled={files[rowIndex].status === 'Ready'}
+                disabledText={'This file is not ready to be mapped yet.'}
+              />
+            )}
+          />
+          <Column label='File Name' dataKey='file_name' width={400} />
+          <Column
+            label='Size'
+            dataKey='size'
+            width={100}
+            cellRenderer={({ cellData }) => (
+              <div>{cellData ? humanFileSize(cellData) : '0 B'}</div>
+            )}
+          />
+          <Column
+            label='Uploaded Date'
+            dataKey='created_date'
+            width={300}
+            cellRenderer={({ cellData }) => (
+              <div>{dayjs(cellData).format('MM/DD/YY, hh:mm:ss a [UTC]Z')}</div>
+            )}
+          />
+          <Column
+            label='Status'
+            dataKey='status'
+            width={400}
+            cellRenderer={({ cellData }) => {
+              const className = `map-files__status--${cellData.toLowerCase()}`;
+              return (
+                <div className={className}>
+                  {cellData === 'Ready' ? <StatusReadyIcon /> : null}
+                  <div className='h2-typo'>
+                    {cellData === 'Ready' ? cellData : `${cellData}...`}
+                  </div>
+                </div>
+              );
+            }}
+          />
+        </Table>
+      )}
+    </AutoSizer>
+  );
+}
+
+MapFilesTable.propTypes = {
+  files: PropTypes.array,
+  groupIndex: PropTypes.number,
+  onToggleCheckbox: PropTypes.func,
+  onToggleSelectAll: PropTypes.func,
+  selectStatus: PropTypes.shape({
+    all: PropTypes.bool,
+    files: PropTypes.arrayOf(PropTypes.bool),
+  }),
+};
+
+export default MapFilesTable;


### PR DESCRIPTION
Ticket: [PEDS-832](https://pcdc.atlassian.net/browse/PEDS-832)

This PR replaces the `react-virtualized` table in `<MapFiles>` with a simple table built on native HTML elements. This change is motivated by `react-virtualized`'s incompatibility with React 17 and 18, which prevents the planned migration to Node 18 and npm 8. The package has not been maintained for ~2 years.

The PR also extracts table in `<MapFiles>` as a separate component, `<MapFilesTable>`. 