### PR TITLE
Preserve tableOneConfig and clean up unused code

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTableOne/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTableOne/index.jsx
@@ -199,15 +199,6 @@ function ExplorerTableOne(tabsOptions) {
                             ))}
                           </tbody>
                         </table>
-
-                        {/* <div className='summary'>
-                          <p>Total Count: {result.data.totalCount}</p>
-                          <p>User submitted Cohort: {result.data.trueCount}</p>
-                          <p>
-                            All Cohort Minus User submitted:{' '}
-                            {result.data.totalCount - result.data.trueCount}
-                          </p>
-                        </div> */}
                       </div>
                     )}
                   </>

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -255,6 +255,8 @@ const slice = createSlice({
           ...getCurrentConfig(explorerId),
           // keep survival config
           survivalAnalysisConfig: state.config.survivalAnalysisConfig,
+          // keep table one config
+          tableOneConfig: state.config.tableOneConfig,
         };
         state.explorerId = explorerId;
 

--- a/src/redux/explorer/survivalAnalysisAPI.js
+++ b/src/redux/explorer/survivalAnalysisAPI.js
@@ -1,5 +1,5 @@
 import { fetchWithCreds } from '../utils.fetch';
-import { isSurvivalAnalysisEnabled, isTableOneEnabled } from './utils';
+import { isSurvivalAnalysisEnabled } from './utils';
 
 /** @typedef {import('../../GuppyComponents/types').GqlFilter} GqlFilter */
 /** @typedef {import('./types').ExplorerConfig} ExplorerConfig */


### PR DESCRIPTION
Ensures tableOneConfig is retained when switching explorerId in the Redux slice. Removes commented-out summary code from ExplorerTableOne and cleans up an unused import in survivalAnalysisAPI.js.

This were some clean up Spencer requested in the original PR. Plus a quick fix when switching between explorer tabs "data" and "data - survival" 