### PR TITLE
Support composed filter state pt. 3 PEDS-703

### DIFF
--- a/src/GuppyComponents/GuppyWrapper/index.jsx
+++ b/src/GuppyComponents/GuppyWrapper/index.jsx
@@ -174,9 +174,9 @@ function GuppyWrapper({
   }) {
     if (filter.__type === FILTER_TYPE.COMPOSED)
       return Promise.resolve({
-        aggsData: /** @type {AggsData} */ ({}),
-        initialTabsOptions: /** @type {SimpleAggsData} */ ({}),
-        tabsOptions: /** @type {SimpleAggsData} */ ({}),
+        aggsData: state.aggsData,
+        initialTabsOptions: state.initialTabsOptions,
+        tabsOptions: state.tabsOptions,
       });
 
     return queryGuppyForAggregationOptionsData({
@@ -343,6 +343,7 @@ function GuppyWrapper({
 
   /** @param {string[]} fields */
   function fetchGuppyData(fields) {
+    console.log('fetchGuppyData');
     controller.current.abort();
     controller.current = new AbortController();
     fetchAggsDataFromGuppy(filterState);

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -174,6 +174,11 @@ function ExplorerFilterSetWorkspace() {
     setComposeState((prev) => ({ ...prev, combineMode }));
   }
 
+  let nonEmptyFilterCount = Object.values(workspace.all).length;
+  for (const { filter } of Object.values(workspace.all))
+    if (checkIfFilterEmpty(filter)) nonEmptyFilterCount -= 1;
+  const disableCompose = nonEmptyFilterCount < 2;
+
   return (
     <div className='explorer-filter-set-workspace'>
       <header>
@@ -266,7 +271,7 @@ function ExplorerFilterSetWorkspace() {
                 className='explorer-filter-set-workspace__action-button'
                 type='button'
                 onClick={toggleComposeState}
-                disabled={workspace.size < 2}
+                disabled={disableCompose}
               >
                 Compose
               </button>

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -25,6 +25,7 @@ export type RefFilterState = {
 };
 
 export interface ComposedFilterStateWithRef extends ComposedFilterState {
+  refIds?: string[];
   value?: (ComposedFilterStateWithRef | StandardFilterState | RefFilterState)[];
 }
 

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -15,6 +15,7 @@ import {
   getCurrentConfig,
   initializeWorkspaces,
   parseSurvivalResult,
+  updateFilterRefs,
 } from './utils';
 
 /**
@@ -161,6 +162,7 @@ const slice = createSlice({
 
         state.workspaces[state.explorerId].activeId = id;
         state.workspaces[state.explorerId].all[id] = filterSet;
+        updateFilterRefs(state.workspaces[state.explorerId]);
 
         // sync with exploreFilter
         const workspace = state.workspaces[state.explorerId];

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -35,10 +35,12 @@ const initialPatientIds = initialConfig.patientIdsConfig?.filter
   ? []
   : undefined;
 const initialWorkspaces = initializeWorkspaces(initialExplorerId);
-const initialExplorerFilter =
+const initialExplorerFilter = dereferenceFilter(
   initialWorkspaces[initialExplorerId].all[
     initialWorkspaces[initialExplorerId].activeId
-  ].filter;
+  ].filter,
+  initialWorkspaces[initialExplorerId]
+);
 
 const slice = createSlice({
   name: 'explorer',

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -32,6 +32,29 @@ export function dereferenceFilter(filter, workspace) {
   return filter;
 }
 
+/** @param {ExplorerWorkspace} workspace */
+export function updateFilterRefs(workspace) {
+  const ids = Object.keys(workspace.all);
+  const filterSets = Object.values(workspace.all);
+
+  for (const { filter } of filterSets)
+    if ('refIds' in filter)
+      for (const [index, refId] of filter.refIds.entries()) {
+        const refIndex = filter.value.findIndex(
+          ({ __type, value }) => __type === 'REF' && value.id === refId
+        );
+
+        if (refId in workspace.all) {
+          /** @type {RefFilterState} */ (filter.value[refIndex]).value.label =
+            workspace.all[refId].name ??
+            `#${ids.findIndex((id) => id === refId) + 1}`;
+        } else {
+          filter.value.splice(refIndex, 1);
+          filter.refIds.splice(index, 1);
+        }
+      }
+}
+
 /**
  * @param {SavedExplorerFilterSet} filterSet
  * @returns {ExplorerFilterSetDTO}

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -19,15 +19,17 @@ import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
  * @returns {SavedExplorerFilterSet['filter']}
  */
 export function dereferenceFilter(filter, workspace) {
-  if (filter.__type === FILTER_TYPE.STANDARD) return filter;
+  if (filter.__type === FILTER_TYPE.COMPOSED)
+    return {
+      __combineMode: filter.__combineMode,
+      __type: filter.__type,
+      value: filter.value.map((f) => dereferenceFilter(f, workspace)),
+    };
 
   if (filter.__type === 'REF')
     return dereferenceFilter(workspace.all[filter.value.id].filter, workspace);
 
-  return {
-    ...filter,
-    value: filter.value.map((f) => dereferenceFilter(f, workspace)),
-  };
+  return filter;
 }
 
 /**


### PR DESCRIPTION
Ticket: [PEDS-703](https://pcdc.atlassian.net/browse/PEDS-703)

This PR is the third step toward supporting "composed" filter state and a follow-up to https://github.com/chicagopcdc/data-portal/pull/451 and https://github.com/chicagopcdc/data-portal/pull/454.

The focus of this PR is to implement of UI to support "composing" filter states on Filter Set Workspace. One key feature included in this PR to support this UI is to update filter references in workspace on removing a filter set.

The intended UX is as follows:

1. User creates and/or loads filter sets onto Workspace intended as building blocks
2. User clicks the new "Compose" button to initiate the filter composing process
    - "Compose" button is enabled only if two or more filter sets have non-empty filter content
3. User selects filter sets to compose & composing operator (`AND` or `OR`)
4. User clicks "Done" button to complete filter composing process

See the following screen recording demonstrating this UX:

https://user-images.githubusercontent.com/22449454/187548562-1fb90e90-79ac-4570-bb69-2c43f58bbf19.mov

