### PR TITLE
PEDS-1610: add data request re-export action

### DIFF
--- a/src/DataRequests/AdminProjectActions.jsx
+++ b/src/DataRequests/AdminProjectActions.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import * as Yup from 'yup';
 import Select from 'react-select';
 import { Formik, Field, Form, FieldArray } from 'formik';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import Button from '../gen3-ui-component/components/Button';
 import IconComponent from '../components/Icon';
@@ -22,7 +23,10 @@ import UserAccessTable from './UserAccessTable';
 import DataRequestFilterSets from './DataRequestFilterSets';
 import DataRequestApprovedUrl from './DataRequestApprovedUrl';
 import ViewProjectStatusHistory from './ViewProjectStatusHistory';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  isTerminalReExportStatus,
+  RE_EXPORT_STATUS,
+} from '../redux/dataRequest/constants';
 
 const dataAccessSchema = Yup.object().shape({
   email: Yup.string().email().required('Must be a valid email address'),
@@ -83,24 +87,22 @@ export default function AdminProjectActions({
     value: projectStates[name].id,
   }));
   const isReExportPending = Boolean(
-    reExportJob &&
-    reExportJob.status !== 'Completed' &&
-    reExportJob.status !== 'Failed',
+    reExportJob && !isTerminalReExportStatus(reExportJob.status),
   );
   const reExportStatusMessage = (() => {
     switch (reExportJob?.status) {
-      case 'Dispatching':
+      case RE_EXPORT_STATUS.DISPATCHING:
         return 'Starting export...';
-      case 'Running':
+      case RE_EXPORT_STATUS.RUNNING:
         return reExportJob.error || 'Export job in progress.';
-      case 'Completed':
+      case RE_EXPORT_STATUS.COMPLETED:
         return 'Export completed successfully.';
-      case 'Failed':
+      case RE_EXPORT_STATUS.FAILED:
         return reExportJob.error || 'The export job failed.';
+      case RE_EXPORT_STATUS.UNKNOWN:
+        return 'Export job status is unavailable. Checking again...';
       default:
-        return reExportJob
-          ? reExportJob.error || `Export job status: ${reExportJob.status}.`
-          : '';
+        return '';
     }
   })();
   return (
@@ -556,7 +558,8 @@ export default function AdminProjectActions({
                     {reExportStatusMessage && (
                       <span
                         className={`data-request-admin__re-export-status data-request-admin__re-export-status--${
-                          reExportJob.status === 'Failed' || reExportJob.error
+                          reExportJob.status === RE_EXPORT_STATUS.FAILED ||
+                          reExportJob.error
                             ? 'error'
                             : 'info'
                         }`}

--- a/src/DataRequests/AdminProjectActions.jsx
+++ b/src/DataRequests/AdminProjectActions.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import * as Yup from 'yup';
 import Select from 'react-select';
 import { Formik, Field, Form, FieldArray } from 'formik';
-import { useAppDispatch } from '../redux/hooks';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import Button from '../gen3-ui-component/components/Button';
 import IconComponent from '../components/Icon';
 import SimpleInputField from '../components/SimpleInputField';
@@ -15,6 +15,7 @@ import {
   updateProjectUsers,
   updateUserDataAccess,
   deleteRequest,
+  startProjectReExport,
 } from '../redux/dataRequest/asyncThunks';
 import '../GuppyDataExplorer/ExplorerFilterSetForms/ExplorerFilterSetForms.css';
 import UserAccessTable from './UserAccessTable';
@@ -63,6 +64,9 @@ export default function AdminProjectActions({
   onShowStatusFlow,
 }) {
   const dispatch = useAppDispatch();
+  const reExportJob = useAppSelector(
+    (state) => state.dataRequest.reExportJobs?.[project.id],
+  );
   const [actionType, setActionType] = useState('');
   const [currentEmailInput, setCurrentEmailInput] = useState('');
   const [isActionPending, setActionPending] = useState(false);
@@ -78,6 +82,27 @@ export default function AdminProjectActions({
     label: name,
     value: projectStates[name].id,
   }));
+  const isReExportPending = Boolean(
+    reExportJob &&
+    reExportJob.status !== 'Completed' &&
+    reExportJob.status !== 'Failed',
+  );
+  const reExportStatusMessage = (() => {
+    switch (reExportJob?.status) {
+      case 'Dispatching':
+        return 'Starting export...';
+      case 'Running':
+        return reExportJob.error || 'Export job in progress.';
+      case 'Completed':
+        return 'Export completed successfully.';
+      case 'Failed':
+        return reExportJob.error || 'The export job failed.';
+      default:
+        return reExportJob
+          ? reExportJob.error || `Export job status: ${reExportJob.status}.`
+          : '';
+    }
+  })();
   return (
     <div
       className={`data-request-admin__actions-container
@@ -516,6 +541,30 @@ export default function AdminProjectActions({
                       }
                       buttonType='secondary'
                     />
+                  </li>
+
+                  <li className='data-request-admin__re-export-action'>
+                    <Button
+                      label={
+                        isReExportPending ? 'Exporting...' : 'Export Again'
+                      }
+                      enabled={!isReExportPending}
+                      isPending={isReExportPending}
+                      onClick={() => dispatch(startProjectReExport(project.id))}
+                      buttonType='secondary'
+                    />
+                    {reExportStatusMessage && (
+                      <span
+                        className={`data-request-admin__re-export-status data-request-admin__re-export-status--${
+                          reExportJob.status === 'Failed' || reExportJob.error
+                            ? 'error'
+                            : 'info'
+                        }`}
+                        role='status'
+                      >
+                        {reExportStatusMessage}
+                      </span>
+                    )}
                   </li>
 
                   <li>

--- a/src/DataRequests/AdminProjectActions.test.jsx
+++ b/src/DataRequests/AdminProjectActions.test.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import AdminProjectActions from './AdminProjectActions';
 import dataRequestReducer from '../redux/dataRequest/slice';
+import { RE_EXPORT_STATUS } from '../redux/dataRequest/constants';
 
 function renderActions(reExportJob) {
   const initialDataRequestState = dataRequestReducer(undefined, {
@@ -41,7 +42,7 @@ describe('AdminProjectActions re-export action', () => {
   it('keeps other admin actions available while an export runs', () => {
     const { getByRole, getByText } = renderActions({
       job_uid: 'export-job-uid',
-      status: 'Running',
+      status: RE_EXPORT_STATUS.RUNNING,
       error: null,
     });
 
@@ -52,5 +53,18 @@ describe('AdminProjectActions re-export action', () => {
       'g3-button--disabled',
     );
     expect(getByText('Export job in progress.')).toBeInTheDocument();
+  });
+
+  it('does not expose an unknown backend status', () => {
+    const { getByText, queryByText } = renderActions({
+      job_uid: 'export-job-uid',
+      status: RE_EXPORT_STATUS.UNKNOWN,
+      error: null,
+    });
+
+    expect(
+      getByText('Export job status is unavailable. Checking again...'),
+    ).toBeInTheDocument();
+    expect(queryByText(/UNKNOWN/)).not.toBeInTheDocument();
   });
 });

--- a/src/DataRequests/AdminProjectActions.test.jsx
+++ b/src/DataRequests/AdminProjectActions.test.jsx
@@ -1,0 +1,56 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import AdminProjectActions from './AdminProjectActions';
+import dataRequestReducer from '../redux/dataRequest/slice';
+
+function renderActions(reExportJob) {
+  const initialDataRequestState = dataRequestReducer(undefined, {
+    type: 'test/init',
+  });
+  const store = configureStore({
+    reducer: {
+      dataRequest: dataRequestReducer,
+    },
+    preloadedState: {
+      dataRequest: {
+        ...initialDataRequestState,
+        reExportJobs: reExportJob ? { 904: reExportJob } : {},
+      },
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <AdminProjectActions
+        project={{ id: 904, name: 'Test project', status: 'Approved' }}
+        projectStates={{ Approved: { id: 1, code: 'APPROVED' } }}
+        savedFilterSets={{}}
+      />
+    </Provider>,
+  );
+}
+
+describe('AdminProjectActions re-export action', () => {
+  it('shows Export Again when no export is active', () => {
+    const { getByRole } = renderActions();
+
+    expect(getByRole('button', { name: 'Export Again' })).toBeEnabled();
+  });
+
+  it('keeps other admin actions available while an export runs', () => {
+    const { getByRole, getByText } = renderActions({
+      job_uid: 'export-job-uid',
+      status: 'Running',
+      error: null,
+    });
+
+    expect(getByRole('button', { name: 'Exporting...' })).toHaveClass(
+      'g3-button--disabled',
+    );
+    expect(getByRole('button', { name: 'Update State' })).not.toHaveClass(
+      'g3-button--disabled',
+    );
+    expect(getByText('Export job in progress.')).toBeInTheDocument();
+  });
+});

--- a/src/DataRequests/DataRequests.css
+++ b/src/DataRequests/DataRequests.css
@@ -312,6 +312,27 @@
   width: 250px;
 }
 
+.data-request-admin__re-export-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.data-request-admin__re-export-status {
+  max-width: 250px;
+  margin-top: 6px;
+  font-size: 12px;
+  text-align: center;
+}
+
+.data-request-admin__re-export-status--info {
+  color: var(--g3-color__gray);
+}
+
+.data-request-admin__re-export-status--error {
+  color: var(--g3-color__rose);
+}
+
 .data-request-admin__action-list-container {
   height: 100%;
   display: flex;

--- a/src/redux/dataRequest/asyncThunks.js
+++ b/src/redux/dataRequest/asyncThunks.js
@@ -1,5 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { jobapiPath } from '../../localconf';
 import { fetchWithCreds } from '../../utils.fetch';
+
+const PROJECT_RE_EXPORT_POLL_INTERVAL_MS = 5000;
+const projectReExportPollTimeouts = new Map();
 
 function statusCategory(status) {
   return `${Math.floor(status / 100)}XX`;
@@ -31,6 +35,12 @@ function handleRequestError(status, response, data = null) {
         data: null,
       };
   }
+}
+
+function getRequestErrorMessage(data, fallbackMessage) {
+  if (typeof data === 'string' && data) return data;
+  if (typeof data?.message === 'string' && data.message) return data.message;
+  return fallbackMessage;
 }
 
 function getPaginationLinks(linkHeader) {
@@ -301,6 +311,116 @@ export const updateProjectApprovedUrl = createAsyncThunk(
     }
   },
 );
+
+export const exportProjectAgain = createAsyncThunk(
+  'dataRequest/exportProjectAgain',
+  /** @param {number} projectId */
+  async (projectId, { rejectWithValue }) => {
+    try {
+      const { data, status } = await fetchWithCreds({
+        path: `/amanuensis/admin/project/export/${projectId}`,
+        method: 'POST',
+        customHeaders: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      if (statusCategory(status) !== '2XX' || !data?.job_uid) {
+        return rejectWithValue(
+          getRequestErrorMessage(
+            data,
+            'Failed to start the export job. Please try again.',
+          ),
+        );
+      }
+
+      return data;
+    } catch (e) {
+      return rejectWithValue(
+        e?.message || 'Failed to start the export job. Please try again.',
+      );
+    }
+  },
+);
+
+export const checkProjectReExportStatus = createAsyncThunk(
+  'dataRequest/checkProjectReExportStatus',
+  /** @param {{ projectId: number, jobUid: string }} params */
+  async ({ projectId, jobUid }, { rejectWithValue }) => {
+    try {
+      const { data, status } = await fetchWithCreds({
+        path: `${jobapiPath}status?UID=${jobUid}`,
+        method: 'GET',
+      });
+
+      if (status !== 200 || !data?.status) {
+        return rejectWithValue(
+          getRequestErrorMessage(
+            data,
+            'Unable to check the export job status.',
+          ),
+        );
+      }
+
+      return { projectId, jobUid, status: data.status };
+    } catch (e) {
+      return rejectWithValue(
+        e?.message || 'Unable to check the export job status.',
+      );
+    }
+  },
+);
+
+/** @param {number} projectId */
+function clearProjectReExportPoll(projectId) {
+  const timeout = projectReExportPollTimeouts.get(projectId);
+  if (timeout) window.clearTimeout(timeout);
+  projectReExportPollTimeouts.delete(projectId);
+}
+
+/**
+ * Poll outside the modal lifecycle so closing it does not interrupt the job.
+ *
+ * @param {{ projectId: number, jobUid: string }} params
+ */
+export const pollProjectReExportStatus =
+  ({ projectId, jobUid }) =>
+  async (dispatch) => {
+    const action = await dispatch(
+      checkProjectReExportStatus({ projectId, jobUid }),
+    );
+
+    if (
+      checkProjectReExportStatus.fulfilled.match(action) &&
+      (action.payload.status === 'Completed' ||
+        action.payload.status === 'Failed')
+    ) {
+      clearProjectReExportPoll(projectId);
+      return;
+    }
+
+    const timeout = window.setTimeout(
+      () => dispatch(pollProjectReExportStatus({ projectId, jobUid })),
+      PROJECT_RE_EXPORT_POLL_INTERVAL_MS,
+    );
+    projectReExportPollTimeouts.set(projectId, timeout);
+  };
+
+/** @param {number} projectId */
+export const startProjectReExport = (projectId) => async (dispatch) => {
+  clearProjectReExportPoll(projectId);
+  const action = await dispatch(exportProjectAgain(projectId));
+
+  if (exportProjectAgain.fulfilled.match(action)) {
+    await dispatch(
+      pollProjectReExportStatus({
+        projectId,
+        jobUid: action.payload.job_uid,
+      }),
+    );
+  }
+
+  return action;
+};
 
 export const updateUserDataAccess = createAsyncThunk(
   'dataRequest/updateUserDataAccess',

--- a/src/redux/dataRequest/asyncThunks.js
+++ b/src/redux/dataRequest/asyncThunks.js
@@ -1,6 +1,10 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { jobapiPath } from '../../localconf';
 import { fetchWithCreds } from '../../utils.fetch';
+import {
+  isTerminalReExportStatus,
+  normalizeReExportStatus,
+} from './constants';
 
 const PROJECT_RE_EXPORT_POLL_INTERVAL_MS = 5000;
 const projectReExportPollTimeouts = new Map();
@@ -361,7 +365,11 @@ export const checkProjectReExportStatus = createAsyncThunk(
         );
       }
 
-      return { projectId, jobUid, status: data.status };
+      return {
+        projectId,
+        jobUid,
+        status: normalizeReExportStatus(data.status),
+      };
     } catch (e) {
       return rejectWithValue(
         e?.message || 'Unable to check the export job status.',
@@ -391,8 +399,7 @@ export const pollProjectReExportStatus =
 
     if (
       checkProjectReExportStatus.fulfilled.match(action) &&
-      (action.payload.status === 'Completed' ||
-        action.payload.status === 'Failed')
+      isTerminalReExportStatus(action.payload.status)
     ) {
       clearProjectReExportPoll(projectId);
       return;

--- a/src/redux/dataRequest/constants.js
+++ b/src/redux/dataRequest/constants.js
@@ -1,0 +1,43 @@
+/** @type {Readonly<Record<string, import('./types').ReExportStatus>>} */
+export const RE_EXPORT_STATUS = Object.freeze({
+  DISPATCHING: 'DISPATCHING',
+  RUNNING: 'RUNNING',
+  COMPLETED: 'COMPLETED',
+  FAILED: 'FAILED',
+  UNKNOWN: 'UNKNOWN',
+});
+
+const RE_EXPORT_STATUS_ALIASES = Object.freeze({
+  dispatching: RE_EXPORT_STATUS.DISPATCHING,
+  queued: RE_EXPORT_STATUS.RUNNING,
+  pending: RE_EXPORT_STATUS.RUNNING,
+  running: RE_EXPORT_STATUS.RUNNING,
+  inprogress: RE_EXPORT_STATUS.RUNNING,
+  complete: RE_EXPORT_STATUS.COMPLETED,
+  completed: RE_EXPORT_STATUS.COMPLETED,
+  success: RE_EXPORT_STATUS.COMPLETED,
+  succeeded: RE_EXPORT_STATUS.COMPLETED,
+  failed: RE_EXPORT_STATUS.FAILED,
+  failure: RE_EXPORT_STATUS.FAILED,
+  error: RE_EXPORT_STATUS.FAILED,
+  canceled: RE_EXPORT_STATUS.FAILED,
+  cancelled: RE_EXPORT_STATUS.FAILED,
+});
+
+/**
+ * @param {unknown} status
+ * @returns {import('./types').ReExportStatus}
+ */
+export function normalizeReExportStatus(status) {
+  const normalizedStatus = String(status ?? '')
+    .toLowerCase()
+    .replace(/[\s_-]/g, '');
+  return RE_EXPORT_STATUS_ALIASES[normalizedStatus] ?? RE_EXPORT_STATUS.UNKNOWN;
+}
+
+/** @param {import('./types').ReExportStatus} status */
+export function isTerminalReExportStatus(status) {
+  return (
+    status === RE_EXPORT_STATUS.COMPLETED || status === RE_EXPORT_STATUS.FAILED
+  );
+}

--- a/src/redux/dataRequest/reExport.test.js
+++ b/src/redux/dataRequest/reExport.test.js
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import reducer from './slice';
 import { exportProjectAgain, startProjectReExport } from './asyncThunks';
+import { RE_EXPORT_STATUS } from './constants';
 
 function createStore() {
   return configureStore({
@@ -45,7 +46,7 @@ describe('project re-export', () => {
       job_uid: 'export-job-uid',
       project_id: '904',
       search_id: 1805,
-      status: 'Running',
+      status: RE_EXPORT_STATUS.RUNNING,
       error: null,
     });
   });
@@ -61,15 +62,15 @@ describe('project re-export', () => {
         }),
         { status: 200 },
       )
-      .mockResponseOnce(JSON.stringify({ status: 'Running' }), { status: 200 })
-      .mockResponseOnce(JSON.stringify({ status: 'Completed' }), {
+      .mockResponseOnce(JSON.stringify({ status: 'rUn-NiNg' }), { status: 200 })
+      .mockResponseOnce(JSON.stringify({ status: 'SuCcEeDeD' }), {
         status: 200,
       });
 
     await store.dispatch(startProjectReExport(904));
 
     expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
-      'Running',
+      RE_EXPORT_STATUS.RUNNING,
     );
     expect(jest.getTimerCount()).toBe(1);
 
@@ -80,7 +81,7 @@ describe('project re-export', () => {
       expect.objectContaining({ method: 'GET' }),
     );
     expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
-      'Completed',
+      RE_EXPORT_STATUS.COMPLETED,
     );
     expect(jest.getTimerCount()).toBe(0);
   });
@@ -104,7 +105,7 @@ describe('project re-export', () => {
     await store.dispatch(startProjectReExport(904));
 
     expect(store.getState().dataRequest.reExportJobs[904]).toMatchObject({
-      status: 'Running',
+      status: RE_EXPORT_STATUS.RUNNING,
       error: 'Service unavailable',
     });
     expect(jest.getTimerCount()).toBe(1);
@@ -112,9 +113,42 @@ describe('project re-export', () => {
     await jest.advanceTimersByTimeAsync(5000);
 
     expect(store.getState().dataRequest.reExportJobs[904]).toMatchObject({
-      status: 'Completed',
+      status: RE_EXPORT_STATUS.COMPLETED,
       error: null,
     });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('continues polling when the backend adds an unknown status', async () => {
+    const store = createStore();
+    fetch
+      .mockResponseOnce(
+        JSON.stringify({
+          job_uid: 'export-job-uid',
+          project_id: '904',
+          search_id: 1805,
+        }),
+        { status: 200 },
+      )
+      .mockResponseOnce(JSON.stringify({ status: 'Awaiting Worker' }), {
+        status: 200,
+      })
+      .mockResponseOnce(JSON.stringify({ status: 'completed' }), {
+        status: 200,
+      });
+
+    await store.dispatch(startProjectReExport(904));
+
+    expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
+      RE_EXPORT_STATUS.UNKNOWN,
+    );
+    expect(jest.getTimerCount()).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
+      RE_EXPORT_STATUS.COMPLETED,
+    );
     expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/src/redux/dataRequest/reExport.test.js
+++ b/src/redux/dataRequest/reExport.test.js
@@ -1,0 +1,120 @@
+import { configureStore } from '@reduxjs/toolkit';
+import reducer from './slice';
+import { exportProjectAgain, startProjectReExport } from './asyncThunks';
+
+function createStore() {
+  return configureStore({
+    reducer: {
+      dataRequest: reducer,
+    },
+  });
+}
+
+describe('project re-export', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('starts an export job for the selected project', async () => {
+    const store = createStore();
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        job_uid: 'export-job-uid',
+        project_id: '904',
+        search_id: 1805,
+      }),
+      { status: 200 },
+    );
+
+    await store.dispatch(exportProjectAgain(904));
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/amanuensis/admin/project/export/904',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{}',
+      }),
+    );
+    expect(store.getState().dataRequest.reExportJobs[904]).toEqual({
+      job_uid: 'export-job-uid',
+      project_id: '904',
+      search_id: 1805,
+      status: 'Running',
+      error: null,
+    });
+  });
+
+  it('polls until the export job completes', async () => {
+    const store = createStore();
+    fetch
+      .mockResponseOnce(
+        JSON.stringify({
+          job_uid: 'export-job-uid',
+          project_id: '904',
+          search_id: 1805,
+        }),
+        { status: 200 },
+      )
+      .mockResponseOnce(JSON.stringify({ status: 'Running' }), { status: 200 })
+      .mockResponseOnce(JSON.stringify({ status: 'Completed' }), {
+        status: 200,
+      });
+
+    await store.dispatch(startProjectReExport(904));
+
+    expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
+      'Running',
+    );
+    expect(jest.getTimerCount()).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining('job/status?UID=export-job-uid'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(store.getState().dataRequest.reExportJobs[904].status).toBe(
+      'Completed',
+    );
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('keeps polling after a temporary status request error', async () => {
+    const store = createStore();
+    fetch
+      .mockResponseOnce(
+        JSON.stringify({
+          job_uid: 'export-job-uid',
+          project_id: '904',
+          search_id: 1805,
+        }),
+        { status: 200 },
+      )
+      .mockResponseOnce('Service unavailable', { status: 503 })
+      .mockResponseOnce(JSON.stringify({ status: 'Completed' }), {
+        status: 200,
+      });
+
+    await store.dispatch(startProjectReExport(904));
+
+    expect(store.getState().dataRequest.reExportJobs[904]).toMatchObject({
+      status: 'Running',
+      error: 'Service unavailable',
+    });
+    expect(jest.getTimerCount()).toBe(1);
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(store.getState().dataRequest.reExportJobs[904]).toMatchObject({
+      status: 'Completed',
+      error: null,
+    });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/redux/dataRequest/slice.js
+++ b/src/redux/dataRequest/slice.js
@@ -9,6 +9,7 @@ import {
   exportProjectAgain,
   checkProjectReExportStatus,
 } from './asyncThunks';
+import { RE_EXPORT_STATUS } from './constants';
 
 const slice = createSlice({
   name: 'dataRequest',
@@ -132,20 +133,20 @@ const slice = createSlice({
     });
     builder.addCase(exportProjectAgain.pending, (state, action) => {
       state.reExportJobs[action.meta.arg] = {
-        status: 'Dispatching',
+        status: RE_EXPORT_STATUS.DISPATCHING,
         error: null,
       };
     });
     builder.addCase(exportProjectAgain.fulfilled, (state, action) => {
       state.reExportJobs[action.meta.arg] = {
         ...action.payload,
-        status: 'Running',
+        status: RE_EXPORT_STATUS.RUNNING,
         error: null,
       };
     });
     builder.addCase(exportProjectAgain.rejected, (state, action) => {
       state.reExportJobs[action.meta.arg] = {
-        status: 'Failed',
+        status: RE_EXPORT_STATUS.FAILED,
         error: action.payload || action.error.message,
       };
     });
@@ -155,7 +156,8 @@ const slice = createSlice({
       if (currentJob?.job_uid !== jobUid) return;
 
       currentJob.status = status;
-      currentJob.error = status === 'Failed' ? 'The export job failed.' : null;
+      currentJob.error =
+        status === RE_EXPORT_STATUS.FAILED ? 'The export job failed.' : null;
     });
     builder.addCase(checkProjectReExportStatus.rejected, (state, action) => {
       const { projectId, jobUid } = action.meta.arg;

--- a/src/redux/dataRequest/slice.js
+++ b/src/redux/dataRequest/slice.js
@@ -6,6 +6,8 @@ import {
   fetchProjectConsortiums,
   getProjectUsers,
   getUserRoles,
+  exportProjectAgain,
+  checkProjectReExportStatus,
 } from './asyncThunks';
 
 const slice = createSlice({
@@ -16,6 +18,7 @@ const slice = createSlice({
     projectStates: {},
     projectConsortiums: [],
     paginationLinks: {},
+    reExportJobs: {},
     isError: false,
     isAdminActive: false,
     isProjectsReloading: false,
@@ -126,6 +129,40 @@ const slice = createSlice({
       if (action.payload) {
         state.userRoles = action.payload;
       }
+    });
+    builder.addCase(exportProjectAgain.pending, (state, action) => {
+      state.reExportJobs[action.meta.arg] = {
+        status: 'Dispatching',
+        error: null,
+      };
+    });
+    builder.addCase(exportProjectAgain.fulfilled, (state, action) => {
+      state.reExportJobs[action.meta.arg] = {
+        ...action.payload,
+        status: 'Running',
+        error: null,
+      };
+    });
+    builder.addCase(exportProjectAgain.rejected, (state, action) => {
+      state.reExportJobs[action.meta.arg] = {
+        status: 'Failed',
+        error: action.payload || action.error.message,
+      };
+    });
+    builder.addCase(checkProjectReExportStatus.fulfilled, (state, action) => {
+      const { projectId, jobUid, status } = action.payload;
+      const currentJob = state.reExportJobs[projectId];
+      if (currentJob?.job_uid !== jobUid) return;
+
+      currentJob.status = status;
+      currentJob.error = status === 'Failed' ? 'The export job failed.' : null;
+    });
+    builder.addCase(checkProjectReExportStatus.rejected, (state, action) => {
+      const { projectId, jobUid } = action.meta.arg;
+      const currentJob = state.reExportJobs[projectId];
+      if (currentJob?.job_uid !== jobUid) return;
+
+      currentJob.error = action.payload || action.error.message;
     });
   },
 });

--- a/src/redux/dataRequest/types.d.ts
+++ b/src/redux/dataRequest/types.d.ts
@@ -100,22 +100,28 @@ export type ProjectFilterSets = {
   ids_list: list[string];
 };
 
+export type ReExportStatus =
+  | 'DISPATCHING'
+  | 'RUNNING'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'UNKNOWN';
+
+export type ReExportJob = {
+  job_uid?: string;
+  project_id?: string;
+  search_id?: number;
+  status: ReExportStatus;
+  error: string | null;
+};
+
 export type DataRequestState = {
   projects: DataRequestProject[];
   projectStates: Record<string, { id: number; code: string }>;
   userRoles: { id: number; code: string; role: string }[];
   projectUsers: { email: string; role: string }[];
   projectFilterSets: ProjectFilterSets[];
-  reExportJobs: Record<
-    number,
-    {
-      job_uid?: string;
-      project_id?: string;
-      search_id?: number;
-      status: string;
-      error: string | null;
-    }
-  >;
+  reExportJobs: Record<number, ReExportJob>;
   isError: boolean;
   isAdminActive: boolean;
   isProjectsReloading: boolean;

--- a/src/redux/dataRequest/types.d.ts
+++ b/src/redux/dataRequest/types.d.ts
@@ -106,6 +106,16 @@ export type DataRequestState = {
   userRoles: { id: number; code: string; role: string }[];
   projectUsers: { email: string; role: string }[];
   projectFilterSets: ProjectFilterSets[];
+  reExportJobs: Record<
+    number,
+    {
+      job_uid?: string;
+      project_id?: string;
+      search_id?: number;
+      status: string;
+      error: string | null;
+    }
+  >;
   isError: boolean;
   isAdminActive: boolean;
   isProjectsReloading: boolean;


### PR DESCRIPTION
Adds a non-blocking admin workflow to rerun data request exports. The portal dispatches the export through Amanuensis, tracks the returned job in Redux, and polls job status in the background so administrators can continue using the portal.

Testing:
- Added component coverage for the Export Again action and non-blocking admin controls.
- Added Redux/API coverage for export dispatch, completion polling, and temporary status request failures.
- Ran the targeted Jest tests, portal sanity check, and PCDC webpack build successfully.

Link to JIRA ticket if there is one: PEDS-1181

### New Features

- Add an Export Again action to Data Request admin options.

### Breaking Changes

### Bug Fixes

### Improvements

- Track re-export jobs asynchronously until completion without blocking other portal actions.
- Display dispatching, running, completed, and failed export states in the admin modal.
- Continue polling after temporary job status request failures.

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->