### PR TITLE
Fix index bar chart tooltip counts PEDS-857

### DIFF
--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -47,10 +47,14 @@ const computeSummations = (projectList, countNames) => {
 };
 
 const createChartData = (projectList, countNames, sumList) => {
-  let indexChart = countNames.map((countName) => ({ name: countName }));
+  let indexChart = countNames.map((countName) => ({
+    name: countName,
+    allCounts: [],
+  }));
   projectList.forEach((project, i) => {
     project.counts.forEach((count, j) => {
       if (typeof indexChart[j] === 'undefined') return;
+      indexChart[j].allCounts.push(count);
       indexChart[j][`count${i}`] =
         sumList[j] > 0 ? ((count * 100) / sumList[j]).toFixed(2) : 0;
     });

--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -68,16 +68,6 @@ const createChartData = (projectList, countNames, sumList) => {
   return indexChart;
 };
 
-const createBarNames = (indexChart) => {
-  let barNames = [];
-  if (indexChart.length > 0) {
-    barNames = Object.keys(indexChart[0])
-      .filter((key) => key.indexOf('count') === 0)
-      .map((name) => name);
-  }
-  return barNames;
-};
-
 /**
  * Component shows stacked-bars - one stacked-bar for each project in props.projectList -
  * where experiments are stacked on top of cases.  projectList looks like:
@@ -103,7 +93,10 @@ function IndexBarChart({ projectList, countNames, barChartStyle, xAxisStyle }) {
   const sumList = computeSummations(topList, countNames);
   const indexChart = createChartData(topList, countNames, sumList);
   const projectNames = topList.map((project) => project.code);
-  const barNames = createBarNames(indexChart);
+  const barNames = Object.keys(indexChart[0] ?? {}).filter((key) =>
+    key.startsWith('count')
+  );
+
   let countBar = 0;
   return (
     <div className='index-bar-chart'>

--- a/src/components/charts/TooltipCDIS/index.jsx
+++ b/src/components/charts/TooltipCDIS/index.jsx
@@ -5,7 +5,8 @@ import './TooltipCDIS.css';
  * @typedef {Object} TooltipCDISProps
  * @property {boolean} [active]
  * @property {string} [label]
- * @property {{ fill: string; name: string; value: number }[]} [payload]
+ * @property {{ fill: string; name: string; payload: { allCounts: number[] } }[]} [payload]
+ * @property {any} [testProp]
  */
 
 /** @param {TooltipCDISProps} props */
@@ -13,16 +14,15 @@ function TooltipCDIS({ active = false, label = '', payload = [] }) {
   if (!active) return null;
 
   const txts = label.split('#');
-  const number = parseInt(txts[0], 10);
   return (
     <div className='cdis-tooltip'>
       <h2>{`${txts[1]}`}</h2>
-      {payload.map((item) => (
+      {payload.map((item, i) => (
         <div
           key={item.name}
           style={{ color: `${item.fill}` }}
           className='body-typo'
-        >{`${item.name} : ${Math.round((item.value / 100) * number)}`}</div>
+        >{`${item.name} : ${item.payload.allCounts[i]}`}</div>
       ))}
     </div>
   );
@@ -35,7 +35,9 @@ TooltipCDIS.propTypes = {
     PropTypes.shape({
       fill: PropTypes.string,
       name: PropTypes.string,
-      value: PropTypes.string,
+      payload: PropTypes.shape({
+        allCounts: PropTypes.arrayOf(PropTypes.number),
+      }),
     })
   ),
 };


### PR DESCRIPTION
Ticket: [PEDS-857](https://pcdc.atlassian.net/browse/PEDS-857)

This PR fixes the incorrect count display values on the custom tooltip component for the index page's bar chart. This mismatch between actual counts and their display values arises because the custom tooltip component `<TooltipCDIS>` does not have access to the original values but instead lossily recalculates them. This is in fact not a new bug but has been there ever since `<TooltipCDIS>` was [first created](https://github.com/chicagopcdc/data-portal/commit/91120f3cbca11248ace708f34eb6d43643429904#diff-48b597417770bf35c89179d5fffcdae66bd7e282fa1c9a1ea644c3b0dc349428).

The fix simply finds a way to pass original count values to `<TooltipCIDS>` to replace the recalculated values.

This PR also includes some minor refactoring.