### PR TITLE
Support filter state with reference PEDS-840

### DIFF
--- a/.storybook/stories/FilterDisplay.jsx
+++ b/.storybook/stories/FilterDisplay.jsx
@@ -112,4 +112,26 @@ storiesOf('FilterDisplay', module)
       }}
       filterInfo={filterInfo}
     />
+  ))
+  .add('Composed with ref', () => (
+    <FilterDisplay
+      filter={{
+        __combineMode: 'OR',
+        __type: FILTER_TYPE.COMPOSED,
+        value: [
+          { __type: 'REF', value: { id: '', label: 'Ref #1' } },
+          {
+            __combineMode: 'AND',
+            __type: FILTER_TYPE.COMPOSED,
+            value: [
+              simpleFilter,
+              complexFilter,
+              { __type: 'REF', value: { id: '', label: 'Ref #2' } },
+            ],
+          },
+          complexFilter,
+        ],
+      }}
+      filterInfo={filterInfo}
+    />
   ));

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -3,11 +3,9 @@ import FilterDisplay from '../../components/FilterDisplay';
 import { useAppSelector } from '../../redux/hooks';
 import './ExplorerFilterDisplay.css';
 
-/** @typedef {import('../../redux/types').RootState} RootState */
-
 /**
  * @param {Object} props
- * @param {import('../types').ExplorerFilter} props.filter
+ * @param {import('../types').ExplorerFilterSet['filter']} props.filter
  * @param {string} [props.title]
  */
 function ExplorerFilterDisplay({ filter, title = 'Filters' }) {

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetCreateForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetCreateForm.jsx
@@ -7,16 +7,15 @@ import { defaultFilterSet as survivalDefaultFilterSet } from '../ExplorerSurviva
 import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 import './ExplorerFilterSetForms.css';
 
-/** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
-/** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 
 /**
  * @param {Object} prop
- * @param {ExplorerFilterSet} prop.currentFilterSet
- * @param {ExplorerFilter} prop.currentFilter
- * @param {ExplorerFilterSet[]} prop.filterSets
+ * @param {SavedExplorerFilterSet} prop.currentFilterSet
+ * @param {SavedExplorerFilterSet['filter']} prop.currentFilter
+ * @param {SavedExplorerFilterSet[]} prop.filterSets
  * @param {boolean} prop.isFiltersChanged
- * @param {(created: ExplorerFilterSet) => void} prop.onAction
+ * @param {(created: SavedExplorerFilterSet) => void} prop.onAction
  * @param {() => void} prop.onClose
  */
 function FilterSetCreateForm({

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetUpdateForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetUpdateForm.jsx
@@ -6,16 +6,15 @@ import Button from '../../gen3-ui-component/components/Button';
 import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 import './ExplorerFilterSetForms.css';
 
-/** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
-/** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 
 /**
  * @param {Object} prop
- * @param {ExplorerFilterSet} prop.currentFilterSet
- * @param {ExplorerFilter} prop.currentFilter
- * @param {ExplorerFilterSet[]} prop.filterSets
+ * @param {SavedExplorerFilterSet} prop.currentFilterSet
+ * @param {SavedExplorerFilterSet['filter']} prop.currentFilter
+ * @param {SavedExplorerFilterSet[]} prop.filterSets
  * @param {boolean} prop.isFiltersChanged
- * @param {(updated: ExplorerFilterSet) => void} prop.onAction
+ * @param {(updated: SavedExplorerFilterSet) => void} prop.onAction
  * @param {() => void} prop.onClose
  */
 function FilterSetUpdateForm({

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -6,18 +6,19 @@ import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
 import FilterSetUpdateForm from '../ExplorerFilterSetForms/FilterSetUpdateForm';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 /** @typedef {'CLEAR-ALL' | 'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
 
 /**
  * @param {Object} prop
- * @param {ExplorerFilterSet['filter']} prop.currentFilter
- * @param {{ active: ExplorerFilterSet; all: ExplorerFilterSet[]; empty: ExplorerFilterSet }} prop.filterSets
+ * @param {SavedExplorerFilterSet['filter']} prop.currentFilter
+ * @param {{ active: SavedExplorerFilterSet; all: SavedExplorerFilterSet[]; empty: SavedExplorerFilterSet }} prop.filterSets
  * @param {Object} prop.handlers
  * @param {() => void} prop.handlers.clearAll
  * @param {() => void} prop.handlers.close
- * @param {(deleted: ExplorerFilterSet) => void} prop.handlers.delete
- * @param {(loaded: ExplorerFilterSet) => void} prop.handlers.load
- * @param {(saved: ExplorerFilterSet) => void} prop.handlers.save
+ * @param {(deleted: SavedExplorerFilterSet) => void} prop.handlers.delete
+ * @param {(loaded: SavedExplorerFilterSet) => void} prop.handlers.load
+ * @param {(saved: SavedExplorerFilterSet) => void} prop.handlers.save
  * @param {ActionFormType} prop.type
  */
 function FilterSetActionForm({ currentFilter, filterSets, handlers, type }) {

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -16,6 +16,7 @@ import FilterSetLabel from './FilterSetLabel';
 import useFilterSetWorkspace from './useFilterSetWorkspace';
 import {
   checkIfFilterEmpty,
+  dereferenceFilter,
   FILTER_TYPE,
   pluckFromAnchorFilter,
   pluckFromFilter,
@@ -311,7 +312,9 @@ function ExplorerFilterSetWorkspace() {
       {actionFormType !== undefined && (
         <SimplePopup>
           <FilterSetActionForm
-            currentFilter={activeFilterSet?.filter ?? {}}
+            currentFilter={
+              dereferenceFilter(activeFilterSet?.filter, workspace) ?? {}
+            }
             filterSets={{
               active: activeSavedFilterSet,
               all: savedFilterSets.data,

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -22,7 +22,7 @@ import {
 } from './utils';
 import './ExplorerFilterSetWorkspace.css';
 
-/** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 /** @typedef {import('./FilterSetActionForm').ActionFormType} ActionFormType */
 
 function ExplorerFilterSetWorkspace() {
@@ -60,7 +60,7 @@ function ExplorerFilterSetWorkspace() {
   function handleCreate() {
     workspace.create();
   }
-  /** @param {ExplorerFilterSet} deleted */
+  /** @param {SavedExplorerFilterSet} deleted */
   async function handleDelete(deleted) {
     try {
       await dispatch(deleteFilterSet(deleted));
@@ -72,7 +72,7 @@ function ExplorerFilterSetWorkspace() {
   function handleDuplicate() {
     workspace.duplicate();
   }
-  /** @param {ExplorerFilterSet} loaded */
+  /** @param {SavedExplorerFilterSet} loaded */
   function handleLoad(loaded) {
     let newActiveId;
     for (const [id, filterSet] of Object.entries(workspace.all))
@@ -86,7 +86,7 @@ function ExplorerFilterSetWorkspace() {
 
     closeActionForm();
   }
-  /** @param {ExplorerFilterSet} saved */
+  /** @param {SavedExplorerFilterSet} saved */
   async function handleSave(saved) {
     try {
       if (saved.id === undefined) await dispatch(createFilterSet(saved));

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -1,6 +1,7 @@
 import { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
 export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
+export { dereferenceFilter } from '../../redux/explorer/utils';
 
 /** @typedef {import('../../GuppyComponents/types').AnchoredFilterState} AnchoredFilterState */
 /** @typedef {import('../../GuppyComponents/types').StandardFilterState} StandardFilterState */

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/utils.js
@@ -4,7 +4,7 @@ export { FILTER_TYPE } from '../../GuppyComponents/Utils/const';
 
 /** @typedef {import('../../GuppyComponents/types').AnchoredFilterState} AnchoredFilterState */
 /** @typedef {import('../../GuppyComponents/types').StandardFilterState} StandardFilterState */
-/** @typedef {import("../types").ExplorerFilter} ExplorerFilter */
+/** @typedef {import("../types").ExplorerFilterSet} ExplorerFilterSet */
 /**
  * @template T
  * @param {Object} args
@@ -53,7 +53,7 @@ export function pluckFromAnchorFilter({ anchor, field, filter }) {
   return newFilter;
 }
 
-/** @param {ExplorerFilter} filter */
+/** @param {ExplorerFilterSet['filter']} filter */
 export function checkIfFilterEmpty(filter) {
   return filter.__type === FILTER_TYPE.COMPOSED
     ? filter.value.length === 0

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/types.d.ts
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/types.d.ts
@@ -1,5 +1,5 @@
 export type { GqlFilter } from '../../GuppyComponents/types';
-export type { ExplorerFilterSet } from '../types';
+export type { ExplorerFilterSet, SavedExplorerFilterSet } from '../types';
 
 export type ColorScheme = {
   [key: string]: string;
@@ -52,7 +52,7 @@ export type UserInput = {
   startTime: number;
   endTime: number;
   efsFlag: boolean;
-  usedFilterSets: ExplorerFilterSet[];
+  usedFilterSets: SavedExplorerFilterSet[];
 };
 
 export type UserInputSubmitHandler = (userInput: UserInput) => void;

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -64,13 +64,25 @@ export type SurvivalAnalysisConfig = {
   };
 };
 
-export type ExplorerFilterSet = {
+export type SavedExplorerFilterSet = {
   description: string;
   explorerId?: number;
-  filter: ExplorerFilter;
+  filter: FilterState;
   id?: number;
   name: string;
 };
+
+export type UnsavedExplorerFilterSet = {
+  description?: never;
+  explorerId?: never;
+  filter: FilterState;
+  id?: never;
+  name?: never;
+};
+
+export type ExplorerFilterSet =
+  | SavedExplorerFilterSet
+  | UnsavedExplorerFilterSet;
 
 export type ExplorerFilterSetDTO = {
   description: string;

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -1,4 +1,9 @@
-import { FilterState, GqlFilter } from '../GuppyComponents/types';
+import {
+  ComposedFilterState,
+  FilterState,
+  GqlFilter,
+  StandardFilterState,
+} from '../GuppyComponents/types';
 
 export type {
   FilterConfig,
@@ -10,6 +15,18 @@ export type {
 } from '../GuppyComponents/types';
 
 export type ExplorerFilter = FilterState;
+
+export type RefFilterState = {
+  __type: 'REF';
+  value: {
+    id: string;
+    label: string;
+  };
+};
+
+export interface ComposedFilterStateWithRef extends ComposedFilterState {
+  value?: (ComposedFilterStateWithRef | StandardFilterState | RefFilterState)[];
+}
 
 export type SingleChartConfig = {
   chartType: string;
@@ -75,7 +92,7 @@ export type SavedExplorerFilterSet = {
 export type UnsavedExplorerFilterSet = {
   description?: never;
   explorerId?: never;
-  filter: FilterState;
+  filter: ComposedFilterStateWithRef | StandardFilterState;
   id?: never;
   name?: never;
 };

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -86,9 +86,13 @@ function FilterDisplay({
       <span className='filter-display'>
         {filter.value.map((__filter, i) => (
           <Fragment key={i}>
-            <span className='pill-container'>
-              <FilterDisplay filter={__filter} filterInfo={filterInfo} />
-            </span>
+            {__filter.__type === 'REF' ? (
+              <Pill>{__filter.value.label}</Pill>
+            ) : (
+              <span className='pill-container'>
+                <FilterDisplay filter={__filter} filterInfo={filterInfo} />
+              </span>
+            )}
             {i < filter.value.length - 1 && <Pill>{filter.__combineMode}</Pill>}
           </Fragment>
         ))}

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -60,13 +60,13 @@ Pill.propTypes = {
 };
 
 /** @typedef {import('../GuppyComponents/types').FilterConfig} FilterConfig */
-/** @typedef {import('../GuppyComponents/types').FilterState} FilterState */
+/** @typedef {import('../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
 
 /**
  * @param {Object} props
  * @param {[anchorField: string, anchorValue: string]} [props.anchorInfo]
  * @param {'AND' | 'OR'} [props.combineMode]
- * @param {FilterState} props.filter
+ * @param {ExplorerFilterSet['filter']} props.filter
  * @param {FilterConfig['info']} props.filterInfo
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]

--- a/src/redux/explorer/asyncThunks.js
+++ b/src/redux/explorer/asyncThunks.js
@@ -3,13 +3,13 @@ import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 import * as filterSetsAPI from './filterSetsAPI';
 import * as survivalAnalysisAPI from './survivalAnalysisAPI';
 
-/** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../../GuppyDataExplorer/types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 /** @typedef {import('../types').AppGetState} AppGetState */
 /** @typedef {import('./types').ExplorerState} ExplorerState */
 
 export const createFilterSet = createAsyncThunk(
   'explorer/createFilterSet',
-  /** @param {ExplorerFilterSet} filterSet */
+  /** @param {SavedExplorerFilterSet} filterSet */
   async (filterSet, { getState, rejectWithValue }) => {
     const { explorer } = /** @type {AppGetState} */ (getState)();
     try {
@@ -22,7 +22,7 @@ export const createFilterSet = createAsyncThunk(
 
 export const deleteFilterSet = createAsyncThunk(
   'explorer/deleteFilterSet',
-  /** @param {ExplorerFilterSet} filterSet */
+  /** @param {SavedExplorerFilterSet} filterSet */
   async (filterSet, { getState, rejectWithValue }) => {
     const { explorer } = /** @type {AppGetState} */ (getState)();
     try {
@@ -47,7 +47,7 @@ export const fetchFilterSets = createAsyncThunk(
 
 export const updateFilterSet = createAsyncThunk(
   'explorer/updateFilterSet',
-  /** @param {ExplorerFilterSet} filterSet */
+  /** @param {SavedExplorerFilterSet} filterSet */
   async (filterSet, { getState, rejectWithValue }) => {
     const { explorer } = /** @type {AppGetState} */ (getState)();
     try {
@@ -64,7 +64,7 @@ export const updateSurvivalResult = createAsyncThunk(
    * @param {{
    *  efsFlag: boolean;
    *  shouldRefetch?: boolean
-   *  usedFilterSets: (ExplorerFilterSet & { isStale?: boolean })[];
+   *  usedFilterSets: (SavedExplorerFilterSet & { isStale?: boolean })[];
    * }} args
    */
   async (args, { getState, rejectWithValue }) => {

--- a/src/redux/explorer/filterSetsAPI.js
+++ b/src/redux/explorer/filterSetsAPI.js
@@ -1,14 +1,14 @@
 import { fetchWithCreds } from '../utils.fetch';
 import { convertFromFilterSetDTO, convertToFilterSetDTO } from './utils';
 
-/** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../../GuppyDataExplorer/types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 
 const FILTER_SET_URL = '/amanuensis/filter-sets';
 
 /**
  * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
- * @returns {Promise<ExplorerFilterSet>}
+ * @param {SavedExplorerFilterSet} filterSet
+ * @returns {Promise<SavedExplorerFilterSet>}
  */
 export function createNew(explorerId, filterSet) {
   return fetchWithCreds({
@@ -23,7 +23,7 @@ export function createNew(explorerId, filterSet) {
 
 /**
  * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
+ * @param {SavedExplorerFilterSet} filterSet
  */
 export function deleteById(explorerId, filterSet) {
   return fetchWithCreds({
@@ -37,7 +37,7 @@ export function deleteById(explorerId, filterSet) {
 
 /**
  * @param {number} explorerId
- * @returns {Promise<ExplorerFilterSet[]>}
+ * @returns {Promise<SavedExplorerFilterSet[]>}
  */
 export function fetchAll(explorerId) {
   return fetchWithCreds({
@@ -58,7 +58,7 @@ export function fetchAll(explorerId) {
 
 /**
  * @param {number} explorerId
- * @param {ExplorerFilterSet} filterSet
+ * @param {SavedExplorerFilterSet} filterSet
  */
 export function updateById(explorerId, filterSet) {
   const { id, ...requestBody } = filterSet;

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -11,6 +11,7 @@ import {
 } from './asyncThunks';
 import {
   checkIfFilterEmpty,
+  dereferenceFilter,
   getCurrentConfig,
   initializeWorkspaces,
   parseSurvivalResult,
@@ -24,7 +25,6 @@ import {
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').ExplorerState} ExplorerState */
 /** @typedef {import('./types').ExplorerWorkspace} ExplorerWorkspace */
-/** @typedef {import('./types').UnsavedExplorerFilterSet} UnsavedExplorerFilterSet */
 
 /** @type {ExplorerState['explorerIds']} */
 const explorerIds = [];
@@ -116,17 +116,18 @@ const slice = createSlice({
         state.workspaces[state.explorerId].all[newActiveId] = filterSet;
 
         // sync with exploreFilter
-        state.explorerFilter = filterSet.filter;
+        const workspace = state.workspaces[state.explorerId];
+        state.explorerFilter = dereferenceFilter(filterSet.filter, workspace);
       },
     },
     loadWorkspaceFilterSet: {
-      /** @param {ExplorerFilterSet | UnsavedExplorerFilterSet} filterSet */
+      /** @param {ExplorerFilterSet} filterSet */
       prepare: (filterSet) => ({
         payload: { filterSet, newActiveId: crypto.randomUUID() },
       }),
       /**
        * @param {PayloadAction<{
-       *  filterSet: ExplorerFilterSet | UnsavedExplorerFilterSet;
+       *  filterSet: ExplorerFilterSet;
        *  newActiveId: string;
        * }>} action
        */
@@ -142,7 +143,8 @@ const slice = createSlice({
         state.workspaces[state.explorerId].all[id] = filterSet;
 
         // sync with exploreFilter
-        state.explorerFilter = filterSet.filter;
+        const workspace = state.workspaces[state.explorerId];
+        state.explorerFilter = dereferenceFilter(filterSet.filter, workspace);
       },
     },
     removeWorkspaceFilterSet: {
@@ -159,7 +161,8 @@ const slice = createSlice({
         state.workspaces[state.explorerId].all[id] = filterSet;
 
         // sync with exploreFilter
-        state.explorerFilter = filterSet.filter;
+        const workspace = state.workspaces[state.explorerId];
+        state.explorerFilter = dereferenceFilter(filterSet.filter, workspace);
       },
     },
     /** @param {PayloadAction<ExplorerState['explorerFilter']>} action */
@@ -225,7 +228,8 @@ const slice = createSlice({
         }
 
         // sync with explorerFilter
-        state.explorerFilter = workspace.all[workspace.activeId].filter;
+        const { filter } = workspace.all[workspace.activeId];
+        state.explorerFilter = dereferenceFilter(filter, workspace);
       },
     },
     /** @param {PayloadAction<string>} action */
@@ -235,8 +239,9 @@ const slice = createSlice({
       state.workspaces[explorerId].activeId = newActiveId;
 
       // sync with exploreFilter
-      const { filter } = state.workspaces[explorerId].all[newActiveId];
-      state.explorerFilter = filter;
+      const workspace = state.workspaces[explorerId];
+      const { filter } = workspace.all[newActiveId];
+      state.explorerFilter = dereferenceFilter(filter, workspace);
     },
   },
   extraReducers: (builder) => {

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -36,17 +36,10 @@ export type ExplorerFilter = ExplorerFilter;
 
 export type ExplorerFilterSet = ExplorerFilterSet;
 
-export type UnsavedExplorerFilterSet = {
-  filter: ExplorerFilterSet['filter'];
-  id?: never;
-  name?: never;
-  description?: never;
-};
-
 export type ExplorerWorkspace = {
   activeId: string;
   all: {
-    [id: string]: ExplorerFilterSet | UnsavedExplorerFilterSet;
+    [id: string]: ExplorerFilterSet;
   };
 };
 

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -9,6 +9,7 @@ import type {
   ExplorerFilter,
   ExplorerFilterSet,
   PatientIdsConfig,
+  SavedExplorerFilterSet,
   SurvivalAnalysisConfig,
   TableConfig,
 } from '../../GuppyDataExplorer/types';
@@ -50,7 +51,7 @@ export type ExplorerState = {
   explorerIds: ExplorerState['explorerId'][];
   patientIds: string[];
   savedFilterSets: {
-    data: ExplorerFilterSet[];
+    data: SavedExplorerFilterSet[];
     isError: boolean;
   };
   survivalAnalysisResult: {

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -8,10 +8,11 @@ import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 /** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSetDTO} ExplorerFilterSetDTO */
 /** @typedef {import('../../GuppyDataExplorer/types').SurvivalAnalysisConfig} SurvivalAnalysisConfig */
+/** @typedef {import('../../GuppyDataExplorer/types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 /** @typedef {import('./types').ExplorerState} ExplorerState */
 
 /**
- * @param {ExplorerFilterSet} filterSet
+ * @param {SavedExplorerFilterSet} filterSet
  * @returns {ExplorerFilterSetDTO}
  */
 export function convertToFilterSetDTO({ filter: filters, ...rest }) {
@@ -37,7 +38,7 @@ export function polyfillFilterValue(filter) {
 
 /**
  * @param {{ [key: string]: any }} filter
- * @returns {ExplorerFilterSet['filter']}
+ * @returns {SavedExplorerFilterSet['filter']}
  */
 export function polyfillFilter({ __combineMode, __type, ...rest }) {
   const shouldPolyfill =
@@ -54,7 +55,7 @@ export function polyfillFilter({ __combineMode, __type, ...rest }) {
 
 /**
  * @param {ExplorerFilterSetDTO} filterSetDTO
- * @returns {ExplorerFilterSet}
+ * @returns {SavedExplorerFilterSet}
  */
 export function convertFromFilterSetDTO({ filters, ...rest }) {
   return {

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -7,9 +7,28 @@ import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
 /** @typedef {import('../../GuppyComponents/types').FilterConfig} FilterConfig */
 /** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('../../GuppyDataExplorer/types').ExplorerFilterSetDTO} ExplorerFilterSetDTO */
+/** @typedef {import('../../GuppyDataExplorer/types').RefFilterState} RefFilterState */
 /** @typedef {import('../../GuppyDataExplorer/types').SurvivalAnalysisConfig} SurvivalAnalysisConfig */
 /** @typedef {import('../../GuppyDataExplorer/types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 /** @typedef {import('./types').ExplorerState} ExplorerState */
+/** @typedef {import('./types').ExplorerWorkspace} ExplorerWorkspace */
+
+/**
+ * @param {ExplorerFilterSet['filter'] | RefFilterState} filter
+ * @param {ExplorerWorkspace} workspace
+ * @returns {SavedExplorerFilterSet['filter']}
+ */
+export function dereferenceFilter(filter, workspace) {
+  if (filter.__type === FILTER_TYPE.STANDARD) return filter;
+
+  if (filter.__type === 'REF')
+    return dereferenceFilter(workspace.all[filter.value.id].filter, workspace);
+
+  return {
+    ...filter,
+    value: filter.value.map((f) => dereferenceFilter(f, workspace)),
+  };
+}
 
 /**
  * @param {SavedExplorerFilterSet} filterSet

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -119,7 +119,7 @@ export function getCurrentConfig(explorerId) {
   };
 }
 
-/** @param {import('./types').ExplorerFilter} filter */
+/** @param {ExplorerFilterSet['filter']} filter */
 export function checkIfFilterEmpty(filter) {
   return filter.__type === FILTER_TYPE.COMPOSED
     ? filter.value.length === 0


### PR DESCRIPTION
Ticket: [PEDS-840](https://pcdc.atlassian.net/browse/PEDS-840)

This PR implements internal support for "reference filter", which can be used to point to another filter set's filter value:

```ts
type RefFilterState = {
  __type: 'REF';
  value: {
    id: string;      // intended to be the id value for filter set in the workspace
    label: string;   // intended to match the index value of the referenced filter set in the workspace 
  };
};
```

When passed to `<FilterDisplay>`, a reference filter's `value.label` will be used as the display value. For example:

<image alt="image" src="https://user-images.githubusercontent.com/22449454/186981115-6ea33aa4-724e-4879-b3ad-0d72b8a979a7.png" width="600">

Importantly, reference filter is intended to be used only as an element in a composed filter state value, rather than used on its own. The goal is to provide users with a convenience UX for building composed filter state where updates to a filter set's filter value automatically propagate to all other filter sets whose filter value includes a reference to it.

Also importantly, reference filters are for display on workspace only and they get dereferenced whenever requests are made to the server. I.e. a reference will always be swapped with the referenced filter value when user uses or saves a filter set that includes references in its filter value. This means that no saved filter set will retain references in their filter value.

