### PR TITLE
Fix lost survival config on explorer id update PEDS-848

### DIFF
--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -221,7 +221,11 @@ const slice = createSlice({
        */
       reducer: (state, action) => {
         const { explorerId } = action.payload;
-        state.config = getCurrentConfig(explorerId);
+        state.config = {
+          ...getCurrentConfig(explorerId),
+          // keep survival config
+          survivalAnalysisConfig: state.config.survivalAnalysisConfig,
+        };
         state.explorerId = explorerId;
 
         // sync with workspaces


### PR DESCRIPTION
Ticket: [PEDS-848](https://pcdc.atlassian.net/browse/PEDS-848)

This PR fixes the issue of lost survival config state on switching explorers.