### PR TITLE
Refactor patient ID filter handling in explorer

### DIFF
--- a/src/GuppyComponents/ConnectedFilter/index.jsx
+++ b/src/GuppyComponents/ConnectedFilter/index.jsx
@@ -12,6 +12,7 @@ import {
 /** @typedef {import('../types').FilterChangeHandler} FilterChangeHandler */
 /** @typedef {import('../types').FilterConfig} FilterConfig */
 /** @typedef {import('../types').GuppyConfig} GuppyConfig */
+/** @typedef {import('../../GuppyDataExplorer/types').PatientIdsConfig} PatientIdsConfig */
 /** @typedef {import('../types').SimpleAggsData} SimpleAggsData */
 /** @typedef {import('../types').StandardFilterState} StandardFilterState */
 
@@ -23,13 +24,12 @@ import {
  * @property {StandardFilterState} filter
  * @property {FilterConfig} filterConfig
  * @property {GuppyConfig} guppyConfig
+ * @property {PatientIdsConfig} patientIdsConfig
  * @property {boolean} [hidden]
  * @property {boolean} [hideZero]
  * @property {SimpleAggsData} [initialTabsOptions]
  * @property {(anchorValue: string) => void} onAnchorValueChange
  * @property {FilterChangeHandler} onFilterChange
- * @property {(x: string[]) => void} [onPatientIdsChange]
- * @property {string[]} [patientIds]
  * @property {SimpleAggsData} tabsOptions
  * @property {Array} dictionaryEntries
  */
@@ -42,15 +42,14 @@ function ConnectedFilter({
   filter = {},
   filterConfig,
   guppyConfig,
+  patientIdsConfig,
   hidden = false,
   hideZero = false,
   initialTabsOptions = {},
   onAnchorValueChange,
   onFilterChange,
-  onPatientIdsChange,
-  patientIds,
   tabsOptions,
-  dictionaryEntries
+  dictionaryEntries,
 }) {
   if (
     hidden ||
@@ -60,7 +59,7 @@ function ConnectedFilter({
     return null;
 
   const processedTabsOptions = sortTabsOptions(
-    updateCountsInInitialTabsOptions(initialTabsOptions, tabsOptions, filter)
+    updateCountsInInitialTabsOptions(initialTabsOptions, tabsOptions, filter),
   );
   if (Object.keys(processedTabsOptions).length === 0) {
     return null;
@@ -85,7 +84,7 @@ function ConnectedFilter({
       initialTabsOptions,
       searchFields,
       tabsOptions: processedTabsOptions,
-    })
+    }),
   );
 
   return (
@@ -97,11 +96,10 @@ function ConnectedFilter({
       }
       filter={filter}
       filterConfig={filterConfig}
+      patientIdsConfig={patientIdsConfig}
       lockedTooltipMessage={`You may only view summary information for this project. You do not have ${guppyConfig.dataType}-level access.`}
       onAnchorValueChange={onAnchorValueChange}
       onFilterChange={onFilterChange}
-      onPatientIdsChange={onPatientIdsChange}
-      patientIds={patientIds}
       hideZero={hideZero}
       tabs={filterTabs}
     />
@@ -123,14 +121,14 @@ ConnectedFilter.propTypes = {
       PropTypes.shape({
         label: PropTypes.string,
         tooltip: PropTypes.string,
-      })
+      }),
     ),
     tabs: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,
         fields: PropTypes.arrayOf(PropTypes.string),
         searchFields: PropTypes.arrayOf(PropTypes.string),
-      })
+      }),
     ),
   }).isRequired,
   guppyConfig: PropTypes.shape({
@@ -140,7 +138,7 @@ ConnectedFilter.propTypes = {
         field: PropTypes.string,
         name: PropTypes.string,
         tooltip: PropTypes.string,
-      })
+      }),
     ),
     nodeCountTitle: PropTypes.string,
   }).isRequired,
