### PR TITLE
PEDS-972 - sending user id as the user property for sending notification emails

### DIFF
--- a/src/redux/user/asyncThunks.js
+++ b/src/redux/user/asyncThunks.js
@@ -13,7 +13,11 @@ export const fetchUser = createAsyncThunk(
         onError: () => dispatch(requestErrored()),
       });
       if (status === 200) {
-        ReactGA.set({ userId: data.user_id.toString() });
+        const userId = data.user_id.toString();
+        ReactGA.set({ userId });
+        ReactGA.gtag('set', 'user_properties', {
+          userId,
+        });
         return { data, status };
       }
       if (status === 401) return { data: 'UPDATE_POPUP', status };


### PR DESCRIPTION
This is to set the ```userId``` user properties, so that the App Script can access and send notification emails
![Screen Shot 2024-02-26 at 11 16 08 AM](https://github.com/chicagopcdc/data-portal/assets/4490199/866dbfc4-ba2e-4a5f-9b30-7772aa815632)
