### PR TITLE
PEDS-940 - showing count in the index bar chart and made showing count/percentage configurable

### DIFF
--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -13,7 +13,9 @@ import TooltipCDIS from '../TooltipCDIS';
 import Tick from '../Tick';
 import './IndexBarChart.css';
 import { getCategoryColor } from '../helper';
+import { components } from '../../../params';
 
+const showPercentage = components.index?.barChart?.showPercentage;
 const sortCount = (a, b) => {
   const countA = a.counts.reduce((res, item) => res + item);
   const countB = b.counts.reduce((res, item) => res + item);
@@ -55,8 +57,7 @@ const createChartData = (projectList, countNames, sumList) => {
     project.counts.forEach((count, j) => {
       if (typeof indexChart[j] === 'undefined') return;
       indexChart[j].allCounts.push(count);
-      indexChart[j][`count${i}`] =
-        sumList[j] > 0 ? ((count * 100) / sumList[j]).toFixed(2) : 0;
+      indexChart[j][`count${i}`] = getChartCount(count, sumList[j]);
     });
   });
 
@@ -66,6 +67,13 @@ const createChartData = (projectList, countNames, sumList) => {
     return newIndex;
   });
   return indexChart;
+};
+
+const getChartCount = (count, sum) => {
+  if (showPercentage) {
+    return sum > 0 ? ((count * 100) / sum).toFixed(2) : 0;
+  }
+  return sum > 0 ? count : 0;
 };
 
 /**
@@ -110,7 +118,6 @@ function IndexBarChart({ projectList, countNames, barChartStyle, xAxisStyle }) {
             {...xAxisStyle}
             stroke={xAxisStyle.color}
             fill={xAxisStyle.color}
-            unit='%'
             type='number'
           />
           <YAxis
@@ -152,9 +159,10 @@ IndexBarChart.defaultProps = {
   countNames: [],
   xAxisStyle: {
     color: '#666666',
-    domain: [0, 100],
-    ticks: [0, 25, 50, 75, 100],
+    domain: showPercentage ? [0, 100] : [],
+    ticks: showPercentage ? [0, 25, 50, 75, 100] : [],
     allowDecimals: false,
+    unit: showPercentage ? '%' : '',
   },
   barChartStyle: {
     margins: {


### PR DESCRIPTION
ticket [PEDS-940](https://pcdc.atlassian.net/browse/PEDS-940)

Add the following in the config file to show the percentage in the bar chart (under ```components.index```), otherwise, it shows the count
```
"components": {
    ....
    "index": {
    ....
    "barChart": {
        "showPercentage": true
      }
   }
}
```
![Screen Shot 2023-06-20 at 11 24 26 AM](https://github.com/chicagopcdc/data-portal/assets/4490199/7bc0741b-84a0-4e8b-85e7-74a5b7f1a4c6)


[PEDS-940]: https://pcdc.atlassian.net/browse/PEDS-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