### PR TITLE
Fix popup accessibility: replace non-interactive element with button

### DIFF
--- a/src/components/Popup.css
+++ b/src/components/Popup.css
@@ -44,6 +44,18 @@
   overflow: hidden;
 }
 
+.popup__close-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  font-size: inherit;
+}
+
 .popup__close-button:hover {
   cursor: pointer;
 }

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -60,17 +60,10 @@ function Popup({
             <div className='h2-typo popup__title-text'>{title}</div>
           </div>
           {onClose && (
-            <div
-              role='button'
-              tabIndex={-1}
+            <button
+              type='button'
               className='popup__close-button'
               onClick={onClose}
-              onKeyPress={(e) => {
-                if (e.charCode === 13 || e.charCode === 32) {
-                  e.preventDefault();
-                  onClose?.();
-                }
-              }}
               aria-label='Close popup'
             >
               <IconComponent
@@ -78,7 +71,7 @@ function Popup({
                 dictIcons={dictIcons}
                 style={{ verticalAlign: 'middle' }}
               />
-            </div>
+            </button>
           )}
         </div>
         <div className='popup__message'>


### PR DESCRIPTION
## Description
This PR improves accessibility of the popup close button by replacing a non-semantic element with a proper `<button>`.

## Changes
- Replaced `<div role="button">` with semantic `<button>`
- Removed custom keyboard handling in favor of native button behavior
- Added `type="button"` to prevent unintended form submission
- Retained `aria-label="Close popup"` for accessibility
- Added minimal CSS to preserve existing styling

## Impact
- Improves keyboard accessibility (Enter/Space support)
- Enhances screen reader compatibility
- Uses semantic HTML for interactive elements
- Keeps existing functionality and layout unchanged