### PR TITLE
Support workspace share filter set feature PEDS-878

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,10 +3,11 @@ import {
   faAnchor,
   faAngleUp,
   faAngleDown,
+  faCheckCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import '@fontsource/raleway';
 import 'graphiql/graphiql.css';
 import '@src/base.css';
 import '@src/icon.css';
 
-library.add(faAnchor, faAngleUp, faAngleDown);
+library.add(faAnchor, faAngleUp, faAngleDown, faCheckCircle);

--- a/.storybook/stories/FilterSetForms.jsx
+++ b/.storybook/stories/FilterSetForms.jsx
@@ -9,6 +9,7 @@ import FilterSetUpdateForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/F
 import {
   testFilterSets,
   testReduxStore,
+  testToken,
 } from '@src/GuppyDataExplorer/ExplorerFilterSetForms/testData';
 
 const style = {
@@ -85,7 +86,7 @@ storiesOf('FilterSetForms', module)
             action('share')();
             setTimeout(() => {});
             return new Promise((resolve) => {
-              setTimeout(() => resolve('token-value'), 1000);
+              setTimeout(() => resolve(testToken), 1000);
             });
           }}
           onClose={action('close')}

--- a/.storybook/stories/FilterSetForms.jsx
+++ b/.storybook/stories/FilterSetForms.jsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import FilterSetCreateForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetCreateForm';
 import FilterSetDeleteForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetDeleteForm';
 import FilterSetOpenForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetOpenForm';
+import FilterSetShareForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm';
 import FilterSetUpdateForm from '@src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetUpdateForm';
 import {
   testFilterSets,
@@ -74,4 +75,35 @@ storiesOf('FilterSetForms', module)
         onClose={action('close')}
       />
     </Wrapper>
+  ))
+  .add('Share form', () => (
+    <>
+      <strong>Success</strong>
+      <Wrapper>
+        <FilterSetShareForm
+          onAction={() => {
+            action('share')();
+            setTimeout(() => {});
+            return new Promise((resolve) => {
+              setTimeout(() => resolve('token-value'), 1000);
+            });
+          }}
+          onClose={action('close')}
+        />
+      </Wrapper>
+      <br />
+      <strong>Error</strong>
+      <Wrapper>
+        <FilterSetShareForm
+          onAction={() => {
+            action('share')();
+            setTimeout(() => {});
+            return new Promise((_, reject) => {
+              setTimeout(() => reject(), 1000);
+            });
+          }}
+          onClose={action('close')}
+        />
+      </Wrapper>
+    </>
   ));

--- a/.storybook/stories/FilterSetForms.jsx
+++ b/.storybook/stories/FilterSetForms.jsx
@@ -62,6 +62,17 @@ storiesOf('FilterSetForms', module)
         filterSets={testFilterSets}
         onAction={action('open')}
         onClose={action('close')}
+        fetchWithToken={(token) => {
+          action('fetch-shared')(token);
+          setTimeout(() => {});
+          return new Promise((resolve, reject) => {
+            setTimeout(
+              () =>
+                token === testToken ? resolve(testFilterSets[0]) : reject(),
+              1000
+            );
+          });
+        }}
       />
     </Wrapper>
   ))

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetOpenForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetOpenForm.jsx
@@ -8,20 +8,67 @@ import ExplorerFilterDisplay from '../ExplorerFilterDisplay';
 import './ExplorerFilterSetForms.css';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
