### PR TITLE
Implement UI for server-side survival configuration consortium values PEDS-835

### DIFF
--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -15,7 +15,7 @@ import { checkIfFilterInScope } from './utils';
 /** @typedef {import('./types').ParsedSurvivalAnalysisResult} ParsedSurvivalAnalysisResult */
 /** @typedef {import('./types').UserInputSubmitHandler} UserInputSubmitHandler */
 
-/** @param {{ label: string; [x: string]: any }} props */
+/** @param {{ label: string | JSX.Element; [x: string]: any }} props */
 function ControlFormSelect({ label, ...selectProps }) {
   return (
     <SimpleInputField

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -108,7 +108,7 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
   const [startTime, setStartTime] = useState(0);
   const [endTime, setEndTime] = useState(undefined);
   const [survivalType, setSurvivalType] = useState(survivalTypeOptions[0]);
-  const [selectFilterSetId, setSelectFilterSetId] = useState(null);
+  const [selectFilterSet, setSelectFilterSet] = useState(null);
   const [usedFilterSetIds, setUsedFilterSetIds] = useState(emptyFilterSetIds);
 
   const filterSetOptions = [];
@@ -241,18 +241,18 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
           inputId='survival-filter-sets'
           placeholder='Select Filter Set to analyze'
           options={filterSetOptions}
-          onChange={({ value }) => setSelectFilterSetId(value)}
+          onChange={setSelectFilterSet}
           maxMenuHeight={160}
-          value={selectFilterSetId}
+          value={selectFilterSet}
           theme={overrideSelectTheme}
         />
         <Button
           label='Add'
           buttonType='default'
-          enabled={selectFilterSetId !== null}
+          enabled={selectFilterSet !== null}
           onClick={() => {
-            setUsedFilterSetIds((ids) => [...ids, selectFilterSetId]);
-            setSelectFilterSetId(null);
+            setUsedFilterSetIds((ids) => [...ids, selectFilterSet.value]);
+            setSelectFilterSet(null);
             setIsInputChanged(true);
           }}
         />

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/ControlForm.jsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
+import 'rc-tooltip/assets/bootstrap_white.css';
 import Select from 'react-select';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Button from '../../gen3-ui-component/components/Button';
 import SimpleInputField from '../../components/SimpleInputField';
 import { useAppSelector } from '../../redux/hooks';
 import { overrideSelectTheme } from '../../utils';
 import FilterSetCard from './FilterSetCard';
+import { checkIfFilterInScope } from './utils';
 
 /** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('./types').ParsedSurvivalAnalysisResult} ParsedSurvivalAnalysisResult */
@@ -26,6 +30,13 @@ function ControlFormSelect({ label, ...selectProps }) {
               ...provided,
               cursor: isDisabled ? 'not-allowed' : '',
               pointerEvents: 'auto',
+            }),
+            multiValue: (provided, { isDisabled }) => ({
+              ...provided,
+              backgroundColor: isDisabled
+                ? 'lightgrey'
+                : provided.backgroundColor,
+              paddingRight: isDisabled ? '3px' : provided.paddingRight,
             }),
           }}
         />
