### PR TITLE
 Support server-side surival configuration PEDS-836

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import {
 import { fetchGuppySchema, fetchSchema } from './redux/graphiql/asyncThunks';
 import { fetchAccess } from './redux/userProfile/asyncThunks';
 import { fetchGraphvizLayout } from './redux/ddgraph/asyncThunks';
+import { fetchSurvivalConfig } from './redux/explorer/asyncThunks';
 import { useAppDispatch } from './redux/hooks';
 
 // lazy-loaded pages
@@ -188,7 +189,7 @@ function App() {
         <Route
           path='explorer'
           element={
-            <ProtectedContent>
+            <ProtectedContent preload={() => dispatch(fetchSurvivalConfig())}>
               <Explorer />
             </ProtectedContent>
           }

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -101,3 +101,8 @@ export const updateSurvivalResult = createAsyncThunk(
     }
   }
 );
+
+export const fetchSurvivalConfig = createAsyncThunk(
+  'explorer/fetchSurvivalConfig',
+  survivalAnalysisAPI.fetchConfig
+);

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -102,7 +102,13 @@ export const updateSurvivalResult = createAsyncThunk(
   }
 );
 
+let shouldFetchSurvivalConfig = true;
 export const fetchSurvivalConfig = createAsyncThunk(
   'explorer/fetchSurvivalConfig',
-  survivalAnalysisAPI.fetchConfig
+  async () => {
+    if (!shouldFetchSurvivalConfig) return undefined;
+
+    shouldFetchSurvivalConfig = false;
+    return survivalAnalysisAPI.fetchConfig();
+  }
 );

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -5,6 +5,7 @@ import {
   createFilterSet,
   deleteFilterSet,
   fetchFilterSets,
+  fetchSurvivalConfig,
   updateFilterSet,
   updateSurvivalResult,
 } from './asyncThunks';
@@ -306,6 +307,13 @@ const slice = createSlice({
         state.survivalAnalysisResult.parsed = {};
         state.survivalAnalysisResult.staleFilterSetIds = [];
         state.survivalAnalysisResult.usedFilterSetIds = [];
+      })
+      .addCase(fetchSurvivalConfig.fulfilled, (state, action) => {
+        state.config.survivalAnalysisConfig = action.payload;
+        state.survivalAnalysisResult.parsed = parseSurvivalResult({
+          config: action.payload,
+          result: null,
+        });
       });
   },
 });

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -309,9 +309,12 @@ const slice = createSlice({
         state.survivalAnalysisResult.usedFilterSetIds = [];
       })
       .addCase(fetchSurvivalConfig.fulfilled, (state, action) => {
-        state.config.survivalAnalysisConfig = action.payload;
+        const config = action.payload;
+        if (config === undefined) return;
+
+        state.config.survivalAnalysisConfig = config;
         state.survivalAnalysisResult.parsed = parseSurvivalResult({
-          config: action.payload,
+          config,
           result: null,
         });
       });

--- a/src/redux/explorer/survivalAnalysisAPI.js
+++ b/src/redux/explorer/survivalAnalysisAPI.js
@@ -1,4 +1,5 @@
 import { fetchWithCreds } from '../utils.fetch';
+import { isSurvivalAnalysisEnabled } from './utils';
 
 /** @typedef {import('../../GuppyComponents/types').GqlFilter} GqlFilter */
 /** @typedef {import('./types').ExplorerConfig} ExplorerConfig */
@@ -28,5 +29,16 @@ export function fetchResult(body) {
   }).then(({ response, data, status }) => {
     if (status !== 200) throw response.statusText;
     return data;
+  });
+}
+
+/** @returns {Promise<ExplorerState['config']['survivalAnalysisConfig']>} */
+export function fetchConfig() {
+  return fetchWithCreds({
+    path: '/analysis/tools/survival/config',
+    method: 'GET',
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    return { ...data, enabled: isSurvivalAnalysisEnabled(data) };
   });
 }

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -113,10 +113,7 @@ export function getCurrentConfig(explorerId) {
     guppyConfig: config.guppyConfig,
     hideGetAccessButton: config.hideGetAccessButton,
     patientIdsConfig: config.patientIds,
-    survivalAnalysisConfig: {
-      ...config.survivalAnalysis,
-      enabled: isSurvivalAnalysisEnabled(config.survivalAnalysis),
-    },
+    survivalAnalysisConfig: { enabled: false },
     tableConfig: config.table,
   };
 }


### PR DESCRIPTION
Ticket: [PEDS-836](https://pcdc.atlassian.net/browse/PEDS-836)

This is a breaking change: client-side configuration for survival analysis no longer applies. Deploying the change must be coupled with a corresponding change to the `PcdcAnalysisTools` service (https://github.com/chicagopcdc/PcdcAnalysisTools/pull/57).

This PR implements the support for server-side survival configuration, which is available at the new `/tools/survival/config` endpoint.