### PR TITLE
PEDS-1599 fix(density-heatmap): strip node prefix from field labels

### DIFF
--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
@@ -22,9 +22,22 @@ export function collectDensityHeatmapFields({
   return orderedFields;
 }
 
-/** @param {string} field @param {{ [field: string]: { label?: string } }} fieldInfo */
+/**
+ * Prefer fieldMapping / filterConfig.info label; otherwise strip the first
+ * path segment (node/table) so nested fields read as attribute names only.
+ *
+ * @param {string} field
+ * @param {{ [field: string]: { label?: string } }} fieldInfo
+ */
 export function getDensityHeatmapFieldLabel(field, fieldInfo = {}) {
-  return fieldInfo[field]?.label ?? capitalizeFirstLetter(field);
+  const mappedLabel = fieldInfo[field]?.label;
+  if (mappedLabel) return mappedLabel;
+
+  const dotIndex = field.indexOf('.');
+  const labelSource =
+    dotIndex === -1 ? field : field.slice(dotIndex + 1);
+
+  return capitalizeFirstLetter(labelSource);
 }
 
 /** @param {any} value */

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
@@ -62,14 +62,33 @@ describe('Explorer density heatmap helpers', () => {
     expect(model.rows[2].cells.map((cell) => cell.density)).toEqual([0.5, 1]);
   });
 
-  it('formats density and field labels consistently', () => {
+  it('formats density percentages consistently', () => {
     expect(formatDensityPercentage(0.625)).toBe('62.5%');
     expect(formatDensityPercentage(0.85)).toBe('85%');
     expect(formatDensityPercentage(0.855)).toBe('85.5%');
     expect(formatDensityPercentage(0.8567)).toBe('85.67%');
     expect(formatDensityPercentage(0.85678)).toBe('85.68%');
-    expect(getDensityHeatmapFieldLabel('file_type', {})).toBe('File Type');
     expect(getDensityHeatmapColor(0)).toContain('var(--g3-color__silver)');
+  });
+
+  it('prefers mapped field labels from fieldInfo', () => {
+    expect(
+      getDensityHeatmapFieldLabel('histologies.age_at_course_anc_500', {
+        'histologies.age_at_course_anc_500': {
+          label: 'Age at Course ANC 500',
+        },
+      }),
+    ).toBe('Age at Course ANC 500');
+  });
+
+  it('strips the node prefix from nested fields without mapping', () => {
+    expect(
+      getDensityHeatmapFieldLabel('histologies.age_at_course_anc_500', {}),
+    ).toBe('Age At Course Anc 500');
+  });
+
+  it('capitalizes top-level fields without a node prefix', () => {
+    expect(getDensityHeatmapFieldLabel('file_type', {})).toBe('File Type');
   });
 
   it('interpolates colors correctly for low, medium, and high densities', () => {


### PR DESCRIPTION
## Summary
- Prefer `fieldMapping` / `filterConfig.info` labels for density heatmap field names when present.
- Fall back by stripping the first path segment (node/table), so `histologies.age_at_course_anc_500` shows as `Age At Course Anc 500` instead of `Histologies Age At Course Anc 500`.
- Keep the raw GraphQL path on the secondary `field-path` line. Add unit tests for mapped, nested, and top-level cases.

| Before |
| :-: |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10a673c3-b5d6-47f5-ae6d-8b4cf4df5ddf" /> |

| After |
| :-: |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e1d93c62-ad16-4277-8de8-4b443654fe9c" /> |

## Test plan
- [x] `npm test -- --testPathPattern=ExplorerDensityHeatmap/utils.test.js`
- [x] Open Density Heatmap with "Show all fields" and confirm Histologies (and other nested) labels no longer repeat the table name
- [x] Confirm fields with `fieldMapping` entries still use the configured label
- [x] Confirm top-level fields (e.g. `file_type`) still capitalize normally
- [x] Confirm secondary path line still shows the full field path