@@ -54,7 +65,7 @@ const survivalTypeOptions = [
 
 /** @type {ExplorerFilterSet['id'][]} */
 const emptyFilterSetIds = [];
-/** @type {ExplorerFilterSet} */
+/** @type {import('../types').SavedExplorerFilterSet} */
 export const defaultFilterSet = {
   name: '*** All Subjects ***',
   description: '',
@@ -83,6 +94,9 @@ function validateNumberInput(e, setStateAction) {
  * @param {number} prop.timeInterval
  */
 function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
+  const consortiums = useAppSelector(
+    (state) => state.explorer.config.survivalAnalysisConfig.consortium ?? []
+  );
   const savedFilterSets = useAppSelector(
     (state) => state.explorer.savedFilterSets.data
   );
@@ -102,7 +116,8 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
   for (const filterSet of [defaultFilterSet, ...savedFilterSets]) {
     const { name: label, id: value } = filterSet;
     const isUsed = usedFilterSetIds.includes(value);
-    filterSetOptions.push({ label, value, isDisabled: isUsed });
+    const isOutOfScope = !checkIfFilterInScope(consortiums, filterSet.filter);
+    filterSetOptions.push({ label, value, isDisabled: isUsed || isOutOfScope });
 
     if (isUsed) {
       const isStale = staleFilterSetIdSet.has(value);
@@ -137,6 +152,33 @@ function ControlForm({ countByFilterSet, onSubmit, timeInterval }) {
 
   return (
     <form className='explorer-survival-analysis__control-form'>
+      <ControlFormSelect
+        inputId='consortium'
+        label={
+          <Tooltip
+            arrowContent={<div className='rc-tooltip-arrow-inner' />}
+            mouseLeaveDelay={0}
+            overlay='Only data from the following sources are available for survival analysis. Filter Sets including other consortium values are disabled.'
+            placement='left'
+          >
+            <span>
+              <FontAwesomeIcon
+                icon='circle-info'
+                color='var(--pcdc-color__primary-light)'
+              />{' '}
+              Consortium
+            </span>
+          </Tooltip>
+        }
+        components={{
+          IndicatorsContainer: () => null,
+          MultiValueRemove: () => null,
+        }}
+        isMulti
+        isDisabled
+        value={consortiums.map((label) => ({ label }))}
+        theme={overrideSelectTheme}
+      />
       <ControlFormSelect
         inputId='survival-type'
         label='Survival type'

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.js
@@ -1,6 +1,29 @@
 /* eslint-disable no-shadow */
+import { FILTER_TYPE } from '../ExplorerFilterSetWorkspace/utils';
+
 /** @typedef {import('./types').RisktableData} RisktableData */
 /** @typedef {import('./types').SurvivalData} SurvivalData */
+
+/**
+ * @param {string[]} consortium
+ * @param {import('../types').ExplorerFilter} filter
+ */
+export function checkIfFilterInScope(consortium, filter) {
+  if (consortium.length === 0) return true;
+
+  if (filter.__type === FILTER_TYPE.COMPOSED)
+    return filter.value.every((f) => checkIfFilterInScope(consortium, f));
+
+  for (const [key, val] of Object.entries(filter.value ?? {}))
+    if (
+      key === 'consortium' &&
+      val.__type === FILTER_TYPE.OPTION &&
+      val.selectedValues.some((v) => !consortium.includes(v))
+    )
+      return false;
+
+  return true;
+}
 
 /**
  * Builds x-axis ticks array to use in plots

--- a/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerSurvivalAnalysis/utils.test.js
@@ -1,0 +1,159 @@
+import { FILTER_TYPE } from '../ExplorerFilterSetWorkspace/utils';
+import { checkIfFilterInScope } from './utils';
+
+describe('check if a filter state is in scope for survival analysis', () => {
+  const __combineMode = /** @type {'AND'} */ ('AND');
+  const consortiums = ['foo', 'bar'];
+  const optionFilter = {
+    __type: FILTER_TYPE.OPTION,
+    selectedValues: ['foo', 'bar'],
+  };
+  const rangeFilter = {
+    __type: FILTER_TYPE.RANGE,
+    lowerBound: 0,
+    upperBound: 1,
+  };
+  test('standard filter state, empty', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.STANDARD,
+        value: {},
+      })
+    ).toBe(true);
+  });
+  test('composed filter state, empty', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.COMPOSED,
+        value: [],
+      })
+    ).toBe(true);
+  });
+  test('standard filter state, no consortium filter', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.STANDARD,
+        value: { x: optionFilter, y: rangeFilter },
+      })
+    ).toBe(true);
+  });
+  test('composed filter state, no consortium filter', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.COMPOSED,
+        value: [
+          {
+            __combineMode,
+            __type: FILTER_TYPE.STANDARD,
+            value: { x: optionFilter },
+          },
+          {
+            __combineMode,
+            __type: FILTER_TYPE.COMPOSED,
+            value: [
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { x: optionFilter },
+              },
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { y: rangeFilter },
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+  test('standard filter state, consortium filter in scope', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.STANDARD,
+        value: { consortium: optionFilter, y: rangeFilter },
+      })
+    ).toBe(true);
+  });
+  test('composed filter state, consortium filter in scope', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.COMPOSED,
+        value: [
+          {
+            __combineMode,
+            __type: FILTER_TYPE.STANDARD,
+            value: { x: optionFilter },
+          },
+          {
+            __combineMode,
+            __type: FILTER_TYPE.COMPOSED,
+            value: [
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { consortium: optionFilter },
+              },
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { y: rangeFilter },
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+  test('standard filter state, consortium filter out of scope', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.STANDARD,
+        value: {
+          consortium: { ...optionFilter, selectedValues: ['baz'] },
+          y: rangeFilter,
+        },
+      })
+    ).toBe(false);
+  });
+  test('composed filter state, consortium filter out of scope', () => {
+    expect(
+      checkIfFilterInScope(consortiums, {
+        __combineMode,
+        __type: FILTER_TYPE.COMPOSED,
+        value: [
+          {
+            __combineMode,
+            __type: FILTER_TYPE.STANDARD,
+            value: {
+              consortiums: { ...optionFilter, selectedValues: ['baz'] },
+            },
+          },
+          {
+            __combineMode,
+            __type: FILTER_TYPE.COMPOSED,
+            value: [
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { consortium: optionFilter },
+              },
+              {
+                __combineMode,
+                __type: FILTER_TYPE.STANDARD,
+                value: { y: rangeFilter },
+              },
+            ],
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+});

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -72,6 +72,7 @@ export const ButtonConfigType = PropTypes.exact({
 export const ChartConfigType = PropTypes.object;
 
 export const SurvivalAnalysisConfigType = PropTypes.shape({
+  consortium: PropTypes.arrayOf(PropTypes.string),
   result: PropTypes.shape({
     risktable: PropTypes.bool,
     survival: PropTypes.bool,

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -76,6 +76,7 @@ export type PatientIdsConfig = {
 };
 
 export type SurvivalAnalysisConfig = {
+  consortium?: string[];
   result?: {
     risktable?: boolean;
     survival?: boolean;

--- a/src/components/SimpleInputField.jsx
+++ b/src/components/SimpleInputField.jsx
@@ -6,7 +6,7 @@ import './SimpleInputField.css';
  * @typedef {Object} SimpleInputFieldProps
  * @property {?{ isError: boolean; message: string }} [error]
  * @property {JSX.Element} input
- * @property {string} label
+ * @property {string | JSX.Element} label
  */
 
 /** @param {SimpleInputFieldProps} props */
@@ -41,7 +41,7 @@ SimpleInputField.propTypes = {
     message: PropTypes.string,
   }),
   input: PropTypes.object.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 };
 
 export default SimpleInputField;


### PR DESCRIPTION
Ticket: [PEDS-835](https://pcdc.atlassian.net/browse/PEDS-835)

This PR is a follow-up to https://github.com/chicagopcdc/data-portal/pull/453 and implements UI to support server-side survival configuration with the following changes:

1. Disable Filter Set options for those with consortium filter values that are out of scope
2. Add a read-only select input to display allowed consortium values for survival analysis
    - Its label displays a tooltip with detailed information on hover 

![image](https://user-images.githubusercontent.com/22449454/188016886-50ae3250-f8e3-4870-8430-8df965ecaf2c.png)

The PR also includes a fix for selected Filter Set's label not being displayed on the select input's container (https://github.com/chicagopcdc/data-portal/pull/458/commits/5332f8160066a97b0124d8435c87af63d9e21c33). 