### PR TITLE
Fix not updated filter references PEDS-844

### DIFF
--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -39,7 +39,7 @@ export function updateFilterRefs(workspace) {
 
   for (const { filter } of filterSets)
     if ('refIds' in filter)
-      for (const [index, refId] of filter.refIds.entries()) {
+      for (const [index, refId] of [...filter.refIds].entries()) {
         const refIndex = filter.value.findIndex(
           ({ __type, value }) => __type === 'REF' && value.id === refId
         );

--- a/src/redux/explorer/utils.test.js
+++ b/src/redux/explorer/utils.test.js
@@ -286,7 +286,7 @@ describe('update filter references after a filter set removed', () => {
       },
     });
   });
-  test('referenced filter removed', () => {
+  test('referenced local filter removed', () => {
     const workspace = /** @type {import('./types').ExplorerWorkspace} */ ({
       activeId: '',
       all: {
@@ -319,6 +319,44 @@ describe('update filter references after a filter set removed', () => {
             __combineMode,
             refIds: ['foo'],
             value: [{ __type: 'REF', value: { id: 'foo', label: 'foo' } }],
+          },
+        },
+      },
+    });
+  });
+  test.only('referenced saved filter removed', () => {
+    const workspace = /** @type {import('./types').ExplorerWorkspace} */ ({
+      activeId: '',
+      all: {
+        foo: { name: 'foo', description: '', filter: standardFilter },
+        bar: { filter: standardFilter },
+        baz: {
+          filter: {
+            __type: FILTER_TYPE.COMPOSED,
+            __combineMode,
+            refIds: ['foo', 'bar'],
+            value: [
+              { __type: 'REF', value: { id: 'foo', label: 'foo' } },
+              { __type: 'REF', value: { id: 'bar', label: '#2' } },
+            ],
+          },
+        },
+      },
+    });
+
+    delete workspace.all.foo;
+    updateFilterRefs(workspace);
+
+    expect(workspace).toStrictEqual({
+      activeId: '',
+      all: {
+        bar: { filter: standardFilter },
+        baz: {
+          filter: {
+            __type: FILTER_TYPE.COMPOSED,
+            __combineMode,
+            refIds: ['bar'],
+            value: [{ __type: 'REF', value: { id: 'bar', label: '#1' } }],
           },
         },
       },


### PR DESCRIPTION
Ticket: [PEDS-844](https://pcdc.atlassian.net/browse/PEDS-844)

This PR fixes the problem in updating filter references in a composed filter value when a referred filter set is removed. This bug was caused by the in-place mutatation of the `refIds` array that is being looped over.