### PR TITLE
Show missing TopBar items on small screens (top-left corner)

### DIFF
--- a/src/components/layout/TopBar.css
+++ b/src/components/layout/TopBar.css
@@ -17,12 +17,12 @@
   margin: 0 20px;
 }
 
-@media screen and (max-width: 820px) {
-  .top-bar {
-    justify-content: flex-end;
+@media screen and (max-width: 420px) {
+  .top-bar-item__content {
+    margin: auto 8px;
   }
 
-  .top-bar .top-bar__items {
-    display: none;
+  .top-bar__menu-group {
+    margin: 0 10px;
   }
 }

--- a/src/components/layout/TopBarItems.css
+++ b/src/components/layout/TopBarItems.css
@@ -40,3 +40,16 @@ button.top-bar-item {
 .top-bar-item__content:hover {
   border-bottom: 1px solid var(--g3-color__white);
 }
+
+@media screen and (max-width: 420px) {
+  .top-bar-item__content.body-typo {
+    font-size: 12px;
+  }
+
+  .top-bar-item__content > i.g3-icon {
+    width: 10px;
+    height: 10px;
+    top: 1px;
+    margin-left: 0.2rem;
+  }
+}

--- a/src/components/layout/TopBarMenu.css
+++ b/src/components/layout/TopBarMenu.css
@@ -90,3 +90,11 @@
 .top-bar-menu > button:hover svg {
   color: var(--pcdc-color__secondary-light);
 }
+
+@media screen and (max-width: 420px) {
+  .top-bar-menu > button i.g3-icon,
+  .top-bar-menu > button svg {
+    height: 18px;
+    width: 18px;
+  }
+}


### PR DESCRIPTION
## 📝 Description
This pull request fixes the issue where `TopBar items` were missing on small screens. Currently, only the `top-right icons` are visible, and no items are shown in the top-left corner, which negatively affects the user interface and accessibility.

This update ensures that essential TopBar items are displayed properly even on **smaller devices**, improving the overall responsiveness and usability of the layout.

## 🐞 Bug Fixes 
- Displayed missing TopBar items on small screens
- Ensured top-left UI elements render correctly on responsive breakpoints
- Improved UI consistency and user experience for mobile and tablet views

## Before 

![Before - Small Mobile](https://github.com/user-attachments/assets/99b88447-e68b-4b3e-892a-fa02e406a306)

![Before - Large Mobile](https://github.com/user-attachments/assets/2f891ed8-9396-4392-9793-7546bfd65f36)

![Before - Tablet View](https://github.com/user-attachments/assets/d45424d8-e896-44f4-b558-386326feed27)

## After 

![After - Small Mobile](https://github.com/user-attachments/assets/8e64ddce-5926-4f57-9005-37f2d37d8bca)

![After - Large Mobile](https://github.com/user-attachments/assets/0354b2f8-26b3-4018-838d-9345ef7a3975)

![After - Tablet View](https://github.com/user-attachments/assets/cba7f5b1-f3cb-4476-85e8-4f469bef60cc)

