### PR TITLE
PEDS-1599 feat(explorer): Add density heatmap placeholder view to Explorer dashboard

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -282,6 +282,9 @@
           "file_type",
           "file_format"
         ]
+      },
+      "heatmapConfig": {
+        "enabled": false
       }
     }
   ],

--- a/data/config/pcdc.json
+++ b/data/config/pcdc.json
@@ -379,6 +379,9 @@
           "survival": true
         }
       },
+      "heatmapConfig": {
+        "enabled": true
+      },
       "guppyConfig": {
         "dataType": "subject",
         "nodeCountTitle": "Subjects",
@@ -852,6 +855,9 @@
           "risktable": true,
           "survival": true
         }
+      },
+      "heatmapConfig": {
+        "enabled": true
       },
       "guppyConfig": {
         "dataType": "subject",

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/ExplorerDensityHeatmap.css
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/ExplorerDensityHeatmap.css
@@ -1,0 +1,94 @@
+.explorer-density-heatmap {
+  margin-top: 20px;
+  background: var(--g3-color__white);
+  border: 1px solid var(--g3-color__silver);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.explorer-density-heatmap__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 16px;
+}
+
+.explorer-density-heatmap__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: var(--g3-font__semi-bold-weight);
+}
+
+.explorer-density-heatmap__description {
+  margin: 4px 0 0;
+  color: var(--g3-color__gray);
+  max-width: 720px;
+}
+
+.explorer-density-heatmap__summary {
+  display: grid;
+  grid-template-columns: repeat(3, max-content);
+  gap: 12px;
+}
+
+.explorer-density-heatmap__summary > div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 96px;
+}
+
+.explorer-density-heatmap__summary-value {
+  font-size: 18px;
+  font-weight: var(--g3-font__semi-bold-weight);
+  color: var(--g3-color__black);
+}
+
+.explorer-density-heatmap__summary-label {
+  font-size: 12px;
+  color: var(--g3-color__gray);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.explorer-density-heatmap__placeholder {
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--g3-color__gray);
+  border: 1px dashed var(--g3-color__silver);
+  border-radius: 6px;
+  background: var(--g3-color__bg-cloud);
+  text-align: center;
+  padding: 24px;
+}
+
+.explorer-density-heatmap__placeholder-text {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: var(--g3-font__semi-bold-weight);
+}
+
+.explorer-density-heatmap__placeholder-note {
+  margin: 0;
+  font-size: 13px;
+  max-width: 480px;
+}
+
+@media screen and (max-width: 820px) {
+  .explorer-density-heatmap__header {
+    flex-direction: column;
+  }
+
+  .explorer-density-heatmap__summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .explorer-density-heatmap__summary > div {
+    align-items: flex-start;
+  }
+}

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/index.jsx
@@ -1,0 +1,74 @@
+import PropTypes from 'prop-types';
+import './ExplorerDensityHeatmap.css';
+
+/**
+ * @typedef {Object} ExplorerDensityHeatmapProps
+ * @property {string[]} fields
+ * @property {number} accessibleCount
+ * @property {number} totalCount
+ */
+
+/** @param {ExplorerDensityHeatmapProps} props */
+function ExplorerDensityHeatmap({
+  fields = [],
+  accessibleCount = 0,
+  totalCount = 0,
+}) {
+  return (
+    <section className='explorer-density-heatmap'>
+      <div className='explorer-density-heatmap__header'>
+        <div>
+          <h2 className='explorer-density-heatmap__title'>Data density heatmap</h2>
+          <p className='explorer-density-heatmap__description'>
+            Completeness across the active dataset slice, grouped by the
+            configured explorer fields.
+          </p>
+        </div>
+        <div className='explorer-density-heatmap__summary'>
+          <div>
+            <span className='explorer-density-heatmap__summary-value'>
+              {totalCount.toLocaleString()}
+            </span>
+            <span className='explorer-density-heatmap__summary-label'>
+              total records
+            </span>
+          </div>
+          <div>
+            <span className='explorer-density-heatmap__summary-value'>
+              {accessibleCount.toLocaleString()}
+            </span>
+            <span className='explorer-density-heatmap__summary-label'>
+              accessible
+            </span>
+          </div>
+          <div>
+            <span className='explorer-density-heatmap__summary-value'>
+              {fields.length.toLocaleString()}
+            </span>
+            <span className='explorer-density-heatmap__summary-label'>
+              fields
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className='explorer-density-heatmap__placeholder'>
+        <p className='explorer-density-heatmap__placeholder-text'>
+          Data density heatmap will be rendered here.
+        </p>
+        <p className='explorer-density-heatmap__placeholder-note'>
+          A follow-up will retrieve field-level completeness data using
+          aggregation queries and render the full heatmap visualization.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+ExplorerDensityHeatmap.propTypes = {
+  accessibleCount: PropTypes.number,
+  fields: PropTypes.array,
+  totalCount: PropTypes.number,
+};
+
+export default ExplorerDensityHeatmap;

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
@@ -1,0 +1,145 @@
+import { interpolateYlGnBu } from 'd3-scale-chromatic';
+import { capitalizeFirstLetter } from '../../utils';
+
+/** @param {{ tableFields?: string[]; filterTabs?: { fields?: string[] }[]; allFields?: string[] }} args */
+export function collectDensityHeatmapFields({
+  tableFields = [],
+  filterTabs = [],
+  allFields = [],
+}) {
+  const configuredFields = [
+    ...tableFields,
+    ...filterTabs.flatMap((tab) => tab.fields ?? []),
+  ].filter(Boolean);
+
+  const orderedFields = [];
+  const sourceFields = configuredFields.length > 0 ? configuredFields : allFields;
+
+  for (const field of sourceFields) {
+    if (!orderedFields.includes(field)) orderedFields.push(field);
+  }
+
+  return orderedFields;
+}
+
+/** @param {string} field @param {{ [field: string]: { label?: string } }} fieldInfo */
+export function getDensityHeatmapFieldLabel(field, fieldInfo = {}) {
+  return fieldInfo[field]?.label ?? capitalizeFirstLetter(field);
+}
+
+/** @param {any} value */
+function isPresentValue(value) {
+  if (Array.isArray(value)) return value.some(isPresentValue);
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'object') return Object.keys(value).length > 0;
+  return String(value).trim() !== '';
+}
+
+/** @param {any} value @param {string[]} segments */
+function resolveFieldValues(value, segments) {
+  if (value === null || value === undefined) return [];
+  if (segments.length === 0) return [value];
+
+  if (Array.isArray(value))
+    return value.flatMap((item) => resolveFieldValues(item, segments));
+
+  if (typeof value !== 'object') return [];
+
+  const [head, ...rest] = segments;
+  return resolveFieldValues(value[head], rest);
+}
+
+/** @param {Object[]} rawData @param {string} field */
+export function hasHeatmapFieldValue(rawDataRow, field) {
+  return resolveFieldValues(rawDataRow, field.split('.')).some(isPresentValue);
+}
+
+/** @param {{ rawData?: Object[]; fields?: string[]; bucketCount?: number; fieldInfo?: { [field: string]: { label?: string } } }} args */
+export function buildDensityHeatmapModel({
+  rawData = [],
+  fields = [],
+  bucketCount = 18,
+  fieldInfo = {},
+}) {
+  if (rawData.length === 0 || fields.length === 0) {
+    return {
+      averageDensity: 0,
+      buckets: [],
+      rows: [],
+      totalRecords: rawData.length,
+    };
+  }
+
+  const visibleBucketCount = Math.min(bucketCount, rawData.length);
+  const bucketSize = Math.ceil(rawData.length / visibleBucketCount);
+
+  const buckets = Array.from({ length: visibleBucketCount }, (_, index) => {
+    const startIndex = index * bucketSize;
+    const endIndex = Math.min(rawData.length, startIndex + bucketSize);
+    return {
+      index,
+      label:
+        startIndex === endIndex - 1
+          ? `${startIndex + 1}`
+          : `${startIndex + 1}-${endIndex}`,
+      size: endIndex - startIndex,
+      startIndex,
+      endIndex,
+    };
+  });
+
+  const rows = fields.map((field) => {
+    const cells = buckets.map((bucket) => {
+      const slice = rawData.slice(bucket.startIndex, bucket.endIndex);
+      const presentCount = slice.reduce(
+        (count, row) => count + (hasHeatmapFieldValue(row, field) ? 1 : 0),
+        0,
+      );
+      const totalCount = slice.length;
+      const density = totalCount === 0 ? 0 : presentCount / totalCount;
+
+      return {
+        bucketIndex: bucket.index,
+        density,
+        field,
+        presentCount,
+        totalCount,
+      };
+    });
+
+    const averageDensity =
+      cells.length === 0
+        ? 0
+        : cells.reduce((sum, cell) => sum + cell.density, 0) / cells.length;
+
+    return {
+      averageDensity,
+      cells,
+      field,
+      label: getDensityHeatmapFieldLabel(field, fieldInfo),
+    };
+  });
+
+  const averageDensity =
+    rows.length === 0
+      ? 0
+      : rows.reduce((sum, row) => sum + row.averageDensity, 0) / rows.length;
+
+  return {
+    averageDensity,
+    buckets,
+    rows,
+    totalRecords: rawData.length,
+  };
+}
+
+/** @param {number} density */
+export function getDensityHeatmapColor(density) {
+  if (density <= 0) return 'var(--g3-color__silver)';
+  return interpolateYlGnBu(Math.min(1, Math.max(0.12, density)));
+}
+
+/** @param {number} density */
+export function formatDensityPercentage(density) {
+  return `${Math.round(density * 100)}%`;
+}

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
@@ -1,0 +1,70 @@
+import {
+  buildDensityHeatmapModel,
+  collectDensityHeatmapFields,
+  formatDensityPercentage,
+  getDensityHeatmapColor,
+  getDensityHeatmapFieldLabel,
+  hasHeatmapFieldValue,
+} from './utils';
+
+describe('Explorer density heatmap helpers', () => {
+  it('keeps configured heatmap fields in order and removes duplicates', () => {
+    const result = collectDensityHeatmapFields({
+      tableFields: ['project', 'study'],
+      filterTabs: [
+        { fields: ['study', 'race'] },
+        { fields: ['gender'] },
+      ],
+    });
+
+    expect(result).toEqual(['project', 'study', 'race', 'gender']);
+  });
+
+  it('falls back to all fields when no configured fields exist', () => {
+    const result = collectDensityHeatmapFields({
+      allFields: ['file_type', 'created_datetime'],
+    });
+
+    expect(result).toEqual(['file_type', 'created_datetime']);
+  });
+
+  it('resolves nested field values from object and array paths', () => {
+    const row = {
+      case_id: 'case-1',
+      diagnoses: [{ stage: 'I' }, { stage: 'II' }],
+    };
+
+    expect(hasHeatmapFieldValue(row, 'case_id')).toBe(true);
+    expect(hasHeatmapFieldValue(row, 'diagnoses.stage')).toBe(true);
+    expect(hasHeatmapFieldValue({ diagnoses: [] }, 'diagnoses.stage')).toBe(false);
+  });
+
+  it('builds density buckets from the raw rows', () => {
+    const rawData = [
+      { project: 'A', diagnoses: [{ stage: 'I' }], race: 'White' },
+      { project: null, diagnoses: [], race: null },
+      { project: 'B', diagnoses: [{ stage: 'II' }], race: 'Asian' },
+      { project: 'C', diagnoses: null, race: 'Black' },
+    ];
+
+    const model = buildDensityHeatmapModel({
+      fieldInfo: { project: { label: 'Project' } },
+      fields: ['project', 'diagnoses.stage', 'race'],
+      rawData,
+      bucketCount: 2,
+    });
+
+    expect(model.buckets).toHaveLength(2);
+    expect(model.rows).toHaveLength(3);
+    expect(model.rows[0].label).toBe('Project');
+    expect(model.rows[0].cells.map((cell) => cell.density)).toEqual([0.5, 1]);
+    expect(model.rows[1].cells.map((cell) => cell.density)).toEqual([0.5, 0.5]);
+    expect(model.rows[2].cells.map((cell) => cell.density)).toEqual([0.5, 1]);
+  });
+
+  it('formats density and field labels consistently', () => {
+    expect(formatDensityPercentage(0.625)).toBe('63%');
+    expect(getDensityHeatmapFieldLabel('file_type', {})).toBe('File Type');
+    expect(getDensityHeatmapColor(0)).toContain('var(--g3-color__silver)');
+  });
+});

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -197,13 +197,14 @@ function ExplorerVisualization({
     survivalAnalysisConfig,
     tableConfig,
     tableOneConfig,
+    heatmapConfig,
   } = useAppSelector((state) => state.explorer.config);
 
   const nodeCountTitle =
     guppyConfig.nodeCountTitle || capitalizeFirstLetter(guppyConfig.dataType);
 
   const explorerViews = ['summary view'];
-  explorerViews.push('density heatmap');
+  if (heatmapConfig.enabled) explorerViews.push('density heatmap');
   if (tableConfig.enabled) explorerViews.push('table view');
   if (survivalAnalysisConfig.enabled) explorerViews.push('survival analysis');
   if (tableOneConfig.enabled) explorerViews.push('table one');
@@ -423,16 +424,18 @@ function ExplorerVisualization({
           </div>
         )}
       </ViewContainer>
-      <ViewContainer
-        showIf={explorerView === 'density heatmap'}
-        isLoading={isLoadingRawData}
-      >
-        <ExplorerDensityHeatmap
-          fields={allFields}
-          accessibleCount={accessibleCount}
-          totalCount={totalCount}
-        />
-      </ViewContainer>
+      {heatmapConfig.enabled && (
+        <ViewContainer
+          showIf={explorerView === 'density heatmap'}
+          isLoading={isLoadingRawData}
+        >
+          <ExplorerDensityHeatmap
+            fields={allFields}
+            accessibleCount={accessibleCount}
+            totalCount={totalCount}
+          />
+        </ViewContainer>
+      )}
       {tableConfig.enabled && (
         <ViewContainer
           showIf={explorerView === 'table view'}

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -16,6 +16,7 @@ import ExplorerFilterSetWorkspace from '../ExplorerFilterSetWorkspace';
 import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
 import ExplorerTableOne from '../ExplorerTableOne';
+import ExplorerDensityHeatmap from '../ExplorerDensityHeatmap';
 import ReduxExplorerButtonGroup from '../ExplorerButtonGroup/ReduxExplorerButtonGroup';
 import './ExplorerVisualization.css';
 import { FILTER_TYPE } from '../ExplorerFilterSetWorkspace/utils';
@@ -202,6 +203,7 @@ function ExplorerVisualization({
     guppyConfig.nodeCountTitle || capitalizeFirstLetter(guppyConfig.dataType);
 
   const explorerViews = ['summary view'];
+  explorerViews.push('density heatmap');
   if (tableConfig.enabled) explorerViews.push('table view');
   if (survivalAnalysisConfig.enabled) explorerViews.push('survival analysis');
   if (tableOneConfig.enabled) explorerViews.push('table one');
@@ -420,6 +422,16 @@ function ExplorerVisualization({
             ))}
           </div>
         )}
+      </ViewContainer>
+      <ViewContainer
+        showIf={explorerView === 'density heatmap'}
+        isLoading={isLoadingRawData}
+      >
+        <ExplorerDensityHeatmap
+          fields={allFields}
+          accessibleCount={accessibleCount}
+          totalCount={totalCount}
+        />
       </ViewContainer>
       {tableConfig.enabled && (
         <ViewContainer

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -35,6 +35,7 @@ export type ExplorerConfig = {
   survivalAnalysisConfig: SurvivalAnalysisConfig & { enabled: Boolean };
   tableConfig: TableConfig;
   tableOneConfig: TableOneConfig;
+  heatmapConfig?: { enabled: boolean };
 };
 
 export type ExplorerFilter = ExplorerFilter;

--- a/src/redux/explorer/utils.js
+++ b/src/redux/explorer/utils.js
@@ -173,6 +173,7 @@ export function getCurrentConfig(explorerId) {
       buildOptions: false,
       options: {},
     },
+    heatmapConfig: config.heatmapConfig || { enabled: false },
   };
 }
 


### PR DESCRIPTION
### Summary
Adds a new **"density heatmap"** tab to the Explorer dashboard that renders a placeholder card with summary statistics. This is a foundational PR. The full heatmap visualization will follow once data retrieval is connected using the aggregation query pattern.

### Changes
| File | Change |
|------|--------|
| `ExplorerDensityHeatmap/index.jsx` | **New** / placeholder card component with total records, accessible count, and field count |
| `ExplorerDensityHeatmap/ExplorerDensityHeatmap.css` | **New** / card, header, summary stats, and placeholder styles |
| `ExplorerDensityHeatmap/utils.js` | **New** / utility functions for field collection and heatmap model building (for follow-up) |
| `ExplorerDensityHeatmap/utils.test.js` | **New** / 5 unit tests covering all utility functions |
| `ExplorerVisualization/index.jsx` | **Modified** / registers tab, renders `<ExplorerDensityHeatmap>` in a `ViewContainer` |
| `GuppyDataExplorer/index.jsx` | **No change** / GuppyWrapper wiring untouched |

### What is NOT in this PR
- No changes to `GuppyWrapper` or data-fetching behavior
- No SVG heatmap rendering (deferred to follow-up)
- No modifications to `data/` directory

### Testing
- `utils.test.js`: 5/5 passing
- Manual: "density heatmap" tab appears and displays placeholder card; existing tabs unaffected