@@ -149,10 +147,8 @@ ConnectedFilter.propTypes = {
   initialTabsOptions: PropTypes.object,
   onAnchorValueChange: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
-  onPatientIdsChange: PropTypes.func,
-  patientIds: PropTypes.arrayOf(PropTypes.string),
   tabsOptions: PropTypes.object.isRequired,
-  dictionaryEntries: PropTypes.array.isRequired
+  dictionaryEntries: PropTypes.array.isRequired,
 };
 
 export default ConnectedFilter;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -1,7 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import PropTypes from 'prop-types';
 import ConnectedFilter from '../../GuppyComponents/ConnectedFilter';
-import { updatePatientIds } from '../../redux/explorer/slice';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import './ExplorerFilter.css';
 
@@ -25,7 +24,10 @@ export function DisabledExplorerFilter({ className }) {
         <em>Composed filter state cannot be modified!</em>
       </p>
       <p>
-        To re-enable <i>this feature</i>, go to Filter Set Workspace and use (activate) a Filter Set with a standard (non-composed) filter state or create a new one. <i>This feature</i> is disabled when the active Filter Set has a composed filter state.       
+        To re-enable <i>this feature</i>, go to Filter Set Workspace and use
+        (activate) a Filter Set with a standard (non-composed) filter state or
+        create a new one. <i>This feature</i> is disabled when the active Filter
+        Set has a composed filter state.
       </p>
     </div>
   );
