### PR TITLE
reload data requests table when user access changes

### DIFF
--- a/src/DataRequests/AdminProjectActions.jsx
+++ b/src/DataRequests/AdminProjectActions.jsx
@@ -182,6 +182,7 @@ export default function AdminProjectActions({
               <UserAccessTable
                 projectId={project.id}
                 setActionType={setActionType}
+                onAction={onAction}
               />
             );
           case 'PROJECT_USERS_ADD':

--- a/src/DataRequests/DataRequestsTable.jsx
+++ b/src/DataRequests/DataRequestsTable.jsx
@@ -299,7 +299,8 @@ function DataRequestsTable({
                   type === 'PROJECT_STATE' ||
                   type === 'DELETE_REQUEST' ||
                   type === 'SUCCESSFUL_FILTER_SET_CHANGE' ||
-                  type === 'SUCCESSFUL_APPROVED_URL_CHANGE'
+                  type === 'SUCCESSFUL_APPROVED_URL_CHANGE' ||
+                  type === 'SUCCESSFUL_USER_ACCESS_CHANGE'
                 ) {
                   shouldReloadProjectsOnActionClose = true;
                 }

--- a/src/DataRequests/UserAccessTable.jsx
+++ b/src/DataRequests/UserAccessTable.jsx
@@ -18,7 +18,7 @@ const filterConfig = {
   Role: false,
   Actions: false,
 };
-export default function UserAccessTable({ projectId, setActionType }) {
+export default function UserAccessTable({ projectId, setActionType, onAction }) {
   const dispatch = useAppDispatch();
 
   const {
@@ -78,6 +78,7 @@ export default function UserAccessTable({ projectId, setActionType }) {
     ).then((action) => {
       if (!action.payload.isError) {
         setSuccessMsg(`Role updated successfully for ${email}`);
+        onAction?.('SUCCESSFUL_USER_ACCESS_CHANGE');
         setErrorMsg('');
       } else {
         setErrorMsg(action.payload.message);


### PR DESCRIPTION
this was the only issue from this ticket that still exists:

for Project ID 44, I updated the status to Data Available, and that status did update in the table, but the Download Data button never appeared when logged in as the end user ([rpalacios@uchicago.edu](mailto:rpalacios@uchicago.edu)). Even after adding a URL. I added a dummy url: ([google.com](http://google.com/))

currently you have to manually reload to the page to get the download data button to appear. This change has the data requests table auto reload so the button will appear or disappear automatically.

no visual changes in this PR.