### PR TITLE
PEDS-947 unitCalculator bug fix: use pcdc.json info to configure rangeFilters

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -230,46 +230,59 @@ See [this page](./multi_tab_explorer.md) for further information on `explorerCon
 
 Information in `pcdc.json` allows the configuration of the filters in the explorer. 
 
-Range filters (filters with a min and max) can be configured according to their specific context. For example, age filters like 'Age at Censor Status' is configured to contain a Unit Calculator (which converts months/years to days) while numerical filters like 'Year at Initial Diagnoses' don't have a Unit Calculator. Currently, all Unit Calculators convert months/years to days.
+Range filters (filters with a min and max) can be configured according to their specific context. For example, age filters like 'Age at Censor Status' is configured to contain a Unit Calculator (which converts months/years to days) while numerical filters like 'Year at Initial Diagnoses' don't have a Unit Calculator. Currently, all Unit Calculators convert months/years to days. [More on how to change this below](#to-add-further-configurations). 
 
-All configurations can be adjusted in `pcdc.json`, in "filters"->"unitCalcConfig". "unitCalcConfig"->"calculatorMapping" separates filters into "number" filters and "age" filters, such that all "age" filters render a Unit Calculator, while "number" filters don't. "unitCalcConfig" -> "ageUnits" allow changes to the `quantity`, `desiredUnit`, and `selectUnits` that are used in the Unit Calculator itself.
+All unit calculator configurations can be adjusted in `pcdc.json`, by adding a new block in "filters" called "unitCalcConfig". 
 
-The current configuration in `pcdc.json is:
+unitCalcConfig contains two fields (they must be named exactly this): `ageUnits` and `calculatorMapping`. 
+1. `ageUnits` allows changes to the `quantity`, `desiredUnit`, and `selectUnits` that are used in the Unit Calculator itself.
+2. `calculatorMapping` separates filters into 2 types: "number" filters and "age" filters, such that all "age" filters render a Unit Calculator, while "number" filters don't. 
+
+A working configuration of `unitCalcConfig` in `pcdc.json` can be placed after "filters"->"tabs":
 ```
   ...
-  "unitCalcConfig": {
-      "ageUnits": {
-          "quantity": "age",
-          "desiredUnit": "days",
-          "selectUnits": { "months": 30, "years": 365 }
-        },
-      "calculatorMapping": {
-          "number": [
-            "Year at Initial Diagnosis",
-            "Longest Diameter Dimension 1",
-            "Radiation Dose",
-            "Necrosis PCT",
-            "MRD Result Numeric"
-          ],
-          "age": [
-            "Age At Censor Status",
-            "Age at Tumor Assessment",
-            "Age at Molecular Analysis",
-            "Age at SMN"
-          ]
+    "filters": {
+      "anchor": {...},
+      "tabs": [...],
+      "unitCalcConfig": {
+          "ageUnits": {
+            "quantity": "age",
+            "desiredUnit": "days",
+            "selectUnits": { "months": 30, "years": 365 }
+          },
+          "calculatorMapping": {
+            "number": [
+              "year_at_disease_phase",
+              "tumor_assessments.longest_diam_dim1",
+              "radiation_therapies.rt_dose",
+              "tumor_assessments.necrosis_pct",
+              "labs.lab_result_numeric" 
+            ],
+            "age": [
+              "age_at_censor_status",
+              "tumor_assessments.age_at_tumor_assessment",
+              "molecular_analysis.age_at_molecular_analysis",
+              "secondary_malignant_neoplasm.age_at_smn"
+            ]
+          }
         }
-      }
+      },
+    }
+...
 ```
 
-For example, to add another range filter called "Year of birth" as a numerical range filter (one without a Unit Calculator), we append "Year of birth" as another element in the list "unitCalcConfig"-> "calculatorMapping" -> "number". 
+For example, to add configurations for an existing range filter with the field name "year_of_birth" as a numerical range filter (one without a Unit Calculator), we append "year_of_birth" as another element in the list "unitCalcConfig"-> "calculatorMapping" -> "number". 
 
-This setup is currently not able to accommodate any other age units apart from `ageUnits`. 
+This setup is currently not able to accommodate any other age units apart from `ageUnits`. See the section below for how to add further configurations to change this. 
 
 ### To add further configurations 
 
