### PR TITLE
 Patch release 1.9.1 PEDS-853 PEDS-848

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcdc/windmill",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.19.0",

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -58,7 +58,7 @@ function ExplorerDashboard() {
     : explorerIds[0];
   useEffect(() => {
     // sync search param with explorer id state
-    setSearchParams(`id=${searchParamId.current}`);
+    setSearchParams(`id=${searchParamId.current}`, { replace: true });
     if (explorerId !== searchParamId.current)
       dispatch(useExplorerById(searchParamId.current));
 

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 /**
  * @typedef {Object} ErrorBoundaryProps
- * @property {React.ReactNode} children
- * @property {React.ReactNode} fallback
+ * @property {JSX.Element} children
+ * @property {JSX.Element} fallback
  * @property {(error: Error, info: React.ErrorInfo) => void} [onError]
  */
 

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -221,7 +221,11 @@ const slice = createSlice({
        */
       reducer: (state, action) => {
         const { explorerId } = action.payload;
-        state.config = getCurrentConfig(explorerId);
+        state.config = {
+          ...getCurrentConfig(explorerId),
+          // keep survival config
+          survivalAnalysisConfig: state.config.survivalAnalysisConfig,
+        };
         state.explorerId = explorerId;
 
         // sync with workspaces


### PR DESCRIPTION
Ticket: [PEDS-853](https://pcdc.atlassian.net/browse/PEDS-853),[ PEDS-848](https://pcdc.atlassian.net/browse/PEDS-848)

This PR bumps the project version to 1.9.1 and includes the following fixes & changes:

- Ensure /explorer route always has `id` search parameter value
- Fix lost survival config on explorer id update (patch checkout the change in https://github.com/chicagopcdc/data-portal/pull/461)