+/** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
+
+/** @type {{ saved: 'saved'; shared: 'shared' }} */
+const FILTER_SET_SOURCE = {
+  saved: 'saved',
+  shared: 'shared',
+};
+
+/** @param {(token:string) => Promise<SavedExplorerFilterSet>} fetcher  */
+function useSharedFilterSet(fetcher) {
+  const [data, setData] = useState(/** @type {ExplorerFilterSet} */ (null));
+  const [lastToken, setLastToken] = useState('');
+
+  const initialStatus = /** @type {'idle' | 'error' | 'pending'} */ ('idle');
+  const [status, setStatus] = useState(initialStatus);
+
+  /** @param {string} token */
+  function refresh(token) {
+    if (token === lastToken) return;
+
+    setData(null);
+    setLastToken(token);
+    setStatus('pending');
+
+    fetcher(token)
+      .then((newData) => {
+        setData(newData);
+        setStatus('idle');
+      })
+      .catch(() => setStatus('error'));
+  }
+
+  return {
+    data,
+    isError: status === 'error',
+    isPending: status === 'pending',
+    refresh,
+  };
+}
 
 /**
  * @param {Object} prop
  * @param {ExplorerFilterSet} prop.currentFilterSet
  * @param {ExplorerFilterSet[]} prop.filterSets
- * @param {(opened: ExplorerFilterSet) => void} prop.onAction
+ * @param {(token: string) => Promise<SavedExplorerFilterSet>} [prop.fetchWithToken]
+ * @param {(opened: ExplorerFilterSet, isShared?: boolean) => void} prop.onAction
  * @param {() => void} prop.onClose
  */
 function FilterSetOpenForm({
   currentFilterSet,
   filterSets,
+  fetchWithToken,
   onAction,
   onClose,
 }) {
+  const initialSource = /** @type {keyof FILTER_SET_SOURCE} */ (
+    FILTER_SET_SOURCE.saved
+  );
+  const [source, setSource] = useState(initialSource);
+
+  // source: saved
   const options = filterSets.map((filterSet) => ({
     label: filterSet.name,
     value: filterSet,
@@ -30,43 +77,116 @@ function FilterSetOpenForm({
     label: currentFilterSet.name,
     value: currentFilterSet,
   });
+
+  // source: shared
+  const [token, setToken] = useState('');
+  const shared = useSharedFilterSet(fetchWithToken);
+  function handleUseToken() {
+    shared.refresh(token);
+  }
+
+  const isSourceSaved = source === FILTER_SET_SOURCE.saved;
+  const isSourceShared = !isSourceSaved;
+  const isActionEnabled = isSourceSaved
+    ? selected.value.name !== ''
+    : shared.data !== null;
+  const value = isSourceSaved ? selected.value : shared.data;
+
   return (
     <div className='explorer-filter-set-form'>
       <h4>Select a saved Filter Set to open</h4>
       <form onSubmit={(e) => e.preventDefault()}>
         <SimpleInputField
-          label='Name'
+          label='Source'
           input={
-            <Select
-              inputId='open-filter-set-name'
-              options={options}
-              value={selected}
-              autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-              isClearable={false}
-              theme={overrideSelectTheme}
-              onChange={(e) => setSelected(e)}
-            />
+            <>
+              <label style={{ display: 'block', textAlign: 'initial' }}>
+                <input
+                  type='radio'
+                  value={FILTER_SET_SOURCE.saved}
+                  checked={source === FILTER_SET_SOURCE.saved}
+                  onChange={() => setSource(FILTER_SET_SOURCE.saved)}
+                  style={{ marginRight: '0.5rem' }}
+                />
+                Saved by me
+              </label>
+              <label style={{ display: 'block', textAlign: 'initial' }}>
+                <input
+                  type='radio'
+                  value={FILTER_SET_SOURCE.shared}
+                  checked={source === FILTER_SET_SOURCE.shared}
+                  onChange={() => setSource(FILTER_SET_SOURCE.shared)}
+                  style={{ marginRight: '0.5rem' }}
+                />
+                Shared via token
+              </label>
+            </>
           }
         />
-        <SimpleInputField
-          label='Description'
-          input={
-            <textarea
-              id='open-filter-set-description'
-              disabled
-              placeholder='No description'
-              value={selected.value.description}
+        {isSourceSaved ? (
+          <div style={{ height: '8rem' }}>
+            <SimpleInputField
+              label='Name'
+              input={
+                <Select
+                  inputId='open-filter-set-name'
+                  options={options}
+                  value={selected}
+                  isClearable={false}
+                  theme={overrideSelectTheme}
+                  onChange={(e) => setSelected(e)}
+                />
+              }
             />
-          }
-        />
-        <ExplorerFilterDisplay filter={selected.value.filter} />
+            <SimpleInputField
+              label='Description'
+              input={
+                <textarea
+                  id='open-filter-set-description'
+                  disabled
+                  placeholder='No description'
+                  value={selected.value.description}
+                />
+              }
+            />
+          </div>
+        ) : (
+          <>
+            <div style={{ height: '4rem' }}>
+              <SimpleInputField
+                label='Token'
+                input={
+                  <input
+                    id='open-filter-set-token'
+                    type='text'
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                  />
+                }
+                error={{
+                  isError: shared.isError,
+                  message: 'Error: Check your token and try again.',
+                }}
+              />
+            </div>
+            <div style={{ height: '4rem', marginLeft: '1rem' }}>
+              <Button
+                buttonType='secondary'
+                label='Use token'
+                enabled={token !== '' && !shared.isPending}
+                onClick={handleUseToken}
+              />
+            </div>
+          </>
+        )}
+        <ExplorerFilterDisplay filter={value?.filter} />
       </form>
       <div>
         <Button buttonType='default' label='Back to page' onClick={onClose} />
         <Button
           label='Open Filter Set'
-          enabled={selected.value.name !== ''}
-          onClick={() => onAction(selected.value)}
+          enabled={isActionEnabled}
+          onClick={() => onAction(value, isSourceShared)}
         />
       </div>
     </div>
@@ -88,6 +208,7 @@ FilterSetOpenForm.propTypes = {
       id: PropTypes.number,
     })
   ),
+  fetchWithToken: PropTypes.func,
   onAction: PropTypes.func,
   onClose: PropTypes.func,
 };

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.jsx
@@ -1,0 +1,89 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import Button from '../../gen3-ui-component/components/Button';
+import './ExplorerFilterSetForms.css';
+
+function useToken(fetcher) {
+  const [data, setData] = useState(null);
+  const [isError, setIsError] = useState(false);
+
+  function refresh() {
+    setData(null);
+    setIsError(false);
+
+    fetcher()
+      .then(setData)
+      .catch(() => setIsError(true));
+  }
+  useEffect(refresh, []);
+
+  return {
+    data,
+    isError,
+    refresh,
+  };
+}
+
+/**
+ * @param {Object} prop
+ * @param {() => Promise<string>} prop.onAction
+ * @param {() => void} prop.onClose
+ */
+function FilterSetShareForm({ onAction, onClose }) {
+  const token = useToken(onAction);
+  const [isTokenCopied, setIsTokenCopied] = useState(false);
+  function toggleIsTokenCopied() {
+    setIsTokenCopied(true);
+    setTimeout(() => setIsTokenCopied(false), 2000);
+  }
+  function handleCopy() {
+    navigator.clipboard.writeText(token.data).then(toggleIsTokenCopied);
+  }
+
+  return (
+    <div className='explorer-filter-set-form'>
+      <h4>Use the following token to share your Filter Set</h4>
+      <div style={{ margin: '1rem' }}>
+        {token.isError ? (
+          <p>Failed to generate a shareable token! Please try again.</p>
+        ) : (
+          <pre>{token.data ?? 'Generating token...'}</pre>
+        )}
+      </div>
+
+      <div>
+        <Button buttonType='default' label='Back to page' onClick={onClose} />
+        {token.isError ? (
+          <Button
+            buttonType='primary'
+            label='Try again'
+            onClick={token.refresh}
+          />
+        ) : (
+          <Button
+            buttonType='secondary'
+            label={
+              isTokenCopied ? (
+                <>
+                  Copied <FontAwesomeIcon icon='circle-check' />
+                </>
+              ) : (
+                'Copy to clipboard'
+              )
+            }
+            enabled={token.data !== null && !isTokenCopied}
+            onClick={handleCopy}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+FilterSetShareForm.propTypes = {
+  onAction: PropTypes.func,
+  onClose: PropTypes.func,
+};
+
+export default FilterSetShareForm;

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.test.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.test.jsx
@@ -1,9 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import FilterSetShareForm from './FilterSetShareForm';
-import { testReduxStore } from './testData';
-
-const TOKEN_VALUE = 'foo';
+import { testReduxStore, testToken } from './testData';
 
 /**
  * @param {Partial<Parameters<typeof FilterSetShareForm>[0]>} [props]
@@ -11,7 +9,7 @@ const TOKEN_VALUE = 'foo';
  */
 function getProps(props = {}) {
   const defaultProps = {
-    onAction: () => Promise.resolve(TOKEN_VALUE),
+    onAction: () => Promise.resolve(testToken),
     onClose: () => {},
   };
   return { ...defaultProps, ...props };
@@ -42,7 +40,7 @@ test('token generated', async () => {
 
   await waitFor(() => expect(container).toBeInTheDocument());
 
-  expect(queryByText(TOKEN_VALUE)).toBeInTheDocument();
+  expect(queryByText(testToken)).toBeInTheDocument();
 
   const copyButton = queryByRole('button', { name: 'Copy to clipboard' });
   expect(copyButton).toBeInTheDocument();
@@ -61,7 +59,7 @@ test('token failed', async () => {
 
   await waitFor(() => expect(container).toBeInTheDocument());
 
-  expect(queryByText(TOKEN_VALUE)).not.toBeInTheDocument();
+  expect(queryByText(testToken)).not.toBeInTheDocument();
 
   const tryAgainButton = queryByRole('button', { name: 'Try again' });
   expect(tryAgainButton).toBeInTheDocument();

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.test.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/FilterSetShareForm.test.jsx
@@ -1,0 +1,68 @@
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import FilterSetShareForm from './FilterSetShareForm';
+import { testReduxStore } from './testData';
+
+const TOKEN_VALUE = 'foo';
+
+/**
+ * @param {Partial<Parameters<typeof FilterSetShareForm>[0]>} [props]
+ * @returns {Parameters<typeof FilterSetShareForm>[0]}
+ */
+function getProps(props = {}) {
+  const defaultProps = {
+    onAction: () => Promise.resolve(TOKEN_VALUE),
+    onClose: () => {},
+  };
+  return { ...defaultProps, ...props };
+}
+
+test('renders', async () => {
+  const { container, queryByRole, queryByText } = render(
+    <Provider store={testReduxStore}>
+      <FilterSetShareForm {...getProps()} />
+    </Provider>
+  );
+
+  await waitFor(() => expect(container).toBeInTheDocument());
+
+  const titleText = 'Use the following token to share your Filter Set';
+  expect(queryByText(titleText)).toBeInTheDocument();
+
+  const closeButton = queryByRole('button', { name: 'Back to page' });
+  expect(closeButton).toBeInTheDocument();
+});
+
+test('token generated', async () => {
+  const { container, queryByRole, queryByText } = render(
+    <Provider store={testReduxStore}>
+      <FilterSetShareForm {...getProps()} />
+    </Provider>
+  );
+
+  await waitFor(() => expect(container).toBeInTheDocument());
+
+  expect(queryByText(TOKEN_VALUE)).toBeInTheDocument();
+
+  const copyButton = queryByRole('button', { name: 'Copy to clipboard' });
+  expect(copyButton).toBeInTheDocument();
+});
+
+test('token failed', async () => {
+  const { container, queryByRole, queryByText } = render(
+    <Provider store={testReduxStore}>
+      <FilterSetShareForm
+        {...getProps({
+          onAction: () => Promise.reject(),
+        })}
+      />
+    </Provider>
+  );
+
+  await waitFor(() => expect(container).toBeInTheDocument());
+
+  expect(queryByText(TOKEN_VALUE)).not.toBeInTheDocument();
+
+  const tryAgainButton = queryByRole('button', { name: 'Try again' });
+  expect(tryAgainButton).toBeInTheDocument();
+});

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/testData.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/testData.js
@@ -57,3 +57,5 @@ export const testFilterSets = [
     },
   },
 ];
+
+export const testToken = 'token-value';

--- a/src/GuppyDataExplorer/ExplorerFilterSetForms/testData.js
+++ b/src/GuppyDataExplorer/ExplorerFilterSetForms/testData.js
@@ -21,7 +21,7 @@ export const testReduxStore = configureStore({
   },
 });
 
-/** @type {import('../types').ExplorerFilterSet[]} */
+/** @type {import('../types').SavedExplorerFilterSet[]} */
 export const testFilterSets = [
   {
     name: 'Simple filter set',

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/FilterSetActionForm.jsx
@@ -3,25 +3,34 @@ import Button from '../../gen3-ui-component/components/Button';
 import FilterSetCreateForm from '../ExplorerFilterSetForms/FilterSetCreateForm';
 import FilterSetDeleteForm from '../ExplorerFilterSetForms/FilterSetDeleteForm';
 import FilterSetOpenForm from '../ExplorerFilterSetForms/FilterSetOpenForm';
+import FilterSetShareForm from '../ExplorerFilterSetForms/FilterSetShareForm';
 import FilterSetUpdateForm from '../ExplorerFilterSetForms/FilterSetUpdateForm';
 
 /** @typedef {import('../types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('../types').SavedExplorerFilterSet} SavedExplorerFilterSet */
-/** @typedef {'CLEAR-ALL' | 'DELETE' | 'LOAD' | 'SAVE'} ActionFormType */
+/** @typedef {'CLEAR-ALL' | 'DELETE' | 'LOAD' | 'SAVE' | 'SHARE'} ActionFormType */
 
 /**
  * @param {Object} prop
  * @param {SavedExplorerFilterSet['filter']} prop.currentFilter
  * @param {{ active: SavedExplorerFilterSet; all: SavedExplorerFilterSet[]; empty: SavedExplorerFilterSet }} prop.filterSets
+ * @param {(token: string) => Promise<SavedExplorerFilterSet>} prop.fetchWithToken
  * @param {Object} prop.handlers
  * @param {() => void} prop.handlers.clearAll
  * @param {() => void} prop.handlers.close
  * @param {(deleted: SavedExplorerFilterSet) => void} prop.handlers.delete
- * @param {(loaded: SavedExplorerFilterSet) => void} prop.handlers.load
+ * @param {(loaded: SavedExplorerFilterSet, isshared?: boolean) => void} prop.handlers.load
  * @param {(saved: SavedExplorerFilterSet) => void} prop.handlers.save
+ * @param {() => Promise} prop.handlers.share
  * @param {ActionFormType} prop.type
  */
-function FilterSetActionForm({ currentFilter, filterSets, handlers, type }) {
+function FilterSetActionForm({
+  currentFilter,
+  filterSets,
+  fetchWithToken,
+  handlers,
+  type,
+}) {
   switch (type) {
     case 'CLEAR-ALL':
       return (
@@ -46,6 +55,7 @@ function FilterSetActionForm({ currentFilter, filterSets, handlers, type }) {
         <FilterSetOpenForm
           currentFilterSet={filterSets.active ?? filterSets.empty}
           filterSets={filterSets.all}
+          fetchWithToken={fetchWithToken}
           onAction={handlers.load}
           onClose={handlers.close}
         />
@@ -73,6 +83,13 @@ function FilterSetActionForm({ currentFilter, filterSets, handlers, type }) {
           }
         />
       );
+    case 'SHARE':
+      return (
+        <FilterSetShareForm
+          onAction={handlers.share}
+          onClose={handlers.close}
+        />
+      );
     case 'DELETE':
       return (
         <FilterSetDeleteForm
@@ -89,14 +106,16 @@ function FilterSetActionForm({ currentFilter, filterSets, handlers, type }) {
 FilterSetActionForm.propTypes = {
   currentFilter: PropTypes.object,
   filterSets: PropTypes.object,
+  fetchWithToken: PropTypes.func,
   handlers: PropTypes.shape({
     clearAll: PropTypes.func,
     close: PropTypes.func,
     delete: PropTypes.func,
     load: PropTypes.func,
     save: PropTypes.func,
+    share: PropTypes.func,
   }),
-  type: PropTypes.oneOf(['CLEAR-ALL', 'DELETE', 'LOAD', 'SAVE']),
+  type: PropTypes.oneOf(['CLEAR-ALL', 'DELETE', 'LOAD', 'SAVE', 'SHARE']),
 };
 
 export default FilterSetActionForm;

--- a/src/redux/explorer/filterSetsAPI.js
+++ b/src/redux/explorer/filterSetsAPI.js
@@ -1,6 +1,7 @@
 import { fetchWithCreds } from '../utils.fetch';
 import { convertFromFilterSetDTO, convertToFilterSetDTO } from './utils';
 
+/** @typedef {import('./types').ExplorerFilterSet} ExplorerFilterSet */
 /** @typedef {import('../../GuppyDataExplorer/types').SavedExplorerFilterSet} SavedExplorerFilterSet */
 
 const FILTER_SET_URL = '/amanuensis/filter-sets';
@@ -69,5 +70,33 @@ export function updateById(explorerId, filterSet) {
   }).then(({ response, status }) => {
     if (status !== 200) throw response.statusText;
     return filterSet;
+  });
+}
+
+/**
+ * @param {SavedExplorerFilterSet} filterSet
+ * @returns {Promise<string>}
+ */
+export function createToken(filterSet) {
+  return fetchWithCreds({
+    path: `${FILTER_SET_URL}/snapshot`,
+    method: 'POST',
+    body: JSON.stringify({ filterSetId: filterSet.id }),
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    return data;
+  });
+}
+
+/**
+ * @param {string} token
+ * @returns {Promise<SavedExplorerFilterSet>}
+ */
+export function fetchWithToken(token) {
+  return fetchWithCreds({
+    path: `${FILTER_SET_URL}/snapshot/${token}`,
+  }).then(({ response, data, status }) => {
+    if (status !== 200) throw response.statusText;
+    return convertFromFilterSetDTO(data);
   });
 }


### PR DESCRIPTION
Ticket: [PEDS-878](https://pcdc.atlassian.net/browse/PEDS-878)

This PR implements a feature to "sharing" filter sets using tokens. This feature consists of two parts:

1. Generate a unique token value using a Saved Filter Set
2. Use a token to retrieve the corresponding Filter Set & use its filter value on Filter Set Workspace.

### Generating token

A new Filter Set "share" form is created. See the following demo with simulated responses:

https://user-images.githubusercontent.com/22449454/206868031-48b6982d-9473-4bd3-8596-4e7e0a860904.mov

### Using token to retrieve a shared Filter Set

The existing "open" form is modified to support using tokens. See the following demo.

https://user-images.githubusercontent.com/22449454/206868187-51e12318-8b22-4e2c-97c9-1801de3d1540.mov

Please note that, to avoid making unnecessary requests, the form prevents making new requests when using the same token i.e. user clicks "Use Token" button again when token value has not changed.