-The information in `ageUnits` and `calculatorMapping` is imported in `src/gen3-ui-component/components/filters/FilterGroup/index.jsx` as `unitCalcTitles` (filterConfig.unitCalcConfig.calculatorMapping) and `unitCalcConfig` (filterConfig.unitCalcConfig.ageUnits). They can then be used to configure the filters accordingly, and be passed down as props to other files. 
+The information in `ageUnits` and `calculatorMapping` is imported in `src/gen3-ui-component/components/filters/FilterGroup/index.jsx` as `unitCalcTitles` (filterConfig.unitCalcConfig.calculatorMapping) and `unitCalcConfig` (filterConfig.unitCalcConfig.ageUnits). They can then be used to configure the filters and be passed down as props to other files.
 
 For example, `unitCalcConfig` is passed as a prop from `~FilterGroup/index.jsx` to `~/FilterSection/index.jsx`, and used in `~/RangeFilter/index.jsx` and `~RangeFilter/UnitCalculator/UnitCalculator.jsx`. 
+
+To add other available age units, add another block `myNewUnits` with the fields "quantity", "desiredUnit", and "selectUnits" (similar to `ageUnits`) to "unitCalcConfig" in `pcdc.json`. Then, it can be imported accordingly as `filterConfig.unitCalcConfig.myNewUnits` in `src/gen3-ui-component/components/filters/FilterGroup/index.jsx`, and can be used to configure the filters or passed down as props to other files. 
+
 
 
 

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -225,3 +225,51 @@ Below is an example, with inline comments describing what each JSON block config
 If you are looking to copy/paste configuration as a start, please use something in the Github repo as the inline comments below will become an issue.
 
 See [this page](./multi_tab_explorer.md) for further information on `explorerConfig` configuration option.
