### PR TITLE
Support updated response data for external commons PEDS-856

### DIFF
--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/ExplorerExploreExternalButton.css
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/ExplorerExploreExternalButton.css
@@ -8,3 +8,17 @@
   flex-direction: column;
   justify-content: space-between;
 }
+
+.explorer-explore-external__download-manifest {
+  margin: 0 1rem 1rem;
+}
+
+.explorer-explore-external__download-manifest > p:first-child {
+  margin-bottom: 0.5rem;
+}
+
+.explorer-explore-external__download-manifest
+  > p:first-child
+  > svg:first-child {
+  margin-right: 0.25rem;
+}

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -13,6 +13,16 @@ import './ExplorerExploreExternalButton.css';
 /** @typedef {import('../types').ExplorerFilter} ExplorerFilter */
 
 /**
+ * @param {{ path: string; body: string }} payload
+ * @returns {Promise<import('./types').ExternalCommonsInfo>}
+ */
+async function fetchExternalCommonsInfo(payload) {
+  const res = await fetchWithCreds({ ...payload, method: 'POST' });
+  if (res.status !== 200) throw res.response.statusText;
+  return res.data;
+}
+
+/**
  * @param {Object} props
  * @param {ExplorerFilter} props.filter
  */
@@ -39,14 +49,12 @@ function ExplorerExploreExternalButton({ filter }) {
   }
   async function handleOpenExternal() {
     try {
-      const { data, response, status } = await fetchWithCreds({
+      const info = await fetchExternalCommonsInfo({
         path: `/analysis/tools/external/${selected.value}`,
-        method: 'POST',
         body: JSON.stringify({ filter: getGQLFilter(filter) }),
       });
-      if (status !== 200) throw response.statusText;
 
-      window.open(data.link, '_blank');
+      window.open(info.link, '_blank');
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import FileSaver from 'file-saver';
 import SimplePopup from '../../components/SimplePopup';
 import SimpleInputField from '../../components/SimpleInputField';
 import Button from '../../gen3-ui-component/components/Button';
@@ -21,6 +23,11 @@ async function fetchExternalCommonsInfo(payload) {
   const res = await fetchWithCreds({ ...payload, method: 'POST' });
   if (res.status !== 200) throw res.response.statusText;
   return res.data;
+}
+
+function saveToFile(savingStr, filename) {
+  const blob = new Blob([savingStr], { type: 'text/plain' });
+  FileSaver.saveAs(blob, filename);
 }
 
 /**
@@ -76,6 +83,11 @@ function ExplorerExploreExternalButton({ filter }) {
     window.open(commonsInfo.link, '_blank');
     closePopup();
   }
+  function handleDownlodManifest() {
+    const dateString = new Date().toISOString().split('T')[0];
+    const filename = `${dateString}-manifest-${selected.value}.txt`;
+    saveToFile(commonsInfo.data, filename);
+  }
 
   return (
     <>
@@ -106,6 +118,22 @@ function ExplorerExploreExternalButton({ filter }) {
               />
               <ExplorerFilterDisplay filter={filter} />
             </form>
+            {commonsInfo?.type === 'file' ? (
+              <div className='explorer-explore-external__download-manifest'>
+                <p>
+                  <FontAwesomeIcon
+                    icon='triangle-exclamation'
+                    color='var(--pcdc-color__secondary)'
+                  />
+                  Download a manifest file and upload it to the select commons
+                  to use the current cohort.
+                </p>
+                <Button
+                  label='Download manifest'
+                  onClick={handleDownlodManifest}
+                />
+              </div>
+            ) : null}
             <div>
               <Button
                 className='explorer-explore-external__button'

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -37,7 +37,7 @@ function ExplorerExploreExternalButton({ filter }) {
   function closePopup() {
     setShow(false);
   }
-  async function handleFind() {
+  async function handleOpenExternal() {
     try {
       const { data, response, status } = await fetchWithCreds({
         path: `/analysis/tools/external/${selected.value}`,
@@ -94,7 +94,7 @@ function ExplorerExploreExternalButton({ filter }) {
               <Button
                 label='Open in new tab'
                 enabled={selected.value !== ''}
-                onClick={handleFind}
+                onClick={handleOpenExternal}
               />
             </div>
           </div>

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -56,6 +56,8 @@ function ExplorerExploreExternalButton({ filter }) {
     setShow(true);
   }
   function closePopup() {
+    setSelected(emptyOption);
+    setCommonsInfo(null);
     setShow(false);
   }
   /** @param {typeof selected} newSelected */

--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/types.d.ts
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/types.d.ts
@@ -1,0 +1,11 @@
+export type ExternalCommonsInfo =
+  | {
+      data: string;
+      link: string;
+      type: 'file';
+    }
+  | {
+      data?: never;
+      link: string;
+      type: 'redirect';
+    };


### PR DESCRIPTION
Ticket: [PEDS-856](https://pcdc.atlassian.net/browse/PEDS-856)

This PR supports the updated response API for `/external/:commons` [PcdcAnalysisTools](https://github.com/chicagopcdc/PcdcAnalysisTools/) endpoint, where the new response data type now looks like:

```ts
type ExternalCommonsInfo = {
      data: string;
      link: string;
      type: 'file';
    }
  | {
      data?: never;
      link: string;
      type: 'redirect';
    };
```

The relevant UX is now that:

* For response `type: 'redirect'`, the same as before.
* For response `type: 'file'`, also display a button to download a "manifest" file with explanation: <img width="852" alt="image" src="https://user-images.githubusercontent.com/22449454/193366586-9c8d239b-e353-4007-8a32-88c5355657e2.png">

Please note that changes in this PR assumes the latest `pcdc_dev` branch of [PcdcAnalysisTools](https://github.com/chicagopcdc/PcdcAnalysisTools/).
