### PR TITLE
PEDS-1626: persist configurable Explorer guide completion

### DIFF
--- a/data/config/pcdc.json
+++ b/data/config/pcdc.json
@@ -108,6 +108,7 @@
     ]
   },
   "explorerWizard": {
+    "version": 1,
     "steps": [
       {
         "route": "/explorer",

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -193,8 +193,11 @@ Below is an example, with inline comments describing what each JSON block config
   // optional; will hide certain parts of the site if needed
   "featureFlags": {},
   // optional; configures the Exploration guide shown by the Guide button.
-  // The guide is disabled when this block or its steps are missing.
+  // The guide is disabled when this block, version, or steps are missing.
+  // Increment version when users should see the guide again. Completion is
+  // saved to the user's additional_info.onboardingVersionSeen field.
   "explorerWizard": {
+    "version": 1,
     "steps": [
       {
         // optional; navigate before showing this step

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SummaryChartGroup from '../../gen3-ui-component/components/charts/SummaryChartGroup';
@@ -17,7 +17,11 @@ import ExplorerTable from '../ExplorerTable';
 import ExplorerSurvivalAnalysis from '../ExplorerSurvivalAnalysis';
 import ExplorerTableOne from '../ExplorerTableOne';
 import ReduxExplorerButtonGroup from '../ExplorerButtonGroup/ReduxExplorerButtonGroup';
-import ExplorerWizard, { OPEN_EXPLORER_WIZARD_EVENT } from '../ExplorerWizard';
+import {
+  hasSeenExplorerWizard,
+  isExplorerWizardEnabled,
+  OPEN_EXPLORER_WIZARD_EVENT,
+} from '../ExplorerWizard';
 import './ExplorerVisualization.css';
 import { FILTER_TYPE } from '../ExplorerFilterSetWorkspace/utils';
 
@@ -145,13 +149,6 @@ function openLink(link) {
   }
 }
 
-function getInitialExplorerWizardCompleted() {
-  return (
-    window.localStorage.getItem(ExplorerWizard.COMPLETION_STORAGE_KEY) ===
-    'true'
-  );
-}
-
 /**
  * @typedef {Object} ExplorerVisualizationProps
  * @property {number} accessibleCount
@@ -192,9 +189,9 @@ function ExplorerVisualization({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [isRequestAccessModalOpen, setRequestAccessModalOpen] = useState(false);
-  const isExplorerWizardEnabled =
-    Array.isArray(config.explorerWizard?.steps) &&
-    config.explorerWizard.steps.length > 0;
+  const hasRequestedExplorerWizard = useRef(false);
+  const isExplorerWizardConfigured = isExplorerWizardEnabled();
+  const user = useAppSelector((state) => state.user);
 
   const {
     buttonConfig,
@@ -249,12 +246,22 @@ function ExplorerVisualization({
     // Load config on first mount of parent, then pass to child.
     handleFetchExternalConfig();
 
-    if (isExplorerWizardEnabled && !getInitialExplorerWizardCompleted())
-      window.dispatchEvent(new Event(OPEN_EXPLORER_WIZARD_EVENT));
-
     if (!explorerViews.includes(explorerView))
       updateExplorerView(explorerViews[0]);
   }, []);
+
+  useEffect(() => {
+    if (
+      !isExplorerWizardConfigured ||
+      !user.fetched_user ||
+      hasRequestedExplorerWizard.current ||
+      hasSeenExplorerWizard(user)
+    )
+      return;
+
+    hasRequestedExplorerWizard.current = true;
+    window.dispatchEvent(new Event(OPEN_EXPLORER_WIZARD_EVENT));
+  }, [isExplorerWizardConfigured, user]);
 
   const chartData = getChartData({
     aggsChartData,
@@ -343,7 +350,7 @@ function ExplorerVisualization({
           ))}
         </div>
         <div className='explorer-visualization__button-group'>
-          {isExplorerWizardEnabled && (
+          {isExplorerWizardConfigured && (
             <button
               className='explorer-visualization__guide-button'
               onClick={() =>

--- a/src/GuppyDataExplorer/ExplorerWizard.jsx
+++ b/src/GuppyDataExplorer/ExplorerWizard.jsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { config } from '../params';
 import './ExplorerWizard.css';
 
-const COMPLETION_STORAGE_KEY = 'pcdc-explorer-wizard-completed-v1';
+export const ONBOARDING_VERSION_FIELD = 'onboardingVersionSeen';
 export const OPEN_EXPLORER_WIZARD_EVENT = 'pcdc-open-explorer-wizard';
 
 function getElements(selectors) {
@@ -54,6 +54,27 @@ function getPopoverPosition(rect) {
 function getConfiguredSteps() {
   const configuredSteps = config.explorerWizard?.steps;
   return Array.isArray(configuredSteps) ? configuredSteps : [];
+}
+
+export function getExplorerWizardVersion() {
+  const version = Number(config.explorerWizard?.version);
+  return Number.isFinite(version) && version > 0 ? version : null;
+}
+
+export function isExplorerWizardEnabled() {
+  return getExplorerWizardVersion() !== null && getConfiguredSteps().length > 0;
+}
+
+export function hasSeenExplorerWizard(user) {
+  const wizardVersion = getExplorerWizardVersion();
+  const seenVersion = Number(
+    user?.additional_info?.[ONBOARDING_VERSION_FIELD],
+  );
+
+  return (
+    wizardVersion === null ||
+    (Number.isFinite(seenVersion) && seenVersion >= wizardVersion)
+  );
 }
 
 function getRouteWithMergedSearch(route, location) {
@@ -278,7 +299,5 @@ ExplorerWizard.propTypes = {
   onClose: PropTypes.func.isRequired,
   onDone: PropTypes.func.isRequired,
 };
-
-ExplorerWizard.COMPLETION_STORAGE_KEY = COMPLETION_STORAGE_KEY;
 
 export default ExplorerWizard;

--- a/src/Layout/index.jsx
+++ b/src/Layout/index.jsx
@@ -1,22 +1,24 @@
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { components } from '../params';
 import isEnabled from '../helpers/featureFlags';
+import { userapiPath } from '../localconf';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { receiveUser } from '../redux/user/slice';
+import { fetchWithCreds } from '../utils.fetch';
 import dictIcons from '../img/icons/index';
 import ReduxFooter from './ReduxFooter';
 import ScreenSizeWarning from '../components/ScreenSizeWarning';
 import ReduxTopBar from './ReduxTopBar';
 import ReduxNavBar from './ReduxNavBar';
 import ExplorerWizard, {
+  getExplorerWizardVersion,
+  ONBOARDING_VERSION_FIELD,
   OPEN_EXPLORER_WIZARD_EVENT,
 } from '../GuppyDataExplorer/ExplorerWizard';
 import './Layout.css';
-
-function markExplorerWizardCompleted() {
-  window.localStorage.setItem(ExplorerWizard.COMPLETION_STORAGE_KEY, 'true');
-}
 
 /**
  * @param {Object} props
@@ -24,6 +26,8 @@ function markExplorerWizardCompleted() {
  */
 function Layout({ children }) {
   const location = useLocation();
+  const dispatch = useAppDispatch();
+  const user = useAppSelector((state) => state.user);
   const [isExplorerWizardOpen, setExplorerWizardOpen] = useState(false);
 
   const isDashboardPage =
@@ -42,6 +46,44 @@ function Layout({ children }) {
         openExplorerWizard,
       );
   }, []);
+
+  const markExplorerWizardCompleted = useCallback(() => {
+    const version = getExplorerWizardVersion();
+    if (version === null) return;
+
+    const additionalInfo = {
+      ...(user.additional_info ?? {}),
+      [ONBOARDING_VERSION_FIELD]: version,
+    };
+
+    fetchWithCreds({
+      body: JSON.stringify(additionalInfo),
+      method: 'PUT',
+      path: `${userapiPath}user/`,
+    })
+      .then(({ data, status }) => {
+        if (status < 200 || status >= 300)
+          throw new Error(
+            `Failed to save Explorer Guide completion: ${status}`,
+          );
+
+        dispatch(
+          receiveUser({
+            ...user,
+            ...(data && typeof data === 'object' ? data : {}),
+            additional_info:
+              data && typeof data === 'object' && data.additional_info
+                ? data.additional_info
+                : additionalInfo,
+          }),
+        );
+      })
+      .catch((error) => {
+        // If saving fails, the backend will not record the version and the
+        // guide can be shown again on the next page load.
+        console.error(error);
+      });
+  }, [dispatch, user]);
 
   return (
     <>

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -23,11 +23,13 @@ const preloadedState = {
   user:
     process.env.NODE_ENV !== 'production' && mockStore
       ? {
+          additional_info: {},
           authz: {
             '/mock/registered-user': [{ method: 'read' }],
           },
           certificates_uploaded: requiredCerts,
           docs_to_be_reviewed: [],
+          fetched_user: true,
           lastAuthMs: Date.now(),
           user_id: 'test',
           username: 'test',

--- a/src/redux/user/types.d.ts
+++ b/src/redux/user/types.d.ts
@@ -9,6 +9,7 @@ export type User = {
     firstName?: string;
     lastName?: string;
     institution?: string;
+    onboardingVersionSeen?: number;
   };
   authz: UserAuthz;
   azp: any;


### PR DESCRIPTION
### New Features

- Add configurable Explorer Guide versioning through `explorerWizard.version`.
- Persist completed Explorer Guide versions to the user profile with `onboardingVersionSeen`.
- Re-show the Explorer Guide when the configured version is newer than the user's saved version.

### Breaking Changes

- None.

### Bug Fixes

- Disable the Explorer Guide when `explorerWizard.version` or guide steps are not configured.
- Prevent the Explorer Guide from auto-opening before user profile data has loaded.

### Improvements

- Use `additional_info.onboardingVersionSeen` from `GET /user/user` to determine whether the guide should auto-open.
- Save guide completion with `PUT /user/user` when the user clicks Done.
- Update portal config documentation for Explorer Guide versioning and completion persistence.
- Keep local mock user setup compatible with Explorer Guide completion checks.

### Dependency updates

- None.

### Deployment changes

- None.