### PR TITLE
PEDS-920 - wrapped long labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "react-select-async-paginate": "^0.6.2",
         "react-switch": "^7.0.0",
         "react-table": "^7.8.0",
-        "recharts": "^2.1.15",
+        "recharts": "^2.4.3",
         "relay-compiler": "^12.0.0",
         "relay-runtime": "^12.0.0",
         "string-similarity": "^4.0.4",
@@ -29177,9 +29177,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
-      "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.4.3.tgz",
+      "integrity": "sha512-/hkRHTQShEOKDYd2OlKLIvGA0X9v/XVO/mNeRoDHg0lgFRL2KbGzeqVnStI3mMfORUZ6Hak4JbQ+uDiin1Foqg==",
       "dependencies": {
         "classnames": "^2.2.5",
         "eventemitter3": "^4.0.1",
@@ -56811,9 +56811,9 @@
       }
     },
     "recharts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
-      "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.4.3.tgz",
+      "integrity": "sha512-/hkRHTQShEOKDYd2OlKLIvGA0X9v/XVO/mNeRoDHg0lgFRL2KbGzeqVnStI3mMfORUZ6Hak4JbQ+uDiin1Foqg==",
       "requires": {
         "classnames": "^2.2.5",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-select-async-paginate": "^0.6.2",
     "react-switch": "^7.0.0",
     "react-table": "^7.8.0",
-    "recharts": "^2.1.15",
+    "recharts": "^2.4.3",
     "relay-compiler": "^12.0.0",
     "relay-runtime": "^12.0.0",
     "string-similarity": "^4.0.4",

--- a/src/components/charts/Tick.jsx
+++ b/src/components/charts/Tick.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { Text } from 'recharts';
 
 /**
  * @typedef {Object} TickProps
@@ -17,9 +18,18 @@ function Tick({ payload = {}, x = 0, y = 0 }) {
           {countNumber}
         </tspan>
       </text>
-      <text textAnchor='end' x={x} y={y} dy={20}>
-        <tspan className='h4-typo'>{countName}</tspan>
-      </text>
+      <Text
+        textAnchor='end'
+        x={x}
+        y={y}
+        dy={10}
+        width='200'
+        verticalAnchor='start'
+        fill={''}
+        className='h4-typo'
+      >
+        {countName}
+      </Text>
     </g>
   );
 }


### PR DESCRIPTION
Ticket [PEDS-920](https://pcdc.atlassian.net/browse/PEDS-920)

Using ```Text``` component from ```recharts``` and set the ```width``` property so that the long label wraps to fit in the width

![Screen Shot 2023-03-09 at 10 44 39 AM](https://user-images.githubusercontent.com/4490199/224077843-8ecc8129-815f-4d55-9f06-6a028fa7f77f.png)



[PEDS-920]: https://pcdc.atlassian.net/browse/PEDS-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