### PR TITLE
Support composed filter state pt. 2 PEDS-703

### DIFF
--- a/.storybook/stories/FilterDisplay.jsx
+++ b/.storybook/stories/FilterDisplay.jsx
@@ -95,4 +95,21 @@ storiesOf('FilterDisplay', module)
         onCloseFilter={action('closeFilter')}
       />
     </div>
+  ))
+  .add('Composed', () => (
+    <FilterDisplay
+      filter={{
+        __combineMode: 'OR',
+        __type: FILTER_TYPE.COMPOSED,
+        value: [
+          {
+            __combineMode: 'AND',
+            __type: FILTER_TYPE.COMPOSED,
+            value: [simpleFilter, complexFilter],
+          },
+          complexFilter,
+        ],
+      }}
+      filterInfo={filterInfo}
+    />
   ));

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -11,16 +11,16 @@ import {
 
 /** @typedef {import('../types').FilterChangeHandler} FilterChangeHandler */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
-/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../types').SimpleAggsData} SimpleAggsData */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 /**
  * @typedef {Object} ConnectedFilterProps
  * @property {object} [adminAppliedPreFilters]
  * @property {string} [anchorValue]
  * @property {string} [className]
- * @property {FilterState} filter
+ * @property {StandardFilterState} filter
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
  * @property {boolean} [hidden]

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -20,23 +20,23 @@ import {
 
 /** @typedef {import('../types').AggsData} AggsData */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
+/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterTabsOption} FilterTabsOption */
 /** @typedef {import('../types').GqlSort} GqlSort */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../types').GuppyData} GuppyData */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
 /** @typedef {import('../types').SimpleAggsData} SimpleAggsData */
-/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 /**
  * @typedef {Object} GuppyWrapperProps
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
  * @property {{ [fieldName: string]: any }} chartConfig
  * @property {((data: GuppyData) => JSX.Element)} children
- * @property {StandardFilterState} explorerFilter
+ * @property {FilterState} explorerFilter
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
- * @property {(x: StandardFilterState) => void} onFilterChange
+ * @property {(x: FilterState) => void} onFilterChange
  * @property {string[]} patientIds
  * @property {string[]} rawDataFields
  */
@@ -104,7 +104,7 @@ function GuppyWrapper({
 
   /**
    * Add patient ids to filter if provided
-   * @param {StandardFilterState} filter
+   * @param {FilterState} filter
    */
   function augmentFilter(filter) {
     return patientIds?.length > 0
@@ -114,7 +114,7 @@ function GuppyWrapper({
       : filter;
   }
 
-  /** @param {StandardFilterState} filter */
+  /** @param {FilterState} filter */
   function fetchAggsChartDataFromGuppy(filter) {
     return queryGuppyForAggregationChartData({
       type: guppyConfig.dataType,
@@ -140,7 +140,7 @@ function GuppyWrapper({
     });
   }
 
-  /** @param {StandardFilterState} filter */
+  /** @param {FilterState} filter */
   function fetchAggsCountDataFromGuppy(filter) {
     return queryGuppyForAggregationCountData({
       type: guppyConfig.dataType,
@@ -164,7 +164,7 @@ function GuppyWrapper({
   /**
    * @param {Object} args
    * @param {string} args.anchorValue
-   * @param {StandardFilterState} args.filter
+   * @param {FilterState} args.filter
    * @param {FilterTabsOption[]} [args.filterTabs]
    */
   function fetchAggsOptionsDataFromGuppy({
@@ -209,7 +209,7 @@ function GuppyWrapper({
     });
   }
 
-  /** @param {StandardFilterState} filter */
+  /** @param {FilterState} filter */
   function fetchAggsDataFromGuppy(filter) {
     if (isMounted.current)
       setState((prevState) => ({ ...prevState, isLoadingAggsData: true }));
@@ -249,7 +249,7 @@ function GuppyWrapper({
   /**
    * @param {Object} args
    * @param {string[]} args.fields
-   * @param {StandardFilterState} [args.filter]
+   * @param {FilterState} [args.filter]
    * @param {number} [args.offset]
    * @param {number} [args.size]
    * @param {GqlSort} [args.sort]
@@ -401,7 +401,7 @@ function GuppyWrapper({
   /**
    * Get total count from other es type, with filter
    * @param {string} type
-   * @param {StandardFilterState} filter
+   * @param {FilterState} filter
    */
   function getTotalCountsByTypeAndFilter(type, filter) {
     return queryGuppyForTotalCounts({ type, filter });
@@ -410,7 +410,7 @@ function GuppyWrapper({
   /**
    * Get raw data from other es type, with filter
    * @param {string} type
-   * @param {StandardFilterState} filter
+   * @param {FilterState} filter
    * @param {string[]} fields
    */
   function downloadRawDataByTypeAndFilter(type, filter, fields) {
@@ -477,7 +477,7 @@ function GuppyWrapper({
     }
   }
 
-  /** @param {StandardFilterState} filter */
+  /** @param {FilterState} filter */
   function handleFilterChange(filter) {
     onFilterChange?.(mergeFilters(filter, adminAppliedPreFilters));
   }

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -11,7 +11,7 @@ import {
   getAllFieldsFromGuppy,
   getGQLFilter,
 } from '../Utils/queries';
-import { FILE_FORMATS, GUPPY_URL } from '../Utils/const';
+import { FILE_FORMATS, FILTER_TYPE, GUPPY_URL } from '../Utils/const';
 import {
   excludeSelfFilterFromAggsData,
   mergeFilters,
@@ -172,6 +172,13 @@ function GuppyWrapper({
     filter,
     filterTabs = filterConfig.tabs,
   }) {
+    if (filter.__type === FILTER_TYPE.COMPOSED)
+      return Promise.resolve({
+        aggsData: /** @type {AggsData} */ ({}),
+        initialTabsOptions: /** @type {SimpleAggsData} */ ({}),
+        tabsOptions: /** @type {SimpleAggsData} */ ({}),
+      });
+
     return queryGuppyForAggregationOptionsData({
       type: guppyConfig.dataType,
       anchorConfig: filterConfig.anchor,

--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -20,23 +20,23 @@ import {
 
 /** @typedef {import('../types').AggsData} AggsData */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
-/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterTabsOption} FilterTabsOption */
 /** @typedef {import('../types').GqlSort} GqlSort */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../types').GuppyData} GuppyData */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
 /** @typedef {import('../types').SimpleAggsData} SimpleAggsData */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 /**
  * @typedef {Object} GuppyWrapperProps
  * @property {{ [x: string]: OptionFilter }} adminAppliedPreFilters
  * @property {{ [fieldName: string]: any }} chartConfig
  * @property {((data: GuppyData) => JSX.Element)} children
- * @property {FilterState} explorerFilter
+ * @property {StandardFilterState} explorerFilter
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
- * @property {(x: FilterState) => void} onFilterChange
+ * @property {(x: StandardFilterState) => void} onFilterChange
  * @property {string[]} patientIds
  * @property {string[]} rawDataFields
  */
@@ -104,7 +104,7 @@ function GuppyWrapper({
 
   /**
    * Add patient ids to filter if provided
-   * @param {FilterState} filter
+   * @param {StandardFilterState} filter
    */
   function augmentFilter(filter) {
     return patientIds?.length > 0
@@ -114,7 +114,7 @@ function GuppyWrapper({
       : filter;
   }
 
-  /** @param {FilterState} filter */
+  /** @param {StandardFilterState} filter */
   function fetchAggsChartDataFromGuppy(filter) {
     return queryGuppyForAggregationChartData({
       type: guppyConfig.dataType,
@@ -140,7 +140,7 @@ function GuppyWrapper({
     });
   }
 
-  /** @param {FilterState} filter */
+  /** @param {StandardFilterState} filter */
   function fetchAggsCountDataFromGuppy(filter) {
     return queryGuppyForAggregationCountData({
       type: guppyConfig.dataType,
@@ -164,7 +164,7 @@ function GuppyWrapper({
   /**
    * @param {Object} args
    * @param {string} args.anchorValue
-   * @param {FilterState} args.filter
+   * @param {StandardFilterState} args.filter
    * @param {FilterTabsOption[]} [args.filterTabs]
    */
   function fetchAggsOptionsDataFromGuppy({
@@ -209,7 +209,7 @@ function GuppyWrapper({
     });
   }
 
-  /** @param {FilterState} filter */
+  /** @param {StandardFilterState} filter */
   function fetchAggsDataFromGuppy(filter) {
     if (isMounted.current)
       setState((prevState) => ({ ...prevState, isLoadingAggsData: true }));
@@ -249,7 +249,7 @@ function GuppyWrapper({
   /**
    * @param {Object} args
    * @param {string[]} args.fields
-   * @param {FilterState} [args.filter]
+   * @param {StandardFilterState} [args.filter]
    * @param {number} [args.offset]
    * @param {number} [args.size]
    * @param {GqlSort} [args.sort]
@@ -401,7 +401,7 @@ function GuppyWrapper({
   /**
    * Get total count from other es type, with filter
    * @param {string} type
-   * @param {FilterState} filter
+   * @param {StandardFilterState} filter
    */
   function getTotalCountsByTypeAndFilter(type, filter) {
     return queryGuppyForTotalCounts({ type, filter });
@@ -410,7 +410,7 @@ function GuppyWrapper({
   /**
    * Get raw data from other es type, with filter
    * @param {string} type
-   * @param {FilterState} filter
+   * @param {StandardFilterState} filter
    * @param {string[]} fields
    */
   function downloadRawDataByTypeAndFilter(type, filter, fields) {
@@ -477,7 +477,7 @@ function GuppyWrapper({
     }
   }
 
-  /** @param {FilterState} filter */
+  /** @param {StandardFilterState} filter */
   function handleFilterChange(filter) {
     onFilterChange?.(mergeFilters(filter, adminAppliedPreFilters));
   }

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -89,7 +89,7 @@ function mergeToStandardFilterState(userFilter, adminAppliedPreFilter) {
  * @returns {FilterState}
  */
 export function mergeFilters(userFilter, adminAppliedPreFilter) {
-  return userFilter.__type === FILTER_TYPE.COMPOSED
+  return userFilter?.__type === FILTER_TYPE.COMPOSED
     ? mergeToComposedFilterState(userFilter, adminAppliedPreFilter)
     : mergeToStandardFilterState(userFilter, adminAppliedPreFilter);
 }

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -5,7 +5,7 @@ import { queryGuppyForRawData } from './queries';
 
 /** @typedef {import('../types').AggsCount} AggsCount */
 /** @typedef {import('../types').AggsData} AggsData */
-/** @typedef {import('../types').FilterState} FilterState */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
@@ -20,11 +20,11 @@ import { queryGuppyForRawData } from './queries';
  * the user undoing the admin filter. (Multiple user checkboxes increase the
  * amount of data shown when combined, but an admin filter should always decrease
  * or keep constant the amount of data shown when combined with a user filter).
- * @param {FilterState} userFilter
+ * @param {StandardFilterState} userFilter
  * @param {{ [x: string]: { selectedValues?: string[] } }} adminAppliedPreFilter
  * */
 export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
-  /** @type {FilterState} */
+  /** @type {StandardFilterState} */
   const mergedFilterState = cloneDeep(userFilter ?? {});
   if (mergedFilterState.value === undefined) mergedFilterState.value = {};
 
@@ -68,7 +68,7 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
  * they are still checked but their counts are zero.
  * @param {AggsData} initialTabsOptions
  * @param {AggsData} tabsOptions
- * @param {FilterState} filtersApplied
+ * @param {StandardFilterState} filtersApplied
  */
 export function updateCountsInInitialTabsOptions(
   initialTabsOptions,
@@ -420,7 +420,7 @@ export const getFilterSections = ({
 
 /**
  * @param {AggsData} aggsData
- * @param {FilterState} filterResults
+ * @param {StandardFilterState} filterResults
  */
 export function excludeSelfFilterFromAggsData(aggsData, filterResults) {
   if (filterResults?.value === undefined) return aggsData;

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -5,12 +5,34 @@ import { queryGuppyForRawData } from './queries';
 
 /** @typedef {import('../types').AggsCount} AggsCount */
 /** @typedef {import('../types').AggsData} AggsData */
-/** @typedef {import('../types').StandardFilterState} StandardFilterState */
+/** @typedef {import('../types').ComposedFilterState} ComposedFilterState */
+/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
 /** @typedef {import('../types').SimpleAggsData} SimpleAggsData */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
+/** @typedef {{ [x: string]: { selectedValues?: string[] } }} AdminAppliedPreFilter */
+
+/**
+ * @param {ComposedFilterState} userFilter
+ * @param {AdminAppliedPreFilter} adminAppliedPreFilter
+ */
+function mergeToComposedFilterState(userFilter, adminAppliedPreFilter) {
+  const formattedAdminAppliedPreFilter = {
+    __combineMode: 'AND',
+    __type: FILTER_TYPE.STANDARD,
+    value: {},
+  };
+  for (const [key, value] of Object.entries(adminAppliedPreFilter))
+    value[key] = { __type: FILTER_TYPE.OPTION, ...value };
+
+  return /** @type {ComposedFilterState} */ ({
+    ...userFilter,
+    value: [...userFilter.value, formattedAdminAppliedPreFilter],
+  });
+}
 
 /**
  * This function takes two objects containing filters to be applied
@@ -21,9 +43,9 @@ import { queryGuppyForRawData } from './queries';
  * amount of data shown when combined, but an admin filter should always decrease
  * or keep constant the amount of data shown when combined with a user filter).
  * @param {StandardFilterState} userFilter
- * @param {{ [x: string]: { selectedValues?: string[] } }} adminAppliedPreFilter
+ * @param {AdminAppliedPreFilter} adminAppliedPreFilter
  * */
-export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
+function mergeToStandardFilterState(userFilter, adminAppliedPreFilter) {
   /** @type {StandardFilterState} */
   const mergedFilterState = cloneDeep(userFilter ?? {});
   if (mergedFilterState.value === undefined) mergedFilterState.value = {};
@@ -59,7 +81,18 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   }
 
   return mergedFilterState;
-};
+}
+
+/**
+ * @param {FilterState} userFilter
+ * @param {AdminAppliedPreFilter} adminAppliedPreFilter
+ * @returns {FilterState}
+ */
+export function mergeFilters(userFilter, adminAppliedPreFilter) {
+  return userFilter.__type === FILTER_TYPE.COMPOSED
+    ? mergeToComposedFilterState(userFilter, adminAppliedPreFilter)
+    : mergeToStandardFilterState(userFilter, adminAppliedPreFilter);
+}
 
 /**
  * This function updates the counts in the initial set of tab options
@@ -420,10 +453,14 @@ export const getFilterSections = ({
 
 /**
  * @param {AggsData} aggsData
- * @param {StandardFilterState} filterResults
+ * @param {FilterState} filterResults
  */
 export function excludeSelfFilterFromAggsData(aggsData, filterResults) {
-  if (filterResults?.value === undefined) return aggsData;
+  if (
+    filterResults?.value === undefined ||
+    filterResults.__type !== FILTER_TYPE.STANDARD
+  )
+    return aggsData;
 
   /** @type {SimpleAggsData} */
   const resultAggsData = {};

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -6,7 +6,7 @@ import { FILE_DELIMITERS, FILTER_TYPE, GUPPY_URL } from './const';
 /** @typedef {import('../types').AnchorConfig} AnchorConfig */
 /** @typedef {import('../types').AnchoredFilterState} AnchoredFilterState */
 /** @typedef {import('../types').ComposedFilterState} ComposedFilterState */
-/** @typedef {import('../types').FilterState} FilterState */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GqlInFilter} GqlInFilter */
 /** @typedef {import('../types').GqlSimpleFilter} GqlSimpleFilter */
@@ -640,7 +640,7 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
 
 /**
  * Convert filter obj into GQL filter format
- * @param {EmptyFilter | ComposedFilterState | FilterState} filterState
+ * @param {EmptyFilter | ComposedFilterState | StandardFilterState} filterState
  * @returns {GqlFilter}
  */
 export function getGQLFilter(filterState) {
@@ -757,7 +757,7 @@ export function downloadDataFromGuppy({
 /**
  * @param {object} args
  * @param {string} args.type
- * @param {FilterState} [args.filter]
+ * @param {StandardFilterState} [args.filter]
  */
 export function queryGuppyForTotalCounts({ type, filter }) {
   const query = (

--- a/src/GuppyComponents/Utils/queries.js
+++ b/src/GuppyComponents/Utils/queries.js
@@ -5,8 +5,7 @@ import { FILE_DELIMITERS, FILTER_TYPE, GUPPY_URL } from './const';
 
 /** @typedef {import('../types').AnchorConfig} AnchorConfig */
 /** @typedef {import('../types').AnchoredFilterState} AnchoredFilterState */
-/** @typedef {import('../types').ComposedFilterState} ComposedFilterState */
-/** @typedef {import('../types').StandardFilterState} StandardFilterState */
+/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').GqlFilter} GqlFilter */
 /** @typedef {import('../types').GqlInFilter} GqlInFilter */
 /** @typedef {import('../types').GqlSimpleFilter} GqlSimpleFilter */
@@ -640,7 +639,7 @@ function parseAnchoredFilters(anchorName, anchoredFilterState, combineMode) {
 
 /**
  * Convert filter obj into GQL filter format
- * @param {EmptyFilter | ComposedFilterState | StandardFilterState} filterState
+ * @param {EmptyFilter | FilterState} filterState
  * @returns {GqlFilter}
  */
 export function getGQLFilter(filterState) {
@@ -757,11 +756,16 @@ export function downloadDataFromGuppy({
 /**
  * @param {object} args
  * @param {string} args.type
- * @param {StandardFilterState} [args.filter]
+ * @param {FilterState} [args.filter]
  */
 export function queryGuppyForTotalCounts({ type, filter }) {
+  const hasFilter =
+    filter !== undefined ||
+    (filter.__type === FILTER_TYPE.COMPOSED
+      ? filter.value.length > 0
+      : Object.keys(filter.value ?? {}).length > 0);
   const query = (
-    filter !== undefined || Object.keys(filter).length > 0
+    hasFilter
       ? `query ($filter: JSON) {
         _aggregation {
           ${type} (filter: $filter, accessibility: all) {

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -37,6 +37,8 @@ export type ComposedFilterState = {
   value?: (ComposedFilterState | StandardFilterState)[];
 };
 
+export type FilterState = ComposedFilterState | StandardFilterState;
+
 export type GqlInFilter = {
   IN: {
     [x: string]: string[];
@@ -173,7 +175,7 @@ export type AggsData = {
     | SimpleAggsData;
 };
 
-export type FilterChangeHandler = (filter: StandardFilterState) => void;
+export type FilterChangeHandler = (filter: FilterState) => void;
 
 export type GuppyData = {
   accessibleCount: number;
@@ -181,7 +183,7 @@ export type GuppyData = {
   aggsData: AggsData;
   allFields: string[];
   anchorValue: string;
-  filter: StandardFilterState;
+  filter: FilterState;
   initialTabsOptions?: SimpleAggsData;
   isLoadingAggsData: boolean;
   isLoadingRawData: boolean;
@@ -195,12 +197,12 @@ export type GuppyData = {
   }) => Promise<void>;
   downloadRawDataByTypeAndFilter: (
     type: string,
-    filter: StandardFilterState,
+    filter: FilterState,
     fields: string[]
   ) => Promise<void>;
   getTotalCountsByTypeAndFilter: (
     type: string,
-    filter: StandardFilterState
+    filter: FilterState
   ) => Promise<void>;
   fetchAndUpdateRawData: (args: {
     offset: number;

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -23,7 +23,7 @@ export type AnchoredFilterState = {
   };
 };
 
-export type FilterState = {
+export type StandardFilterState = {
   __combineMode?: CombineMode;
   __type?: 'STANDARD';
   value?: {
@@ -34,7 +34,7 @@ export type FilterState = {
 export type ComposedFilterState = {
   __combineMode?: CombineMode;
   __type: 'COMPOSED';
-  value?: (ComposedFilterState | FilterState)[];
+  value?: (ComposedFilterState | StandardFilterState)[];
 };
 
 export type GqlInFilter = {
@@ -173,7 +173,7 @@ export type AggsData = {
     | SimpleAggsData;
 };
 
-export type FilterChangeHandler = (filter: FilterState) => void;
+export type FilterChangeHandler = (filter: StandardFilterState) => void;
 
 export type GuppyData = {
   accessibleCount: number;
@@ -181,7 +181,7 @@ export type GuppyData = {
   aggsData: AggsData;
   allFields: string[];
   anchorValue: string;
-  filter: FilterState;
+  filter: StandardFilterState;
   initialTabsOptions?: SimpleAggsData;
   isLoadingAggsData: boolean;
   isLoadingRawData: boolean;
@@ -195,12 +195,12 @@ export type GuppyData = {
   }) => Promise<void>;
   downloadRawDataByTypeAndFilter: (
     type: string,
-    filter: FilterState,
+    filter: StandardFilterState,
     fields: string[]
   ) => Promise<void>;
   getTotalCountsByTypeAndFilter: (
     type: string,
-    filter: FilterState
+    filter: StandardFilterState
   ) => Promise<void>;
   fetchAndUpdateRawData: (args: {
     offset: number;

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -265,7 +265,10 @@ class ExplorerButtonGroup extends Component {
         selectedValues: refIDList,
       },
     };
-    if (this.props.filter.value.data_format) {
+    if (
+      !Array.isArray(this.props.filter.value) &&
+      this.props.filter.value.data_format
+    ) {
       // @ts-ignore
       filter.data_format = this.props.filter.data_format;
     }

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import ConnectedFilter from '../../GuppyComponents/ConnectedFilter';
 import { updatePatientIds } from '../../redux/explorer/slice';
@@ -6,6 +7,33 @@ import './ExplorerFilter.css';
 
 /** @typedef {import('../../redux/types').RootState} RootState */
 /** @typedef {import('../types').GuppyData} GuppyData */
+
+/** @param {{ className: string }} props */
+export function DisabledExplorerFilter({ className }) {
+  return (
+    <div className={className}>
+      <div className='explorer-filter__title-container'>
+        <h4 className='explorer-filter__title'>Filters</h4>
+      </div>
+      <p style={{ marginBottom: '1rem' }}>
+        <FontAwesomeIcon
+          className='screen-size-warning__icon'
+          icon='triangle-exclamation'
+          color='var(--pcdc-color__secondary)'
+        />
+        <em>Composed filter state cannot be modified!</em>
+      </p>
+      <p>
+        Use Filter Set Workspace to build new filter sets or load saved ones
+        with composed filter states.
+      </p>
+    </div>
+  );
+}
+
+DisabledExplorerFilter.propTypes = {
+  className: PropTypes.string,
+};
 
 /**
  * @typedef {Object} ExplorerFilterProps

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import './ExplorerFilter.css';
 
 /** @typedef {import('../../redux/types').RootState} RootState */
+/** @typedef {import('../../GuppyComponents/types').StandardFilterState} StandardFilterState */
 /** @typedef {import('../types').GuppyData} GuppyData */
 
 /** @param {{ className: string }} props */
@@ -40,7 +41,7 @@ DisabledExplorerFilter.propTypes = {
  * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {GuppyData['initialTabsOptions']} [initialTabsOptions]
- * @property {GuppyData['filter']} filter
+ * @property {StandardFilterState} filter
  * @property {GuppyData['onFilterChange']} onFilterChange
  * @property {GuppyData['onAnchorValueChange']} onAnchorValueChange
  * @property {GuppyData['tabsOptions']} tabsOptions

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -16,6 +16,7 @@ import FilterSetLabel from './FilterSetLabel';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 import {
   checkIfFilterEmpty,
+  FILTER_TYPE,
   pluckFromAnchorFilter,
   pluckFromFilter,
 } from './utils';
@@ -107,15 +108,17 @@ function ExplorerFilterSetWorkspace() {
 
   /** @type {import('../../components/FilterDisplay').ClickCombineModeHandler} */
   function handleClickCombineMode(payload) {
-    handleFilterChange(
-      /** @type {import('../types').ExplorerFilter} */ ({
-        ...activeFilterSet.filter,
-        __combineMode: payload === 'AND' ? 'OR' : 'AND',
-      })
-    );
+    if (activeFilterSet.filter.__type !== FILTER_TYPE.STANDARD) return;
+
+    handleFilterChange({
+      ...activeFilterSet.filter,
+      __combineMode: payload === 'AND' ? 'OR' : 'AND',
+    });
   }
   /** @type {import('../../components/FilterDisplay').ClickFilterHandler} */
   function handleCloseFilter(payload) {
+    if (activeFilterSet.filter.__type !== FILTER_TYPE.STANDARD) return;
+
     const { field, anchorField, anchorValue } = payload;
     const { filter } = activeFilterSet;
     if (anchorField !== undefined && anchorValue !== undefined) {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -3,12 +3,13 @@ import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
 /** @typedef {import('../../GuppyComponents/types').AnchoredFilterState} AnchoredFilterState */
+/** @typedef {import('../../GuppyComponents/types').StandardFilterState} StandardFilterState */
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 /**
  * @template T
  * @param {Object} args
  * @param {string} args.field
- * @param {T extends AnchoredFilterState ? AnchoredFilterState : ExplorerFilter} args.filter
+ * @param {T extends AnchoredFilterState ? AnchoredFilterState : StandardFilterState} args.filter
  */
 function _pluckFromFilter({ field, filter }) {
   const newFilter = { ...filter };
@@ -22,17 +23,17 @@ function _pluckFromFilter({ field, filter }) {
   return newFilter;
 }
 
-/** @type {typeof _pluckFromFilter<ExplorerFilter>} */
+/** @type {typeof _pluckFromFilter<StandardFilterState>} */
 export const pluckFromFilter = _pluckFromFilter;
 
 /**
  * @param {Object} args
  * @param {string} args.anchor
  * @param {string} args.field
- * @param {ExplorerFilter} args.filter
+ * @param {StandardFilterState} args.filter
  */
 export function pluckFromAnchorFilter({ anchor, field, filter }) {
-  /** @type {ExplorerFilter} */
+  /** @type {StandardFilterState} */
   const newFilter = { ...filter };
   if (Object.keys(newFilter).length === 0) return newFilter;
 
@@ -54,5 +55,7 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
 
 /** @param {ExplorerFilter} filter */
 export function checkIfFilterEmpty(filter) {
-  return Object.keys(filter.value ?? {}).length === 0;
+  return filter.__type === FILTER_TYPE.COMPOSED
+    ? filter.value.length === 0
+    : Object.keys(filter.value ?? {}).length === 0;
 }

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -3,7 +3,6 @@ import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
 /** @typedef {import('../../GuppyComponents/types').AnchoredFilterState} AnchoredFilterState */
-/** @typedef {import('../../GuppyComponents/types').FilterState} FilterState */
 /** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
 /**
  * @template T

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -10,8 +10,9 @@ import { updateExplorerFilter, useExplorerById } from '../redux/explorer/slice';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import ExplorerSelect from './ExplorerSelect';
 import ExplorerVisualization from './ExplorerVisualization';
-import ExplorerFilter from './ExplorerFilter';
+import ExplorerFilter, { DisabledExplorerFilter } from './ExplorerFilter';
 import './Explorer.css';
+import { FILTER_TYPE } from './ExplorerFilterSetWorkspace/utils';
 
 /** @typedef {import('../redux/types').RootState} RootState */
 /** @typedef {import('./types').OptionFilter} OptionFilter */
@@ -87,15 +88,19 @@ function ExplorerDashboard() {
           <Dashboard.Sidebar className='explorer__sidebar'>
             <div>
               <ExplorerSelect />
-              <ExplorerFilter
-                anchorValue={data.anchorValue}
-                className='explorer__filter'
-                filter={data.filter}
-                initialTabsOptions={data.initialTabsOptions}
-                onAnchorValueChange={data.onAnchorValueChange}
-                onFilterChange={data.onFilterChange}
-                tabsOptions={data.tabsOptions}
-              />
+              {data.filter.__type === FILTER_TYPE.COMPOSED ? (
+                <DisabledExplorerFilter className='explorer__filter' />
+              ) : (
+                <ExplorerFilter
+                  anchorValue={data.anchorValue}
+                  className='explorer__filter'
+                  filter={data.filter}
+                  initialTabsOptions={data.initialTabsOptions}
+                  onAnchorValueChange={data.onAnchorValueChange}
+                  onFilterChange={data.onFilterChange}
+                  tabsOptions={data.tabsOptions}
+                />
+              )}
             </div>
             <div className='explorer__version-info-area'>
               {dataVersion !== '' && (

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -1,4 +1,4 @@
-import { GqlFilter, StandardFilterState } from '../GuppyComponents/types';
+import { FilterState, GqlFilter } from '../GuppyComponents/types';
 
 export type {
   FilterConfig,
@@ -9,7 +9,7 @@ export type {
   SimpleAggsData,
 } from '../GuppyComponents/types';
 
-export type ExplorerFilter = StandardFilterState;
+export type ExplorerFilter = FilterState;
 
 export type SingleChartConfig = {
   chartType: string;

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -1,4 +1,4 @@
-import { FilterState, GqlFilter } from '../GuppyComponents/types';
+import { GqlFilter, StandardFilterState } from '../GuppyComponents/types';
 
 export type {
   FilterConfig,
@@ -9,7 +9,7 @@ export type {
   SimpleAggsData,
 } from '../GuppyComponents/types';
 
-export type ExplorerFilter = FilterState;
+export type ExplorerFilter = StandardFilterState;
 
 export type SingleChartConfig = {
   chartType: string;

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -59,6 +59,7 @@ Pill.propTypes = {
   onClose: PropTypes.func,
 };
 
+/** @typedef {import('../GuppyComponents/types').ComposedFilterState} ComposedFilterState */
 /** @typedef {import('../GuppyComponents/types').FilterConfig} FilterConfig */
 /** @typedef {import('../GuppyComponents/types').StandardFilterState} StandardFilterState */
 
@@ -66,7 +67,7 @@ Pill.propTypes = {
  * @param {Object} props
  * @param {[anchorField: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
- * @param {StandardFilterState} props.filter
+ * @param {ComposedFilterState | StandardFilterState} props.filter
  * @param {FilterConfig['info']} props.filterInfo
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]
@@ -81,6 +82,20 @@ function FilterDisplay({
   onClickFilter,
   onCloseFilter,
 }) {
+  if (filter.__type === FILTER_TYPE.COMPOSED)
+    return (
+      <span className='filter-display'>
+        {filter.value.map((__filter, i) => (
+          <Fragment key={i}>
+            <span className='pill-container'>
+              <FilterDisplay filter={__filter} filterInfo={filterInfo} />
+            </span>
+            {i < filter.value.length - 1 && <Pill>{filter.__combineMode}</Pill>}
+          </Fragment>
+        ))}
+      </span>
+    );
+
   const filterElements = /** @type {JSX.Element[]} */ ([]);
   const { __combineMode, value: __filter } = filter;
   const filterCombineMode = combineMode ?? __combineMode ?? 'AND';

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -59,15 +59,14 @@ Pill.propTypes = {
   onClose: PropTypes.func,
 };
 
-/** @typedef {import('../GuppyComponents/types').ComposedFilterState} ComposedFilterState */
 /** @typedef {import('../GuppyComponents/types').FilterConfig} FilterConfig */
-/** @typedef {import('../GuppyComponents/types').StandardFilterState} StandardFilterState */
+/** @typedef {import('../GuppyComponents/types').FilterState} FilterState */
 
 /**
  * @param {Object} props
  * @param {[anchorField: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
- * @param {ComposedFilterState | StandardFilterState} props.filter
+ * @param {FilterState} props.filter
  * @param {FilterConfig['info']} props.filterInfo
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -59,12 +59,15 @@ Pill.propTypes = {
   onClose: PropTypes.func,
 };
 
+/** @typedef {import('../GuppyComponents/types').FilterConfig} FilterConfig */
+/** @typedef {import('../GuppyComponents/types').StandardFilterState} StandardFilterState */
+
 /**
  * @param {Object} props
  * @param {[anchorField: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
- * @param {import('../GuppyComponents/types').FilterState} props.filter
- * @param {import('../GuppyComponents/types').FilterConfig['info']} props.filterInfo
+ * @param {StandardFilterState} props.filter
+ * @param {FilterConfig['info']} props.filterInfo
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]
  * @param {ClickFilterHandler} [props.onCloseFilter]

--- a/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/FilterGroup.utils.test.js
@@ -12,9 +12,9 @@ import {
   getSelectedAnchors,
 } from './utils';
 
-/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterStatus} FilterStatus */
 /** @typedef {import('../types').FilterTabsOption} FilterTabsOption */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 describe('Get expanded status array for all tabs', () => {
   const filterTabs = [
@@ -331,7 +331,7 @@ describe('Clear a single filter section', () => {
   /**
    * @param {Object} args
    * @param {string} [args.anchorLabel]
-   * @param {FilterState} [args.filterResults]
+   * @param {StandardFilterState} [args.filterResults]
    * @param {FilterStatus} [args.filterStatus]
    * @param {FilterTabsOption[]} [args.filterTabs]
    * @param {number} args.sectionIndex
@@ -567,7 +567,7 @@ describe('Toggles combine mode in option filter', () => {
   /**
    * @param {Object} args
    * @param {FilterStatus} args.filterStatus
-   * @param {FilterState} args.filterResults
+   * @param {StandardFilterState} args.filterResults
    * @param {string} [args.anchorLabel]
    * @param {'AND' | 'OR'} args.combineModeValue
    */
@@ -749,7 +749,7 @@ describe('Update a range filter', () => {
   /**
    * @param {Object} args
    * @param {FilterStatus} [args.filterStatus]
-   * @param {FilterState} [args.filterResults]
+   * @param {StandardFilterState} [args.filterResults]
    * @param {string} [args.anchorLabel]
    * @param {number} args.lowerBound
    * @param {number} args.upperBound
@@ -889,7 +889,7 @@ describe('Update an option filter', () => {
   /**
    * @param {Object} args
    * @param {FilterStatus} args.filterStatus
-   * @param {FilterState} args.filterResults
+   * @param {StandardFilterState} args.filterResults
    * @param {string} [args.anchorLabel]
    * @param {string} args.selectedValue
    */

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -35,15 +35,15 @@ function findFilterElement(label) {
 /** @typedef {import('../types').EmptyFilter} EmptyFilter */
 /** @typedef {import('../types').FilterChangeHandler} FilterChangeHandler */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
-/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterSectionConfig} FilterSectionConfig */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 /**
  * @typedef {Object} FilterGroupProps
  * @property {string} [anchorValue]
  * @property {string} [className]
  * @property {string} [disabledTooltipMessage]
- * @property {EmptyFilter | FilterState} [filter]
+ * @property {EmptyFilter | StandardFilterState} [filter]
  * @property {FilterConfig} filterConfig
  * @property {boolean} [hideZero]
  * @property {string} [lockedTooltipMessage]

--- a/src/gen3-ui-component/components/filters/FilterGroup/utils.js
+++ b/src/gen3-ui-component/components/filters/FilterGroup/utils.js
@@ -7,12 +7,12 @@ export { FILTER_TYPE } from '../../../../GuppyComponents/Utils/const';
 /** @typedef {import('../types').AnchoredFilterState} AnchoredFilterState */
 /** @typedef {import('../types').AnchoredFilterTabStatus} AnchoredFilterTabStatus */
 /** @typedef {import('../types').FilterSectionStatus} FilterSectionStatus */
-/** @typedef {import('../types').FilterState} FilterState */
 /** @typedef {import('../types').FilterStatus} FilterStatus */
 /** @typedef {import('../types').FilterTabsOption} FilterTabsOption */
 /** @typedef {import('../types').FilterTabStatus} FilterTabStatus */
 /** @typedef {import('../types').BaseFilter} BaseFilter */
 /** @typedef {import('../types').OptionFilter} OptionFilter */
+/** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
 /**
  * @param {FilterTabsOption[]} filterTabs
@@ -27,7 +27,7 @@ export function getExpandedStatus(filterTabs, expandedStatusControl) {
 /**
  * @param {Object} args
  * @param {AnchorConfig} [args.anchorConfig]
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  */
 export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
   /** @type {{ [anchorLabel: string]: AnchoredFilterState['value'] }} */
@@ -52,7 +52,7 @@ export function getFilterResultsByAnchor({ anchorConfig, filterResults }) {
 
 /**
  * @param {string[]} fields
- * @param {FilterState} filterResults
+ * @param {StandardFilterState} filterResults
  * @returns {FilterTabStatus}
  */
 function getFilterTabStatus(fields, filterResults) {
@@ -76,7 +76,7 @@ function getFilterTabStatus(fields, filterResults) {
 /**
  * @param {Object} args
  * @param {AnchorConfig} [args.anchorConfig]
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @returns {FilterStatus}
  */
@@ -126,11 +126,11 @@ function _removeEmptyFilter(anchoredFilter) {
 }
 
 /**
- * @param {FilterState} filterResults
- * @returns {FilterState}
+ * @param {StandardFilterState} filterResults
+ * @returns {StandardFilterState}
  */
 export function removeEmptyFilter(filterResults) {
-  const newValue = /** @type {FilterState['value']} */ ({});
+  const newValue = /** @type {StandardFilterState['value']} */ ({});
   for (const [field, filter] of Object.entries(filterResults.value))
     if (filter.__type === FILTER_TYPE.ANCHORED) {
       const newAnchoredFilter = _removeEmptyFilter(filter);
@@ -146,7 +146,7 @@ export function removeEmptyFilter(filterResults) {
 /**
  * @param {Object} args
  * @param {FilterStatus} args.filterStatus
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
  * @param {string} args.anchorLabel
@@ -204,7 +204,7 @@ export function tabHasActiveFilters(filterTabStatus) {
 /**
  * @param {Object} args
  * @param {FilterStatus} args.filterStatus
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
  * @param {string} args.anchorLabel
@@ -280,7 +280,7 @@ export function updateCombineMode({
 /**
  * @param {Object} args
  * @param {FilterStatus} args.filterStatus
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
  * @param {string} args.anchorLabel
@@ -367,7 +367,7 @@ export function updateRangeValue({
 /**
  * @param {Object} args
  * @param {FilterStatus} args.filterStatus
- * @param {FilterState} args.filterResults
+ * @param {StandardFilterState} args.filterResults
  * @param {FilterTabsOption[]} args.filterTabs
  * @param {number} args.tabIndex
  * @param {string} args.anchorLabel

--- a/src/gen3-ui-component/components/filters/types.d.ts
+++ b/src/gen3-ui-component/components/filters/types.d.ts
@@ -3,9 +3,9 @@ import type { Response as PaginateResponse } from 'react-select-async-paginate';
 export type {
   AnchorConfig,
   AnchoredFilterState,
+  StandardFilterState,
   FilterChangeHandler,
   FilterConfig,
-  FilterState,
   FilterTabsOption,
   BaseFilter,
   EmptyFilter,


### PR DESCRIPTION
Ticket: [PEDS-703](https://pcdc.atlassian.net/browse/PEDS-703)

This PR is the second step toward supporting "composed" filter state and a follow-up to https://github.com/chicagopcdc/data-portal/pull/451.

The focus of this PR includes:
* integrating `ComposedFilterState` type into the generic `FilterState` type; and 
* implementing UI support to display composed filter content
  * also to prevent direct update to filter state for composed filter

Here's a screenshot of an active filter set with composed filter content:

![image](https://user-images.githubusercontent.com/22449454/186468092-47e841d8-8a56-4c20-bba3-8387001c8154.png)