### PR TITLE
PEDS-1639: fetch project datapoints via POST

### DIFF
--- a/src/redux/dataRequest/asyncThunks.js
+++ b/src/redux/dataRequest/asyncThunks.js
@@ -605,8 +605,9 @@ export const getProjectDatapoints = createAsyncThunk(
   async (projectId, { rejectWithValue }) => {
     try {
       const { data, response, status } = await fetchWithCreds({
-        path: `/amanuensis/project-datapoints/project/${projectId}`,
-        method: 'GET',
+        path: '/amanuensis/project-datapoints/get-datapoints',
+        method: 'POST',
+        body: JSON.stringify({ project_id: projectId, many: true }),
       });
 
       if (statusCategory(status) !== '2XX') {

--- a/src/redux/dataRequest/projectDatapoints.test.js
+++ b/src/redux/dataRequest/projectDatapoints.test.js
@@ -1,0 +1,24 @@
+import { getProjectDatapoints } from './asyncThunks';
+import { fetchWithCreds } from '../../utils.fetch';
+
+jest.mock('../../utils.fetch', () => ({
+  fetchWithCreds: jest.fn(),
+}));
+
+describe('project datapoints', () => {
+  beforeEach(() => {
+    fetchWithCreds.mockReset();
+  });
+
+  it('loads all datapoints using the project id JSON payload', async () => {
+    fetchWithCreds.mockResolvedValue({ data: [], status: 200 });
+
+    await getProjectDatapoints(904)(jest.fn(), jest.fn(), undefined);
+
+    expect(fetchWithCreds).toHaveBeenCalledWith({
+      path: '/amanuensis/project-datapoints/get-datapoints',
+      method: 'POST',
+      body: JSON.stringify({ project_id: 904, many: true }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- call `/amanuensis/project-datapoints/get-datapoints` using POST
- send `project_id` and `many: true` in the JSON body
- add regression coverage for the endpoint, method, and payload

## Dependency
Amanuensis must update `/project-datapoints/get-datapoints` to accept POST before this portal change is deployed. Its project-datapoints test fixture must also change from `client.get(...)` to `client.post(...)`.

## Testing
- `npm test -- --runInBand src/redux/dataRequest/projectDatapoints.test.js`