@@ -49,14 +51,13 @@ DisabledExplorerFilter.propTypes = {
 
 /** @param {ExplorerFilterProps} props */
 function ExplorerFilter({ className = '', ...filterProps }) {
-  const dispatch = useAppDispatch();
-  /** @param {RootState['explorer']['patientIds']} ids */
-  function handlePatientIdsChange(ids) {
-    dispatch(updatePatientIds(ids));
-  }
   const {
-    config: { adminAppliedPreFilters, filterConfig, guppyConfig },
-    patientIds,
+    config: {
+      adminAppliedPreFilters,
+      filterConfig,
+      guppyConfig,
+      patientIdsConfig,
+    },
   } = useAppSelector((state) => state.explorer);
 
   const connectedFilterProps = {
@@ -64,8 +65,7 @@ function ExplorerFilter({ className = '', ...filterProps }) {
     adminAppliedPreFilters,
     filterConfig,
     guppyConfig,
-    patientIds,
-    onPatientIdsChange: handlePatientIdsChange,
+    patientIdsConfig,
   };
   const hasExplorerFilter =
     Object.keys(filterProps.filter.value ?? {}).length > 0;
@@ -97,7 +97,7 @@ ExplorerFilter.propTypes = {
   onAnchorValueChange: PropTypes.func.isRequired, // from GuppyWrapper
   onFilterChange: PropTypes.func.isRequired, // from GuppyWrapper
   tabsOptions: PropTypes.object.isRequired, // from GuppWrapper
-  dictionaryEntries: PropTypes.array
+  dictionaryEntries: PropTypes.array,
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterDisplay/index.jsx
@@ -11,7 +11,10 @@ import './ExplorerFilterDisplay.css';
  */
 function ExplorerFilterDisplay({ filter, title = 'Filters', manual = false }) {
   const filterInfo = useAppSelector(
-    (state) => state.explorer.config.filterConfig.info
+    (state) => state.explorer.config.filterConfig.info,
+  );
+  const patientIdsConfig = useAppSelector(
+    (state) => state.explorer.config.patientIdsConfig,
   );
   return (
     <div className='explorer-filter-display'>
@@ -19,7 +22,12 @@ function ExplorerFilterDisplay({ filter, title = 'Filters', manual = false }) {
         <>
           <header>{title}</header>
           <main>
-            <FilterDisplay filter={filter} filterInfo={filterInfo} manual={manual} />
+            <FilterDisplay
+              filter={filter}
+              filterInfo={filterInfo}
+              patientIdsConfig={patientIdsConfig}
+              manual={manual}
+            />
           </main>
         </>
       ) : (

--- a/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilterSetWorkspace/index.jsx
@@ -41,15 +41,19 @@ function ExplorerFilterSetWorkspace() {
     dispatch(updateExplorerFilter(filter));
   }
   const filterInfo = useAppSelector(
-    (state) => state.explorer.config.filterConfig.info
+    (state) => state.explorer.config.filterConfig.info,
   );
   const savedFilterSets = useAppSelector(
-    (state) => state.explorer.savedFilterSets
+    (state) => state.explorer.savedFilterSets,
+  );
+
+  const patientIdsConfig = useAppSelector(
+    (state) => state.explorer.config.patientIdsConfig,
   );
   const workspace = useFilterSetWorkspace();
   const activeFilterSet = workspace.all[workspace.activeId];
   const activeSavedFilterSet = savedFilterSets.data.find(
-    ({ id }) => id === activeFilterSet.id
+    ({ id }) => id === activeFilterSet.id,
   );
   const all = workspace.all;
 
@@ -71,7 +75,7 @@ function ExplorerFilterSetWorkspace() {
   const shouldNotRemove = composedWithActive.length > 0;
 
   const [actionFormType, setActionFormType] = useState(
-    /** @type {ActionFormType} */ (undefined)
+    /** @type {ActionFormType} */ (undefined),
   );
   function closeActionForm() {
     setActionFormType(undefined);
@@ -168,7 +172,7 @@ function ExplorerFilterSetWorkspace() {
   }
 
   const disableNew = Object.values(workspace.all).some(({ filter }) =>
-    checkIfFilterEmpty(filter ?? {})
+    checkIfFilterEmpty(filter ?? {}),
   );
 
   const defaultComposeState = {
@@ -252,7 +256,7 @@ function ExplorerFilterSetWorkspace() {
               style={{ display: 'inline-flex', margin: '0 1rem 0 0' }}
             >
               Compose with
-              <ButtonToggle 
+              <ButtonToggle
                 isOn={composeState.combineMode === 'AND'}
                 onText='AND'
                 offText='OR'
@@ -309,9 +313,10 @@ function ExplorerFilterSetWorkspace() {
               </button>
               <Tooltip
                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
-                overlay={shouldNotRemove ?
-                  'To remove the currently active filter set from the workspace, first remove it from any unsaved composed filter set in the workspace' :
-                  'Remove the currently active filter set from the workspace'
+                overlay={
+                  shouldNotRemove
+                    ? 'To remove the currently active filter set from the workspace, first remove it from any unsaved composed filter set in the workspace'
+                    : 'Remove the currently active filter set from the workspace'
                 }
                 placement='bottom'
                 trigger={['hover', 'focus']}
@@ -327,9 +332,10 @@ function ExplorerFilterSetWorkspace() {
               </Tooltip>
               <Tooltip
                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
-                overlay={shouldNotRemove ?
-                  'To clear the currently active filter set from the workspace, first remove it from any unsaved composed filter set in the workspace' :
-                  'Clear the currently active filter set'
+                overlay={
+                  shouldNotRemove
+                    ? 'To clear the currently active filter set from the workspace, first remove it from any unsaved composed filter set in the workspace'
+                    : 'Clear the currently active filter set'
                 }
                 placement='bottom'
                 trigger={['hover', 'focus']}
@@ -338,7 +344,10 @@ function ExplorerFilterSetWorkspace() {
                   className='explorer-filter-set-workspace__action-button'
                   type='button'
                   onClick={handleClear}
-                  disabled={shouldNotRemove || checkIfFilterEmpty(activeFilterSet?.filter ?? {})}
+                  disabled={
+                    shouldNotRemove ||
+                    checkIfFilterEmpty(activeFilterSet?.filter ?? {})
+                  }
                 >
                   Clear
                 </button>
@@ -438,6 +447,7 @@ function ExplorerFilterSetWorkspace() {
                   <FilterDisplay
                     filter={filterSet.filter}
                     filterInfo={filterInfo}
+                    patientIdsConfig={patientIdsConfig}
                     onClickCombineMode={handleClickCombineMode}
                     onCloseFilter={handleCloseFilter}
                   />
@@ -464,6 +474,7 @@ function ExplorerFilterSetWorkspace() {
                   <FilterDisplay
                     filter={filterSet.filter}
                     filterInfo={filterInfo}
+                    patientIdsConfig={patientIdsConfig}
                   />
                 )}
               </main>

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -8,7 +8,7 @@ export const GuppyConfigType = PropTypes.exact({
       field: PropTypes.string,
       name: PropTypes.string,
       tooltip: PropTypes.string,
-    })
+    }),
   ),
   manifestMapping: PropTypes.exact({
     resourceIndexType: PropTypes.string,
@@ -36,7 +36,7 @@ export const FilterConfigType = PropTypes.shape({
     PropTypes.shape({
       title: PropTypes.string,
       fields: PropTypes.arrayOf(PropTypes.string),
-    })
+    }),
   ),
 });
 
@@ -57,12 +57,12 @@ export const ButtonConfigType = PropTypes.exact({
       fileName: PropTypes.string,
       dropdownId: PropTypes.string,
       tooltipText: PropTypes.string,
-    })
+    }),
   ),
   dropdowns: PropTypes.objectOf(
     PropTypes.exact({
       title: PropTypes.string,
-    })
+    }),
   ),
   terraExportURL: PropTypes.string,
   terraTemplate: PropTypes.arrayOf(PropTypes.string),
@@ -77,7 +77,7 @@ export const SurvivalAnalysisConfigType = PropTypes.shape({
     PropTypes.shape({
       field: PropTypes.string,
       label: PropTypes.string,
-    })
+    }),
   ),
   result: PropTypes.shape({
     risktable: PropTypes.bool,
@@ -88,4 +88,6 @@ export const SurvivalAnalysisConfigType = PropTypes.shape({
 export const PatientIdsConfigType = PropTypes.shape({
   filter: PropTypes.bool,
   export: PropTypes.bool,
+  filterName: PropTypes.string,
+  displayName: PropTypes.string,
 });

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -44,7 +44,6 @@ function ExplorerDashboard() {
     explorerFilter,
     explorerId,
     explorerIds,
-    patientIds,
   } = useAppSelector((state) => state.explorer);
   useEffect(() => {
     // sync saved filter sets with explorer id state
@@ -107,7 +106,6 @@ function ExplorerDashboard() {
       guppyConfig={guppyConfig}
       onFilterChange={handleFilterChange}
       rawDataFields={tableConfig.fields}
-      patientIds={patientIds}
     >
       {(data) => {
         return (

--- a/src/GuppyDataExplorer/types.d.ts
+++ b/src/GuppyDataExplorer/types.d.ts
@@ -81,6 +81,8 @@ export type TableOneConfig = {
 export type PatientIdsConfig = {
   export?: boolean;
   filter?: boolean;
+  filterName?: string;
+  displayName?: string;
 };
 
 export type SurvivalAnalysisConfig = {

--- a/src/components/FilterDisplay.jsx
+++ b/src/components/FilterDisplay.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import 'rc-tooltip/assets/bootstrap_white.css';
 import { FILTER_TYPE } from '../GuppyComponents/Utils/const';
-import Pill from "./Pill";
+import Pill from './Pill';
 import './FilterDisplay.css';
 
 /**
@@ -16,8 +16,9 @@ import './FilterDisplay.css';
  * @param {{ anchorField?: string; anchorValue?: string; field: string }} payload
  */
 
-
 /** @typedef {import('../GuppyComponents/types').FilterConfig} FilterConfig */
+
+/** @typedef {import('../GuppyDataExplorer/types').PatientIdsConfig} PatientIdsConfig */
 
 /** @typedef {import('../GuppyDataExplorer/types').ExplorerFilterSet} ExplorerFilterSet */
 
@@ -27,6 +28,7 @@ import './FilterDisplay.css';
  * @param {'AND' | 'OR'} [props.combineMode]
  * @param {ExplorerFilterSet['filter']} props.filter
  * @param {FilterConfig['info']} props.filterInfo
+ * @param {PatientIdsConfig} props.patientIdsConfig
  * @param {boolean} [props.manual]
  * @param {ClickCombineModeHandler} [props.onClickCombineMode]
  * @param {ClickFilterHandler} [props.onClickFilter]
@@ -37,6 +39,7 @@ function FilterDisplay({
   combineMode,
   filter,
   filterInfo,
+  patientIdsConfig,
   manual = false,
   onClickCombineMode,
   onClickFilter,
@@ -51,7 +54,11 @@ function FilterDisplay({
               <Pill>{__filter.value.label}</Pill>
             ) : (
               <span className='pill-container'>
-                <FilterDisplay filter={__filter} filterInfo={filterInfo} />
+                <FilterDisplay
+                  filter={__filter}
+                  filterInfo={filterInfo}
+                  patientIdsConfig={patientIdsConfig}
+                />
               </span>
             )}
             {i < filter.value.length - 1 && <Pill>{filter.__combineMode}</Pill>}
@@ -95,8 +102,13 @@ function FilterDisplay({
       filterElements.push(
         <Pill key={key}>
           <span className='token field'>
-            With <code>{manual ? (filterInfo[anchorField]?.label ?? anchorField) : filterInfo[anchorField].label}</code> of{' '}
-            <code>{`"${anchorValue}"`}</code>
+            With{' '}
+            <code>
+              {manual
+                ? (filterInfo[anchorField]?.label ?? anchorField)
+                : filterInfo[anchorField].label}
+            </code>{' '}
+            of <code>{`"${anchorValue}"`}</code>
           </span>
           <span className='token'>
             ({' '}
@@ -106,13 +118,14 @@ function FilterDisplay({
               filter={value}
               filterInfo={filterInfo}
               combineMode={__combineMode}
+              patientIdsConfig={patientIdsConfig}
               onClickCombineMode={onClickCombineMode}
               onClickFilter={onClickFilter}
               onCloseFilter={onCloseFilter}
             />{' '}
             )
           </span>
-        </Pill>
+        </Pill>,
       );
     } else if (value.__type === FILTER_TYPE.OPTION) {
       filterElements.push(
@@ -123,7 +136,13 @@ function FilterDisplay({
           filterKey={key}
         >
           <span className='token'>
-          <code>{manual ? (filterInfo[key]?.label ?? key) : filterInfo[key].label}</code>{' '}
+            <code>
+              {patientIdsConfig?.filter && key === patientIdsConfig?.filterName
+                ? patientIdsConfig.displayName
+                : manual
+                  ? (filterInfo[key]?.label ?? key)
+                  : filterInfo[key].label}
+            </code>{' '}
             {value.selectedValues.length > 1
               ? `is ${value.isExclusion ? 'not' : ''} any of `
               : `is ${value.isExclusion ? 'not' : ''} `}
@@ -132,9 +151,19 @@ function FilterDisplay({
             {value.selectedValues.length > 1 ? (
               <Tooltip
                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
-                overlay={value.selectedValues.map((v) => `"${v}"`).join(', ')}
-                placement='bottom'
+                overlay={
+                  <div className='filter-values-tooltip'>
+                    {value.selectedValues.map((v) => `"${v}"`).join(', ')}
+                  </div>
+                }
+                placement='bottomLeft'
                 trigger={['hover', 'focus']}
+                getTooltipContainer={() => document.body}
+                overlayStyle={{
+                  maxWidth: 480,
+                  whiteSpace: 'normal',
+                  overflowWrap: 'anywhere',
+                }}
               >
                 <span>
                   <code>{`"${value.selectedValues[0]}"`}</code>, ...
@@ -144,7 +173,7 @@ function FilterDisplay({
               <code>{`"${value.selectedValues[0]}"`}</code>
             )}
           </span>
-        </Pill>
+        </Pill>,
       );
     } else if (value.__type === FILTER_TYPE.RANGE) {
       filterElements.push(
@@ -155,7 +184,9 @@ function FilterDisplay({
           filterKey={key}
         >
           <span className='token'>
-          <code>{manual ? (filterInfo[key]?.label ?? key) : filterInfo[key].label}</code>
+            <code>
+              {manual ? (filterInfo[key]?.label ?? key) : filterInfo[key].label}
+            </code>
             {' is between '}
           </span>
           <span className='token'>
@@ -163,7 +194,7 @@ function FilterDisplay({
               ({value.lowerBound}, {value.upperBound})
             </code>
           </span>
-        </Pill>
+        </Pill>,
       );
     }
 
@@ -188,8 +219,9 @@ FilterDisplay.propTypes = {
   filterInfo: PropTypes.objectOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-    })
+    }),
   ),
+  patientIdsConfig: PropTypes.object,
   manual: PropTypes.bool,
   onClickCombineMode: PropTypes.func,
   onClickFilter: PropTypes.func,

--- a/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
+++ b/src/gen3-ui-component/components/filters/PatientIdFilter.jsx
@@ -7,11 +7,16 @@ import Button from '../Button';
 
 /**
  * @param {Object} props
- * @param {Function} props.onPatientIdsChange
- * @param {string[]} props.patientIds
+ * @param {Function} props.getPatientIds
+ * @param {Function} props.handlePatientIdsChange
+ * @param {Function} props.handleClearPatientIds
  */
-function PatientIdFilter({ onPatientIdsChange, patientIds }) {
-  const isUsingPatientIds = patientIds.length > 0;
+function PatientIdFilter({
+  getPatientIds,
+  handlePatientIdsChange,
+  handleClearPatientIds,
+}) {
+  const isUsingPatientIds = getPatientIds().length > 0;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   function openModal() {
@@ -40,12 +45,11 @@ function PatientIdFilter({ onPatientIdsChange, patientIds }) {
       input = textareaRef.current.value.replace(/\s/g, '');
       textareaRef.current.value = '';
     }
-
-    onPatientIdsChange(input ? input.split(',') : []);
+    handlePatientIdsChange(input ? input.split(',') : []);
     closeModal();
   }
   function handleReset() {
-    onPatientIdsChange([]);
+    handleClearPatientIds();
   }
 
   return (
@@ -167,8 +171,9 @@ function PatientIdFilter({ onPatientIdsChange, patientIds }) {
 }
 
 PatientIdFilter.propTypes = {
-  onPatientIdsChange: PropTypes.func.isRequired,
-  patientIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  getPatientIds: PropTypes.func.isRequired,
+  handlePatientIdsChange: PropTypes.func.isRequired,
+  handleClearPatientIds: PropTypes.func.isRequired,
 };
 
 export default PatientIdFilter;

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -36,9 +36,6 @@ const explorerIds = [];
 for (const { id } of explorerConfig) explorerIds.push(id);
 const initialExplorerId = explorerIds[0];
 const initialConfig = getCurrentConfig(initialExplorerId);
-const initialPatientIds = initialConfig.patientIdsConfig?.filter
-  ? []
-  : undefined;
 const initialWorkspaces = initializeWorkspaces(initialExplorerId);
 const initialExplorerFilter = dereferenceFilter(
   initialWorkspaces[initialExplorerId].all[
@@ -54,7 +51,6 @@ const slice = createSlice({
     explorerFilter: initialExplorerFilter,
     explorerId: initialExplorerId,
     explorerIds,
-    patientIds: initialPatientIds,
     savedFilterSets: {
       data: [],
       isError: false,
@@ -231,11 +227,6 @@ const slice = createSlice({
       const { activeId } = state.workspaces[state.explorerId];
       state.workspaces[state.explorerId].all[activeId].filter = newFilter;
     },
-    /** @param {PayloadAction<ExplorerState['patientIds']>} action */
-    updatePatientIds(state, action) {
-      if (state.config.patientIdsConfig?.filter !== undefined)
-        state.patientIds = action.payload;
-    },
     useExplorerById: {
       /** @param {ExplorerState['explorerId']} explorerId */
       prepare: (explorerId) => {
@@ -409,7 +400,6 @@ export const {
   loadWorkspaceFilterSet,
   removeWorkspaceFilterSet,
   updateExplorerFilter,
-  updatePatientIds,
   useExplorerById,
   useWorkspaceFilterSet,
 } = slice.actions;

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -55,7 +55,6 @@ export type ExplorerState = {
   explorerFilter: ExplorerFilter;
   explorerId: number;
   explorerIds: ExplorerState['explorerId'][];
-  patientIds: string[];
   savedFilterSets: {
     data: SavedExplorerFilterSet[];
     isError: boolean;


### PR DESCRIPTION
Moves patient ID filter state from Redux to local filter state, removing patientIds and updatePatientIds from the Redux explorer slice. Updates FilterGroup and PatientIdFilter to manage patient ID filtering directly in the filter object, and propagates patientIdsConfig for configuration. Updates related components and type definitions to support this change.

<img width="1693" height="1130" alt="Screenshot 2025-08-21 at 4 45 39 PM" src="https://github.com/user-attachments/assets/458986bf-067d-4188-b96e-15c9cbfa42db" />

