### PR TITLE
PEDS-875 - fixed filter selection hiding bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pcdc/windmill",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.22.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pcdc/windmill",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "PCDC Data Portal",
   "dependencies": {
     "@babel/core": "^7.22.1",

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -379,7 +379,6 @@ function FilterGroup({
           />
         )}
         {tabs[tabIndex]
-          .filter((section) => !!section.options.length)
           .map((section, index) => (
             <FilterSection
               key={section.title}

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -577,7 +577,7 @@ function FilterSection({
     </div>
   );
 
-  return (
+  return options.length ? (
     <div className='g3-filter-section'>
       {tooltip ? (
         <Tooltip
@@ -604,7 +604,7 @@ function FilterSection({
         </div>
       )}
     </div>
-  );
+  ) : null;
 }
 
 FilterSection.propTypes = {


### PR DESCRIPTION
The bug was because we have separate arrays to manage the filter tabs, tab status (expanded, selection, excluded and etc). I was only filtering out the filter tabs when "No Data", but leaving other arrays unfiltered. That's why the arrays didn't match each other any more.

I moved the hiding logic into FilterSection component just to be consistent across all arrays.
