### PR TITLE
reroute user/admin/user through amanuensis

### DIFF
--- a/src/redux/user/asyncThunks.js
+++ b/src/redux/user/asyncThunks.js
@@ -33,7 +33,7 @@ export const adminFetchUsers = createAsyncThunk(
   async (_, { dispatch, rejectWithValue }) => {
     try {
       const { status, data } = await fetchWithCreds({
-        path: `${userapiPath}admin/user`,
+        path: `${hostname}amanuensis/admin/get_users`,
         onError: () => dispatch(requestErrored()),
       });
       if (status === 200) return { data, status };


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

instead of calling http://hostname/user/admin/user adminFetchUsers will call http://hostname/amanuensis/admin/get_users
which will call http://hostname/user/admin/user avoiding the need to give amanuensis admin users fence admin permissions 

### Breaking Changes
after approval wait for https://github.com/chicagopcdc/amanuensis/pull/176 to be merged 


### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
