### PR TITLE
Display Export to PFB button to admin only PEDS-845

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
@@ -10,6 +10,7 @@ import { fetchWithCreds } from '../../utils.fetch';
 /** @param {import('../../redux/types').RootState} state */
 const mapStateToProps = (state) => ({
   job: state.kube.job,
+  user: state.user,
   userAccess: state.userAccess,
 });
 

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -42,6 +42,7 @@ import Popup from '../../components/Popup';
  * @property {() => void} checkJobStatus: PropTypes.func.isRequired,
  * @property {(jobId: string) => Promise} fetchJobResult: PropTypes.func.isRequired,
  * @property {boolean} isLocked: PropTypes.bool.isRequired,
+ * @property {RootState['user']} user: PropTypes.object.isRequired,
  * @property {RootState['userAccess']} userAccess: PropTypes.object.isRequired,
  */
 
@@ -615,6 +616,10 @@ class ExplorerButtonGroup extends Component {
   // check if the user has access to this resource
   /** @param {SingleButtonConfig} buttonConfig */
   isButtonDisplayed = (buttonConfig) => {
+    if (buttonConfig.type === 'export-to-pfb') {
+      return '/services/amanuensis' in this.props.user.authz ?? {};
+    }
+
     if (
       buttonConfig.type === 'export-to-workspace' ||
       buttonConfig.type === 'export-files-to-workspace'
@@ -886,6 +891,7 @@ ExplorerButtonGroup.propTypes = {
   checkJobStatus: PropTypes.func.isRequired,
   fetchJobResult: PropTypes.func.isRequired,
   isLocked: PropTypes.bool.isRequired,
+  user: PropTypes.object.isRequired,
   userAccess: PropTypes.objectOf(PropTypes.bool).isRequired,
 };
 


### PR DESCRIPTION
Ticket: [PEDS-845](https://pcdc.atlassian.net/browse/PEDS-845)

This PR changes the visibility condition for the "Export to PFB" button on the Explorer page, to display the button to admin users only.