+
+## Configuring units for range filters in pcdc.json 
+
+Information in `pcdc.json` allows the configuration of the filters in the explorer. 
+
+Range filters (filters with a min and max) can be configured according to their specific context. For example, age filters like 'Age at Censor Status' is configured to contain a Unit Calculator (which converts months/years to days) while numerical filters like 'Year at Initial Diagnoses' don't have a Unit Calculator. Currently, all Unit Calculators convert months/years to days.
+
+All configurations can be adjusted in `pcdc.json`, in "filters"->"unitCalcConfig". "unitCalcConfig"->"calculatorMapping" separates filters into "number" filters and "age" filters, such that all "age" filters render a Unit Calculator, while "number" filters don't. "unitCalcConfig" -> "ageUnits" allow changes to the `quantity`, `desiredUnit`, and `selectUnits` that are used in the Unit Calculator itself.
+
+The current configuration in `pcdc.json is:
+```
+  ...
+  "unitCalcConfig": {
+      "ageUnits": {
+          "quantity": "age",
+          "desiredUnit": "days",
+          "selectUnits": { "months": 30, "years": 365 }
+        },
+      "calculatorMapping": {
+          "number": [
+            "Year at Initial Diagnosis",
+            "Longest Diameter Dimension 1",
+            "Radiation Dose",
+            "Necrosis PCT",
+            "MRD Result Numeric"
+          ],
+          "age": [
+            "Age At Censor Status",
+            "Age at Tumor Assessment",
+            "Age at Molecular Analysis",
+            "Age at SMN"
+          ]
+        }
+      }
+```
+
+For example, to add another range filter called "Year of birth" as a numerical range filter (one without a Unit Calculator), we append "Year of birth" as another element in the list "unitCalcConfig"-> "calculatorMapping" -> "number". 
+
+This setup is currently not able to accommodate any other age units apart from `ageUnits`. 
+
+### To add further configurations 
+
+The information in `ageUnits` and `calculatorMapping` is imported in `src/gen3-ui-component/components/filters/FilterGroup/index.jsx` as `unitCalcTitles` (filterConfig.unitCalcConfig.calculatorMapping) and `unitCalcConfig` (filterConfig.unitCalcConfig.ageUnits). They can then be used to configure the filters accordingly, and be passed down as props to other files. 
+
+For example, `unitCalcConfig` is passed as a prop from `~FilterGroup/index.jsx` to `~/FilterSection/index.jsx`, and used in `~/RangeFilter/index.jsx` and `~RangeFilter/UnitCalculator/UnitCalculator.jsx`. 
+
+
+

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -120,6 +120,20 @@ export type FilterTabsOption = {
   searchFields?: string[];
 };
 
+export type UnitCalcParams = {
+  quantity: string;
+  desiredUnit: string;
+  selectUnits: { [unit: string]: number };
+};
+
+export type UnitCalcConfig = {
+  ageUnits: UnitCalcParams;
+  calculatorMapping: {
+    number: string[];
+    age: string[];
+  };
+};
+
 export type FilterConfig = {
   anchor?: AnchorConfig;
   info?: /* runtime only */ {
@@ -129,6 +143,7 @@ export type FilterConfig = {
     };
   };
   tabs: FilterTabsOption[];
+  unitCalcConfig?: UnitCalcConfig;
 };
 
 export type GuppyConfig = {
@@ -206,11 +221,11 @@ export type GuppyData = {
   downloadRawDataByTypeAndFilter: (
     type: string,
     filter: FilterState,
-    fields: string[]
+    fields: string[],
   ) => Promise<void>;
   getTotalCountsByTypeAndFilter: (
     type: string,
-    filter: FilterState
+    filter: FilterState,
   ) => Promise<void>;
   fetchAndUpdateRawData: (args: {
     offset: number;

--- a/src/GuppyComponents/types.d.ts
+++ b/src/GuppyComponents/types.d.ts
@@ -221,11 +221,11 @@ export type GuppyData = {
   downloadRawDataByTypeAndFilter: (
     type: string,
     filter: FilterState,
-    fields: string[],
+    fields: string[]
   ) => Promise<void>;
   getTotalCountsByTypeAndFilter: (
     type: string,
-    filter: FilterState,
+    filter: FilterState
   ) => Promise<void>;
   fetchAndUpdateRawData: (args: {
     offset: number;

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -213,6 +213,7 @@ function FilterGroup({
     )
       onFilterChange(updated.filterResults);
   }
+  
 
   /**
    * @param {number} sectionIndex
@@ -424,7 +425,7 @@ function FilterGroup({
             title={section.title}
             tooltip={section.tooltip}
             unitCalcType={
-              unitCalcTitles.age.includes(section.title) ? 'age' : 'number'
+              unitCalcTitles.age.includes(filterTabs[tabIndex].fields[index]) ? 'age' : 'number'
             }
             unitCalcConfig={filterConfig.unitCalcConfig ? filterConfig.unitCalcConfig.ageUnits: null}
           />

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -93,7 +93,10 @@ function FilterGroup({
   // pulls info about which range filters use what quantity (e.g. age or number) from pcdc.json
   // unitCalcTitles.age contains all titles with the age quantity, and unitCalcTitles.number
   // contains all titles with the number quantity
-  const unitCalcTitles = filterConfig.unitCalcConfig.calculatorMapping;
+
+  // for backwards compatibility, if filterConfig.unitCalcConfig is undefined, 
+  // no unit calculator is shown on any range filter (all range filters are numeric)
+  const unitCalcTitles = (!filterConfig.unitCalcConfig) ? { number: [], age: [] } : filterConfig.unitCalcConfig.calculatorMapping;
 
   const [tabIndex, setTabIndex] = useState(0);
   const tabTitle = filterTabs[tabIndex].title;
@@ -423,7 +426,7 @@ function FilterGroup({
             unitCalcType={
               unitCalcTitles.age.includes(section.title) ? 'age' : 'number'
             }
-            unitCalcConfig={filterConfig.unitCalcConfig.ageUnits}
+            unitCalcConfig={filterConfig.unitCalcConfig ? filterConfig.unitCalcConfig.ageUnits: null}
           />
         ))}
       </div>

--- a/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterGroup/index.jsx
@@ -87,7 +87,7 @@ function FilterGroup({
       title,
       // If there are any search fields, insert them at the top of each tab's fields.
       fields: searchFields ? searchFields.concat(fields) : fields,
-    }),
+    })
   );
 
   // pulls info about which range filters use what quantity (e.g. age or number) from pcdc.json
@@ -113,7 +113,7 @@ function FilterGroup({
     ? 'Collapse all'
     : 'Open all';
   const [expandedStatus, setExpandedStatus] = useState(
-    getExpandedStatus(filterTabs, false),
+    getExpandedStatus(filterTabs, false)
   );
 
   const [filterResults, setFilterResults] = useState(filter);
@@ -127,7 +127,7 @@ function FilterGroup({
       anchorConfig: filterConfig.anchor,
       filterResults: filter,
       filterTabs,
-    }),
+    })
   );
   const isInitialRenderRef = useRef(true);
   useEffect(() => {
@@ -186,7 +186,7 @@ function FilterGroup({
   function handleToggleCombineMode(
     sectionIndex,
     combineModeFieldName,
-    combineModeValue,
+    combineModeValue
   ) {
     const updated = updateCombineMode({
       filterStatus,
@@ -247,7 +247,7 @@ function FilterGroup({
     });
 
     setExcludedStatus(
-      getExcludedStatus(filterTabs, updated.filterResults, excludedStatus),
+      getExcludedStatus(filterTabs, updated.filterResults, excludedStatus)
     );
     setFilterResults(removeEmptyFilter(updated.filterResults));
     onFilterChange(removeEmptyFilter(updated.filterResults));
@@ -267,7 +267,7 @@ function FilterGroup({
     upperBound,
     minValue,
     maxValue,
-    rangeStep = 1,
+    rangeStep = 1
   ) {
     const updated = updateRangeValue({
       filterStatus,
@@ -333,7 +333,7 @@ function FilterGroup({
           <div
             key={index}
             className={'g3-filter-group__tab'.concat(
-              tabIndex === index ? ' g3-filter-group__tab--selected' : '',
+              tabIndex === index ? ' g3-filter-group__tab--selected' : ''
             )}
             onClick={() => setTabIndex(index)}
             onKeyPress={(e) => {
@@ -448,7 +448,7 @@ FilterGroup.propTypes = {
         title: PropTypes.string,
         fields: PropTypes.arrayOf(PropTypes.string),
         searchFields: PropTypes.arrayOf(PropTypes.string),
-      }),
+      })
     ),
   }).isRequired,
   hideZero: PropTypes.bool,

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -47,6 +47,8 @@ function getNumValuesSelected(filterStatus) {
  * @property {(isExpanded: boolean) => void} [onToggle]
  * @property {(fieldName: string, value: string) => void} [onToggleCombineMode]
  * @property {(SingleSelectFilterOption[] | RangeFilterOption[])} options
+ * @property {string} [unitCalcType]
+ * @property {UnitCalcParams} [unitCalcConfig]
  * @property {string} [title]
  * @property {string} [tooltip]
  */
@@ -64,6 +66,13 @@ function getNumValuesSelected(filterStatus) {
  * @property {number} resetClickCounter
  */
 
+/**
+ * @typedef {Object} UnitCalcParams
+ * @property {string} quantity
+ * @property {string} desiredUnit
+ * @property {Object<string, number>} selectUnits
+ */
+
 const defaultOptions = [];
 
 /** @param {FilterSectionProps} props */
@@ -78,6 +87,8 @@ function FilterSection({
   isArrayField = false,
   isSearchFilter = false,
   lockedTooltipMessage = '',
+  unitCalcType,
+  unitCalcConfig,
   onAfterDrag,
   onClear = () => {},
   onSearchFilterLoadOptions,
@@ -127,7 +138,7 @@ function FilterSection({
       ...prevState,
       optionsVisibleStatus: getOptionsVisibleStatus(
         prevState.isShowingMoreOptions,
-        inputElem.current?.value
+        inputElem.current?.value,
       ),
     }));
   }, [options]);
@@ -138,7 +149,7 @@ function FilterSection({
       ...prevState,
       isSearchInputEmpty: true,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        prevState.isShowingMoreOptions
+        prevState.isShowingMoreOptions,
       ),
     }));
   }
@@ -169,7 +180,7 @@ function FilterSection({
       isSearchInputEmpty: !currentInput || currentInput.length === 0,
       optionsVisibleStatus: getOptionsVisibleStatus(
         prevState.isShowingMoreOptions,
-        currentInput
+        currentInput,
       ),
     }));
   }
@@ -234,7 +245,7 @@ function FilterSection({
       ...prevState,
       isShowingMoreOptions: !prevState.isShowingMoreOptions,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        !prevState.isShowingMoreOptions
+        !prevState.isShowingMoreOptions,
       ),
     }));
   }
@@ -273,7 +284,7 @@ function FilterSection({
               />
               {combineMode}
             </label>
-          )
+          ),
         )}
         <Tooltip
           arrowContent={<div className='rc-tooltip-arrow-inner' />}
@@ -410,6 +421,8 @@ function FilterSection({
           lowerBound={lowerBound}
           upperBound={upperBound}
           onAfterDrag={handleDragRangeFilter}
+          unitCalcType={unitCalcType}
+          unitCalcConfig={unitCalcConfig}
         />
       );
     });
@@ -453,7 +466,7 @@ function FilterSection({
                 onSelect={handleSelectSingleSelectFilter}
                 selected={filterStatus[option.text]}
               />
-            )
+            ),
         )}
       </>
     );
@@ -640,7 +653,7 @@ FilterSection.propTypes = {
       min: PropTypes.number,
       max: PropTypes.number,
       rangeStep: PropTypes.number, // by default 1
-    })
+    }),
   ),
   title: PropTypes.string,
   tooltip: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/FilterSection/index.jsx
+++ b/src/gen3-ui-component/components/filters/FilterSection/index.jsx
@@ -138,7 +138,7 @@ function FilterSection({
       ...prevState,
       optionsVisibleStatus: getOptionsVisibleStatus(
         prevState.isShowingMoreOptions,
-        inputElem.current?.value,
+        inputElem.current?.value
       ),
     }));
   }, [options]);
@@ -149,7 +149,7 @@ function FilterSection({
       ...prevState,
       isSearchInputEmpty: true,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        prevState.isShowingMoreOptions,
+        prevState.isShowingMoreOptions
       ),
     }));
   }
@@ -180,7 +180,7 @@ function FilterSection({
       isSearchInputEmpty: !currentInput || currentInput.length === 0,
       optionsVisibleStatus: getOptionsVisibleStatus(
         prevState.isShowingMoreOptions,
-        currentInput,
+        currentInput
       ),
     }));
   }
@@ -245,7 +245,7 @@ function FilterSection({
       ...prevState,
       isShowingMoreOptions: !prevState.isShowingMoreOptions,
       optionsVisibleStatus: getOptionsVisibleStatus(
-        !prevState.isShowingMoreOptions,
+        !prevState.isShowingMoreOptions
       ),
     }));
   }
@@ -284,7 +284,7 @@ function FilterSection({
               />
               {combineMode}
             </label>
-          ),
+          )
         )}
         <Tooltip
           arrowContent={<div className='rc-tooltip-arrow-inner' />}
@@ -466,7 +466,7 @@ function FilterSection({
                 onSelect={handleSelectSingleSelectFilter}
                 selected={filterStatus[option.text]}
               />
-            ),
+            )
         )}
       </>
     );
@@ -653,7 +653,7 @@ FilterSection.propTypes = {
       min: PropTypes.number,
       max: PropTypes.number,
       rangeStep: PropTypes.number, // by default 1
-    }),
+    })
   ),
   title: PropTypes.string,
   tooltip: PropTypes.string,

--- a/src/gen3-ui-component/components/filters/RangeFilter/UnitCalculator/UnitCalculator.jsx
+++ b/src/gen3-ui-component/components/filters/RangeFilter/UnitCalculator/UnitCalculator.jsx
@@ -87,6 +87,7 @@ export default function UnitCalculator({
             className='full-width'
             value={unit}
             onChange={handleUnitChange}
+            key={unit}
           >
             <option value=''>select unit</option>
             {selectionOptions}

--- a/src/gen3-ui-component/components/filters/RangeFilter/index.jsx
+++ b/src/gen3-ui-component/components/filters/RangeFilter/index.jsx
@@ -17,19 +17,30 @@ import UnitCalculator from './UnitCalculator/UnitCalculator';
 
 const RangeFilter = forwardRef(
   /**
-   * @param {Object} props
-   * @param {number} [props.count]
-   * @param {number} [props.decimalDigitsLen]
-   * @param {number} [props.hideValue]
-   * @param {boolean} [props.inactive]
-   * @param {string} [props.label]
-   * @param {number} [props.lowerBound]
-   * @param {number} props.max
-   * @param {number} props.min
-   * @param {AfterDragHandler} props.onAfterDrag
-   * @param {number} [props.upperBound]
-   * @param {number} [props.rangeStep]
-   * @param {React.Ref<any>} [ref]
+   * @typedef {Object} RangeFilterProps
+   * @property {number} [count]
+   * @property {number} [decimalDigitsLen]
+   * @property {number} [hideValue]
+   * @property {boolean} [inactive]
+   * @property {string} [label]
+   * @property {number} [lowerBound]
+   * @property {number} max
+   * @property {number} min
+   * @property {AfterDragHandler} onAfterDrag
+   * @property {number} [upperBound]
+   * @property {number} [rangeStep]
+   * @property {string} [unitCalcType]
+   * @property {UnitCalcParams} [unitCalcConfig]
+   */
+  /**
+   * @typedef {Object} UnitCalcParams
+   * @property {string} quantity
+   * @property {string} desiredUnit
+   * @property {Object<string, number>} selectUnits
+   */
+  /**
+   * @param {RangeFilterProps} props
+   * @param {React.Ref<any>} ref
    */
   // eslint-disable-next-line prefer-arrow-callback
   function RangeFilter(props, ref) {
@@ -45,6 +56,8 @@ const RangeFilter = forwardRef(
       onAfterDrag,
       upperBound,
       rangeStep = 1,
+      unitCalcType,
+      unitCalcConfig,
     } = props;
 
     const [range, setRange] = useState({
@@ -181,30 +194,29 @@ const RangeFilter = forwardRef(
         : Number.parseFloat(num.toFixed(decimalDigitsLen));
     }
 
-    const params = {
-      quantity: 'age',
-      desiredUnit: 'days',
-      selectUnits: { months: 30, years: 365 },
-    };
-
     return (
       <>
         <div className='g3-range-filter'>
-          <p>
-            Don’t know the {params.quantity} in {params.desiredUnit}?
-          </p>
-          <Button
-            onClick={() => setShowCalculator(true)}
-            label={`Compute ${params.quantity} (in ${params.desiredUnit})`}
-            buttonType='default'
-          />
+          {unitCalcType === 'age' && (
+            <div className='unit-calculator-container'>
+              <p>
+                Don’t know the {unitCalcConfig.quantity} in{' '}
+                {unitCalcConfig.desiredUnit}?
+              </p>
+              <Button
+                onClick={() => setShowCalculator(true)}
+                label={`Compute ${unitCalcConfig.quantity} (in ${unitCalcConfig.desiredUnit})`}
+                buttonType='default'
+              />
 
-          {showCalculator && (
-            <UnitCalculator
-              setShowCalculator={setShowCalculator}
-              parameters={params}
-              updateBound={updateBound}
-            />
+              {showCalculator && (
+                <UnitCalculator
+                  setShowCalculator={setShowCalculator}
+                  parameters={unitCalcConfig}
+                  updateBound={updateBound}
+                />
+              )}
+            </div>
           )}
 
           {label && <p className='g3-range-filter__title'>{label}</p>}

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -41,7 +41,7 @@ export function updateFilterRefs(workspace) {
     if ('refIds' in filter)
       for (const [index, refId] of [...filter.refIds].entries()) {
         const refIndex = filter.value.findIndex(
-          ({ __type, value }) => __type === 'REF' && value.id === refId,
+          ({ __type, value }) => __type === 'REF' && value.id === refId
         );
 
         if (refId in workspace.all) {

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -140,7 +140,12 @@ export function isSurvivalAnalysisEnabled(config) {
 /** @param {number} explorerId */
 export function getCurrentConfig(explorerId) {
   const config = explorerConfig.find(({ id }) => id === explorerId);
-  const unitCalcConfig = explorerConfig[1].filters.unitCalcConfig;
+  // for backwards compatibility, dynamically find unitCalcConfig
+  // make sure we don't get crashes, even if unitCalcConfig doesn't exist 
+  const configWithUnitCalc = explorerConfig.find((item) => (
+    item?.filters?.unitCalcConfig
+  ))
+  const unitCalcConfig = configWithUnitCalc?.filters?.unitCalcConfig
   return {
     adminAppliedPreFilters: config.adminAppliedPreFilters,
     buttonConfig: {

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -140,7 +140,7 @@ export function isSurvivalAnalysisEnabled(config) {
 /** @param {number} explorerId */
 export function getCurrentConfig(explorerId) {
   const config = explorerConfig.find(({ id }) => id === explorerId);
-  const UnitCalcConfig = explorerConfig[1].filters.unitCalcConfig;
+  const unitCalcConfig = explorerConfig[1].filters.unitCalcConfig;
   return {
     adminAppliedPreFilters: config.adminAppliedPreFilters,
     buttonConfig: {
@@ -154,7 +154,7 @@ export function getCurrentConfig(explorerId) {
     filterConfig: {
       ...config.filters,
       info: createFilterInfo(config.filters, config.guppyConfig.fieldMapping),
-      unitCalcConfig: UnitCalcConfig,
+      unitCalcConfig: unitCalcConfig,
     },
     getAccessButtonLink: config.getAccessButtonLink,
     guppyConfig: config.guppyConfig,

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -41,7 +41,7 @@ export function updateFilterRefs(workspace) {
     if ('refIds' in filter)
       for (const [index, refId] of [...filter.refIds].entries()) {
         const refIndex = filter.value.findIndex(
-          ({ __type, value }) => __type === 'REF' && value.id === refId
+          ({ __type, value }) => __type === 'REF' && value.id === refId,
         );
 
         if (refId in workspace.all) {
@@ -140,6 +140,7 @@ export function isSurvivalAnalysisEnabled(config) {
 /** @param {number} explorerId */
 export function getCurrentConfig(explorerId) {
   const config = explorerConfig.find(({ id }) => id === explorerId);
+  const UnitCalcConfig = explorerConfig[1].filters.unitCalcConfig;
   return {
     adminAppliedPreFilters: config.adminAppliedPreFilters,
     buttonConfig: {
@@ -153,6 +154,7 @@ export function getCurrentConfig(explorerId) {
     filterConfig: {
       ...config.filters,
       info: createFilterInfo(config.filters, config.guppyConfig.fieldMapping),
+      unitCalcConfig: UnitCalcConfig,
     },
     getAccessButtonLink: config.getAccessButtonLink,
     guppyConfig: config.guppyConfig,


### PR DESCRIPTION
JIRA ticket: PEDS-947 Add units in numeric filter fields and in specific add the ability to pick your unit for the age

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

- Small fix (filter-specific configurations) for the Unit Calculator feature from pull request #640 
- With this update, range filters are configured according to their specific context. For example, age filters like 'Age at Censor Status' have a Unit Calculator while purely numerical filters like 'Year at Initial Diagnoses' do not. 
- Additionally, all age filters convert months/years to days. 
- All configurations can be adjusted in `pcdc.json`, in "filters"->"unitCalcConfig". "unitCalcConfig"->"calculatorMapping" separates filters into "number" filters and "age" filters, such that all "age" filters render a Unit Calculator, while "number" filters don't. "unitCalcConfig" -> "ageUnits" allow changes to the `quantity`, `desiredUnit`, and `selectUnits` that are used in the Unit Calculator itself. 
    - For example, the current configuration is: 
```
    "unitCalcConfig": {
          "ageUnits": {
            "quantity": "age",
            "desiredUnit": "days",
            "selectUnits": { "months": 30, "years": 365 }
          },
```

See screenshot below for an example of the changes: 'Age at Censor Status' has a Unit Calculator while 'Year at Initial Diagnoses' doesn't.
<img src="https://github.com/user-attachments/assets/2a7659a4-30e3-463b-a72d-49631f37854b" width="300" title="screenshot of feature"/>

### Breaking Changes
N/A

### Bug Fixes
Fixes the Unit Calculator feature 

### Improvements
Allows more configurable range filters

### Dependency updates
N/A

### Deployment changes
N/A
