### PR TITLE
Add code that got left out of last change

### DIFF
--- a/src/DataRequests/create.jsx
+++ b/src/DataRequests/create.jsx
@@ -116,7 +116,8 @@ function DataRequestCreate({ isCreatePending }) {
 
         createRequest.then((action) => {
           if (!action.payload.isError) {
-            window.open(getAccessButtonLink, '_blank');
+            let handle = window.open(getAccessButtonLink, '_blank', 'popup');
+            handle.blur();
             window.focus();
             navigate('/requests');
             return;

--- a/src/DataRequests/create.jsx
+++ b/src/DataRequests/create.jsx
@@ -116,7 +116,8 @@ function DataRequestCreate({ isCreatePending }) {
 
         createRequest.then((action) => {
           if (!action.payload.isError) {
-            window.open(getAccessButtonLink);
+            window.open(getAccessButtonLink, '_blank');
+            window.focus();
             navigate('/requests');
             return;
           }

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -134,7 +134,8 @@ function getChartData({
 
 function openLink(link) {
   if (link) {
-    window.open(link, '_blank');
+    let handle = window.open(link, '_blank', 'popup');
+    handle.blur();
     window.focus();
   }
 }


### PR DESCRIPTION
### Improvements

* Move to using a "popout" window for data request forms, since Chrome now stops running javascript on the originating tab as soon a new tab is opened, making it impossible to bring focus back to the window after opening
