### PR TITLE
PEDS-809 - Include the disease name with the consortium in the data-portal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -189,7 +189,11 @@ function App() {
         <Route
           path='explorer'
           element={
-            <ProtectedContent preload={() => dispatch(fetchSurvivalConfig())}>
+            <ProtectedContent preload={() => 
+              Promise.all([
+                dispatch(fetchDictionary()),
+                dispatch(fetchSurvivalConfig())
+              ])}>
               <Explorer />
             </ProtectedContent>
           }

--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -31,6 +31,7 @@ import {
  * @property {(x: string[]) => void} [onPatientIdsChange]
  * @property {string[]} [patientIds]
  * @property {SimpleAggsData} tabsOptions
+ * @property {Array} dictionaryEntries
  */
 
 /** @param {ConnectedFilterProps} props */
@@ -49,6 +50,7 @@ function ConnectedFilter({
   onPatientIdsChange,
   patientIds,
   tabsOptions,
+  dictionaryEntries
 }) {
   if (
     hidden ||
@@ -74,6 +76,7 @@ function ConnectedFilter({
 
   const filterTabs = filterConfig.tabs.map(({ fields, searchFields }) =>
     getFilterSections({
+      dictionaryEntries,
       adminAppliedPreFilters,
       arrayFields: arrayFields.current,
       fields,
@@ -149,6 +152,7 @@ ConnectedFilter.propTypes = {
   onPatientIdsChange: PropTypes.func,
   patientIds: PropTypes.arrayOf(PropTypes.string),
   tabsOptions: PropTypes.object.isRequired,
+  dictionaryEntries: PropTypes.array.isRequired
 };
 
 export default ConnectedFilter;

--- a/src/GuppyComponents/Utils/filters.js
+++ b/src/GuppyComponents/Utils/filters.js
@@ -240,11 +240,28 @@ export const mergeTabOptions = (firstTabsOptions, secondTabsOptions) => {
 
 /**
  * @param {Object} args
+ * @param {string} [args.field]
+ * @param {Array} [args.dictionaryEntries]
+ */
+function findDictionaryEntryForField(field, dictionaryEntries) {
+  let foundEntry = dictionaryEntries.find((entry) => {
+    let { entryKey, sectionKey } = entry;
+    return field === entryKey || field === `${sectionKey}.${entryKey}`;
+  });
+  return foundEntry?.entryValue;
+}
+
+/**
+ * @param {Object} args
+ * @param {string} [args.field]
+ * @param {Array} [args.dictionaryEntries]
  * @param {OptionFilter['selectedValues']} [args.adminAppliedPreFilterValues]
  * @param {{ histogram: AggsCount[] }} args.histogramResult
  * @param {{ histogram: AggsCount[] }} args.initialHistogramResult
  */
 const getSingleFilterOption = ({
+  field,
+  dictionaryEntries,
   adminAppliedPreFilterValues,
   histogramResult,
   initialHistogramResult,
@@ -274,7 +291,11 @@ const getSingleFilterOption = ({
         count: item.count,
       });
     } else {
+      let entry = findDictionaryEntryForField(field, dictionaryEntries);
+      let enumDef = (entry?.enumDef || []).find((enumDefEntry) => enumDefEntry.enumeration === item.key);
+
       options.push({
+        description: enumDef?.description,
         text: item.key,
         filterType: 'singleSelect',
         count: item.count,
@@ -361,6 +382,7 @@ export const checkIsArrayField = (field, arrayFields) => {
  * @param {SimpleAggsData} args.initialTabsOptions
  * @param {string[]} args.searchFields
  * @param {SimpleAggsData} args.tabsOptions
+ * @param {Array} args.dictionaryEntries
  * @returns {import('../../gen3-ui-component/components/filters/types').FilterSectionConfig[]}
  */
 export const getFilterSections = ({
@@ -372,6 +394,7 @@ export const getFilterSections = ({
   initialTabsOptions,
   searchFields,
   tabsOptions,
+  dictionaryEntries
 }) => {
   let searchFieldSections = [];
 
@@ -396,6 +419,8 @@ export const getFilterSections = ({
       let selectedOptions = [];
       if (tabsOptionsFiltered && tabsOptionsFiltered.histogram) {
         selectedOptions = getSingleFilterOption({
+          field,
+          dictionaryEntries,
           adminAppliedPreFilterValues:
             adminAppliedPreFilters[field]?.selectedValues,
           histogramResult: tabsOptionsFiltered,
@@ -431,6 +456,8 @@ export const getFilterSections = ({
     }
 
     const defaultOptions = getSingleFilterOption({
+      field,
+      dictionaryEntries,
       adminAppliedPreFilterValues:
         adminAppliedPreFilters[field]?.selectedValues,
       histogramResult: tabsOptionsFiltered,

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -44,6 +44,7 @@ DisabledExplorerFilter.propTypes = {
  * @property {GuppyData['onFilterChange']} onFilterChange
  * @property {GuppyData['onAnchorValueChange']} onAnchorValueChange
  * @property {GuppyData['tabsOptions']} tabsOptions
+ * @property {Object} dictionaryEntries
  */
 
 /** @param {ExplorerFilterProps} props */
@@ -96,6 +97,7 @@ ExplorerFilter.propTypes = {
   onAnchorValueChange: PropTypes.func.isRequired, // from GuppyWrapper
   onFilterChange: PropTypes.func.isRequired, // from GuppyWrapper
   tabsOptions: PropTypes.object.isRequired, // from GuppWrapper
+  dictionaryEntries: PropTypes.array
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -13,14 +13,18 @@ import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter, { DisabledExplorerFilter } from './ExplorerFilter';
 import './Explorer.css';
 import { FILTER_TYPE } from './ExplorerFilterSetWorkspace/utils';
+import { useStore } from 'react-redux';
 
 /** @typedef {import('../redux/types').RootState} RootState */
 /** @typedef {import('./types').OptionFilter} OptionFilter */
+/** @typedef {import('../redux/types').RootStore} RootStore */
 
 /** @type {{ [x: string]: OptionFilter }} */
 const emptyAdminAppliedPreFilters = {};
 
 function ExplorerDashboard() {
+    /** @type {RootStore} */
+  const reduxStore = useStore();
   const dispatch = useAppDispatch();
   /** @param {RootState['explorer']['explorerFilter']} filter */
   function handleFilterChange(filter) {
@@ -71,6 +75,19 @@ function ExplorerDashboard() {
       window.removeEventListener('popstate', switchExplorerOnBrowserNavigation);
   }, []);
 
+  const dict = reduxStore.getState().submission.dictionary;
+  const dictSections = dict ? Object.entries(dict) : [];
+
+  const dictionaryEntries = [];
+  for (let [sectionKey, sectionValue] of dictSections) {
+    if (sectionKey && !sectionKey.startsWith('_') && sectionValue?.hasOwnProperty('properties')) {
+      const dictEntries = Object.entries(sectionValue.properties);
+      for (let [entryKey, entryValue] of dictEntries) {
+        dictionaryEntries.push({ sectionKey, entryKey, entryValue });
+      }
+    }
+  }
+
   return (
     <GuppyWrapper
       key={explorerId}
@@ -83,8 +100,8 @@ function ExplorerDashboard() {
       rawDataFields={tableConfig.fields}
       patientIds={patientIds}
     >
-      {(data) => (
-        <Dashboard>
+      {(data) => {
+        return <Dashboard>
           <Dashboard.Sidebar className='explorer__sidebar'>
             <div>
               <ExplorerSelect />
@@ -99,6 +116,7 @@ function ExplorerDashboard() {
                   onAnchorValueChange={data.onAnchorValueChange}
                   onFilterChange={data.onFilterChange}
                   tabsOptions={data.tabsOptions}
+                  dictionaryEntries={dictionaryEntries}
                 />
               )}
             </div>
@@ -139,7 +157,7 @@ function ExplorerDashboard() {
             />
           </Dashboard.Main>
         </Dashboard>
-      )}
+      }}
     </GuppyWrapper>
   );
 }

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -448,6 +448,7 @@ function FilterSection({
                 disabledTooltipMessage={disabledTooltipMessage}
                 hideZero={hideZero}
                 label={option.text}
+                optionTooltip={option.description}
                 lockedTooltipMessage={lockedTooltipMessage}
                 onSelect={handleSelectSingleSelectFilter}
                 selected={filterStatus[option.text]}

--- a/src/gen3-ui-component/components/filters/SingleSelectFilter/index.jsx
+++ b/src/gen3-ui-component/components/filters/SingleSelectFilter/index.jsx
@@ -11,7 +11,8 @@ import './SingleSelectFilter.css';
  * @property {string} [disabledTooltipMessage]
  * @property {number} [hideValue]
  * @property {boolean} [hideZero]
- * @property {string} label
+ * @property {string} [label]
+ * @property {string} [optionTooltip]
  * @property {string} [lockedTooltipMessage]
  * @property {(label: string) => void} onSelect
  * @property {boolean} [selected]
@@ -26,6 +27,7 @@ function SingleSelectFilter({
   hideValue = -1,
   hideZero = true,
   label,
+  optionTooltip,
   lockedTooltipMessage = '',
   onSelect,
   selected,
@@ -103,8 +105,21 @@ function SingleSelectFilter({
         onChange={handleCheck}
         checked={isChecked}
         disabled={inputDisabled}
-      />
-      <span className='g3-single-select-filter__label'>{label}</span>
+      /> 
+      <span className='g3-single-select-filter__label'>
+        {
+          optionTooltip ? 
+          <Tooltip
+              placement='right'
+              overlay={<span>{optionTooltip}</span>}
+              arrowContent={<div className='rc-tooltip-arrow-inner' />}
+              trigger={['hover', 'focus']}
+          >
+            <span>{label}</span>
+          </Tooltip> :
+          label
+        }
+      </span>
       {count !== null && countIconComponent}
       {lockIconComponent}
     </div>
@@ -119,6 +134,7 @@ SingleSelectFilter.propTypes = {
   hideValue: PropTypes.number,
   hideZero: PropTypes.bool,
   label: PropTypes.string.isRequired,
+  optionTooltip: PropTypes.string,
   lockedTooltipMessage: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   selected: PropTypes.bool,


### PR DESCRIPTION
## Description

Includes client changes necessary to support adding an `enumDef` description to any `enum` in the data-dictionary and have the description in said `enumDef` be displayed in the portal as a tooltip on the `enum` member.

<img width="1178" alt="Screenshot 2023-05-17 at 10 00 45 AM" src="https://github.com/chicagopcdc/data-portal/assets/4146362/c394f13f-c70f-4423-b4a1-5b2565861ae7">
