### PR TITLE
Support composed filter state pt. 1 PEDS-703

### DIFF
--- a/src/GuppyComponents/Utils/const.js
+++ b/src/GuppyComponents/Utils/const.js
@@ -24,6 +24,8 @@ export const FILTER_TYPE = {
   RANGE: 'RANGE',
   /** @type {'STANDARD'} */
   STANDARD: 'STANDARD',
+  /** @type {'COMPOSED'} */
+  COMPOSED: 'COMPOSED',
 };
 
 export { guppyUrl as GUPPY_URL } from '../../localconf';

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -5,6 +5,7 @@ import { FILE_DELIMITERS, FILTER_TYPE, GUPPY_URL } from './const';
 
 /** @typedef {import('../types').AnchorConfig} AnchorConfig */
 /** @typedef {import('../types').AnchoredFilterState} AnchoredFilterState */
+/** @typedef {import('../types').ComposedFilterState} ComposedFilterState */
 /** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GqlInFilter} GqlInFilter */
@@ -641,7 +642,7 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
 
 /**
  * Convert filter obj into GQL filter format
- * @param {EmptyFilter | FilterState} filterState
+ * @param {EmptyFilter | ComposedFilterState | FilterState} filterState
  * @returns {GqlFilter}
  */
 export function getGQLFilter(filterState) {
@@ -652,6 +653,10 @@ export function getGQLFilter(filterState) {
   )
     return undefined;
 
+  const combineMode = filterState.__combineMode ?? 'AND';
+  if (filterState.__type === FILTER_TYPE.COMPOSED)
+    return { [combineMode]: filterState.value.map(getGQLFilter) };
+
   /** @type {GqlSimpleFilter[]} */
   const simpleFilters = [];
 
@@ -661,7 +666,6 @@ export function getGQLFilter(filterState) {
   const nestedFilterIndices = {};
   let nestedFilterIndex = 0;
 
-  const combineMode = filterState.__combineMode ?? 'AND';
   for (const [filterKey, filterValues] of Object.entries(filterState.value)) {
     const [fieldStr, nestedFieldStr] = filterKey.split('.');
     const isNestedField = nestedFieldStr !== undefined;

--- a/src/GuppyComponents/__tests__/queries.test.js
+++ b/src/GuppyComponents/__tests__/queries.test.js
@@ -277,6 +277,85 @@ describe('Get GQL filter from filter object from', () => {
     };
     expect(getGQLFilter(filterState)).toEqual(gqlFilter);
   });
+  test('a simple composed filter', () => {
+    const filterState = {
+      __combineMode: /** @type {CombineMode} */ ('AND'),
+      __type: FILTER_TYPE.COMPOASED,
+      value: [
+        {
+          __combineMode: /** @type {CombineMode} */ ('AND'),
+          __type: FILTER_TYPE.STANDARD,
+          value: {
+            a: { __type: FILTER_TYPE.OPTION, selectedValues: ['foo', 'bar'] },
+          },
+        },
+        {
+          __combineMode: /** @type {CombineMode} */ ('OR'),
+          __type: FILTER_TYPE.STANDARD,
+          value: {
+            b: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+          },
+        },
+      ],
+    };
+    const gqlFilter = {
+      AND: [
+        {
+          AND: [{ IN: { a: ['foo', 'bar'] } }],
+        },
+        {
+          OR: [{ AND: [{ GTE: { b: 0 } }, { LTE: { b: 1 } }] }],
+        },
+      ],
+    };
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
+  });
+  test('a higher-order composed filter', () => {
+    const filterState = {
+      __combineMode: /** @type {CombineMode} */ ('AND'),
+      __type: FILTER_TYPE.COMPOASED,
+      value: [
+        {
+          __combineMode: /** @type {CombineMode} */ ('OR'),
+          __type: FILTER_TYPE.COMPOASED,
+          value: [
+            {
+              __combineMode: /** @type {CombineMode} */ ('AND'),
+              __type: FILTER_TYPE.STANDARD,
+              value: {
+                a: {
+                  __type: FILTER_TYPE.OPTION,
+                  selectedValues: ['foo', 'bar'],
+                },
+              },
+            },
+          ],
+        },
+        {
+          __combineMode: /** @type {CombineMode} */ ('OR'),
+          __type: FILTER_TYPE.STANDARD,
+          value: {
+            b: { __type: FILTER_TYPE.RANGE, lowerBound: 0, upperBound: 1 },
+          },
+        },
+      ],
+    };
+    const gqlFilter = {
+      AND: [
+        {
+          OR: [
+            {
+              AND: [{ IN: { a: ['foo', 'bar'] } }],
+            },
+          ],
+        },
+        {
+          OR: [{ AND: [{ GTE: { b: 0 } }, { LTE: { b: 1 } }] }],
+        },
+      ],
+    };
+    expect(getGQLFilter(filterState)).toEqual(gqlFilter);
+  });
 });
 
 describe('Get query info objects for aggregation options data', () => {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -31,6 +31,12 @@ export type FilterState = {
   };
 };
 
+export type ComposedFilterState = {
+  __combineMode?: CombineMode;
+  __type: 'COMPOSED';
+  value?: (ComposedFilterState | FilterState)[];
+};
+
 export type GqlInFilter = {
   IN: {
     [x: string]: string[];


### PR DESCRIPTION
Ticket: [PEDS-703](https://pcdc.atlassian.net/browse/PEDS-703)

This PR is the first step toward supporting "composed" filter state. Composed filter state has a recursive data structure whose value is an array of either other composed filter state or standard filter state objects:

```ts
type ComposedFilterState = {
  __combineMode?: CombineMode;
  __type: 'COMPOSED';
  value?: (ComposedFilterState | FilterState)[];
};
```

The PR defines the core type `ComposedFilterState` and implements `getGQLFilter` logic necessary to convert a composed filter state object to corresponding GraphQL filter object.

More PRs are planned to implement UI to display and generate composed filter state on Workspace and elsewhere.