### PR TITLE
PEDS-962 - fixed no data for redirect link in explore in window

### DIFF
--- a/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerExploreExternalButton/index.jsx
@@ -119,10 +119,12 @@ function ExplorerExploreExternalButton({ filter }) {
   }
 
   function isOpenInNewTabButtonEnabled() {
-    if (!commonsInfo || !commonsInfo.data) {
+    if (!commonsInfo) {
       return false;
     } else if (commonsInfo.type === 'file') {
-      return isFileDownloaded;
+      return commonsInfo.data ? isFileDownloaded : false;
+    } else {
+      return true;
     }
   }
 
@@ -154,12 +156,14 @@ function ExplorerExploreExternalButton({ filter }) {
                 }
               />
               <ExplorerFilterDisplay filter={filter} />
-              {commonsInfo && !commonsInfo.data && (
-                <p className="no-data-info">
-                  There is no data for this cohort of subjects in the{' '}
-                  {selected.value.toUpperCase()} platform
-                </p>
-              )}
+              {commonsInfo &&
+                commonsInfo.type === 'file' &&
+                !commonsInfo.data && (
+                  <p className='no-data-info'>
+                    There is no data for this cohort of subjects in the{' '}
+                    {selected.value.toUpperCase()} platform
+                  </p>
+                )}
               {isLoading && (
                 <div className='explorer-explore-external__loading'>
                   <Spinner />


### PR DESCRIPTION
[PEDS-962](https://pcdc.atlassian.net/browse/PEDS-962)

If the type is 'redirect', always enable the buttons.
If the type is 'file', only enable the buttons when there's data

[PEDS-962]: https://pcdc.atlassian.net/browse/PEDS-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