### PR TITLE
PEDS-1655 Added validation against project's dictionary for requests datapoints

### DIFF
--- a/src/DataRequests/DataRequestSelectAttributes.css
+++ b/src/DataRequests/DataRequestSelectAttributes.css
@@ -26,6 +26,14 @@
   font: inherit;
 }
 
+.data-request-select-attributes__template-warning {
+  padding: 0.75rem;
+  border: 1px solid #d6a700;
+  margin-bottom: 1rem;
+  background: #fff8dc;
+  color: #5f4b00;
+}
+
 .data-request-select-attributes__columns {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/DataRequests/DataRequestSelectAttributes.jsx
+++ b/src/DataRequests/DataRequestSelectAttributes.jsx
@@ -13,6 +13,61 @@ import './DataRequestSelectAttributes.css';
 const normalizeAttributes = (attributes = []) =>
   [...new Set(attributes)].sort((a, b) => a.localeCompare(b));
 
+export const validateSelectionsAgainstTables = (
+  selections = {},
+  tables = [],
+) => {
+  const attributesByTable = tables.reduce((result, table) => {
+    result[table.id] = new Set(table.attributes);
+    return result;
+  }, {});
+  const validSelections = {};
+  const skippedTables = [];
+  const skippedAttributes = [];
+
+  Object.entries(selections).forEach(([tableName, attributes]) => {
+    if (!attributesByTable[tableName]) {
+      skippedTables.push(tableName);
+      return;
+    }
+
+    if (!Array.isArray(attributes)) return;
+
+    const validAttributes = attributes.filter((attribute) => {
+      const isValid = attributesByTable[tableName].has(attribute);
+
+      if (!isValid) skippedAttributes.push(`${tableName}.${attribute}`);
+      return isValid;
+    });
+
+    if (validAttributes.length > 0) {
+      validSelections[tableName] = normalizeAttributes(validAttributes);
+    }
+  });
+
+  return {
+    validSelections,
+    skippedTables: normalizeAttributes(skippedTables),
+    skippedAttributes: normalizeAttributes(skippedAttributes),
+  };
+};
+
+const getSkippedSelectionsMessage = ({ skippedTables, skippedAttributes }) => {
+  const messages = [];
+
+  if (skippedTables.length > 0) {
+    messages.push(`unavailable tables: ${skippedTables.join(', ')}`);
+  }
+
+  if (skippedAttributes.length > 0) {
+    messages.push(`unavailable attributes: ${skippedAttributes.join(', ')}`);
+  }
+
+  return messages.length > 0
+    ? `Skipped ${messages.join('; ')} because they are not in this project's current data dictionary.`
+    : '';
+};
+
 const selectionsEqual = (first = {}, second = {}) => {
   const tableNames = new Set([...Object.keys(first), ...Object.keys(second)]);
 
@@ -100,6 +155,7 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
   const [selectedTemplateId, setSelectedTemplateId] = useState('');
   const [requestError, setRequestError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [templateWarning, setTemplateWarning] = useState('');
 
   const tables = useMemo(
     () =>
@@ -284,15 +340,11 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
 
     if (!template) return;
 
-    const templateSelections = Object.entries(template.white_list || {}).reduce(
-      (selections, [tableName, attributes]) => {
-        if (Array.isArray(attributes) && attributes.length > 0) {
-          selections[tableName] = normalizeAttributes(attributes);
-        }
-        return selections;
-      },
-      {},
+    const validationResult = validateSelectionsAgainstTables(
+      template.white_list,
+      tables,
     );
+    const templateSelections = validationResult.validSelections;
 
     setSelectedAttributesByTable(templateSelections);
     setExpandedTables(
@@ -307,6 +359,7 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
     setAvailableCheckedByTable({});
     setSelectedCheckedByTable({});
     setRequestError('');
+    setTemplateWarning(getSkippedSelectionsMessage(validationResult));
     setSuccessMessage(
       `${template.name} template loaded. Review the attributes and save to apply them to this request.`,
     );
@@ -330,9 +383,19 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
     setRequestError('');
     setSuccessMessage('');
 
+    const validationResult = validateSelectionsAgainstTables(
+      selectedAttributesByTable,
+      tables,
+    );
+    const validSelections = validationResult.validSelections;
+    const validationWarning = getSkippedSelectionsMessage(validationResult);
+
+    setSelectedAttributesByTable(validSelections);
+    setTemplateWarning(validationWarning);
+
     const tableNames = new Set([
       ...Object.keys(savedDatapointsByTable),
-      ...Object.keys(selectedAttributesByTable),
+      ...Object.keys(validSelections),
     ]);
 
     const requests = [];
@@ -340,7 +403,7 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
     tableNames.forEach((tableName) => {
       const savedDatapoint = savedDatapointsByTable[tableName];
       const selectedAttributes = normalizeAttributes(
-        selectedAttributesByTable[tableName] || [],
+        validSelections[tableName] || [],
       );
 
       if (!savedDatapoint && selectedAttributes.length > 0) {
@@ -476,6 +539,15 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
 
           {templateError && (
             <div className='data-request__request-error'>{templateError}</div>
+          )}
+
+          {templateWarning && (
+            <div
+              className='data-request-select-attributes__template-warning'
+              role='alert'
+            >
+              {templateWarning}
+            </div>
           )}
 
           <div className='data-request-select-attributes__columns'>

--- a/src/DataRequests/DataRequestSelectAttributes.jsx
+++ b/src/DataRequests/DataRequestSelectAttributes.jsx
@@ -25,7 +25,7 @@ export const validateSelectionsAgainstTables = (
   const skippedTables = [];
   const skippedAttributes = [];
 
-  Object.entries(selections).forEach(([tableName, attributes]) => {
+  Object.entries(selections || {}).forEach(([tableName, attributes]) => {
     if (!attributesByTable[tableName]) {
       skippedTables.push(tableName);
       return;
@@ -182,6 +182,7 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
         .sort((first, second) => first.title.localeCompare(second.title)),
     [dictionary],
   );
+  const isDictionaryLoaded = dictionary !== undefined && dictionary !== null;
 
   const tableTitlesById = useMemo(
     () =>
@@ -237,8 +238,8 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
   }, [dispatch, projectId, tables]);
 
   useEffect(() => {
-    loadProjectDatapoints();
-  }, [loadProjectDatapoints]);
+    if (isDictionaryLoaded) loadProjectDatapoints();
+  }, [isDictionaryLoaded, loadProjectDatapoints]);
 
   useEffect(() => {
     dispatch(fetchRequestConfigTemplates());

--- a/src/DataRequests/DataRequestSelectAttributes.jsx
+++ b/src/DataRequests/DataRequestSelectAttributes.jsx
@@ -106,6 +106,12 @@ const getSelectionsFromSavedDatapoints = (savedDatapoints) =>
     return result;
   }, {});
 
+export const validateSavedDatapointsAgainstTables = (savedDatapoints, tables) =>
+  validateSelectionsAgainstTables(
+    getSelectionsFromSavedDatapoints(savedDatapoints),
+    tables,
+  );
+
 const areAllAttributesChecked = (attributes = [], checkedAttributes = []) =>
   attributes.length > 0 &&
   attributes.every((attribute) => checkedAttributes.includes(attribute));
@@ -206,13 +212,17 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
     const savedDatapoints = buildSavedDatapointsByTable(
       action.payload?.data || [],
     );
+    const validationResult = validateSavedDatapointsAgainstTables(
+      savedDatapoints,
+      tables,
+    );
+    const validSelections = validationResult.validSelections;
 
     setSavedDatapointsByTable(savedDatapoints);
-    setSelectedAttributesByTable(
-      getSelectionsFromSavedDatapoints(savedDatapoints),
-    );
+    setSelectedAttributesByTable(validSelections);
+    setTemplateWarning(getSkippedSelectionsMessage(validationResult));
     setExpandedTables(
-      Object.keys(savedDatapoints).reduce(
+      Object.keys(validSelections).reduce(
         (expanded, tableName) => ({
           ...expanded,
           [`selected-${tableName}`]: true,
@@ -224,7 +234,7 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
     setSelectedCheckedByTable({});
     setIsLoading(false);
     return true;
-  }, [dispatch, projectId]);
+  }, [dispatch, projectId, tables]);
 
   useEffect(() => {
     loadProjectDatapoints();

--- a/src/DataRequests/DataRequestSelectAttributes.test.js
+++ b/src/DataRequests/DataRequestSelectAttributes.test.js
@@ -58,6 +58,14 @@ test('removes duplicate valid attributes', () => {
   ).toEqual({ subject: ['age'] });
 });
 
+test('handles a missing template white list', () => {
+  expect(validateSelectionsAgainstTables(null, tables)).toEqual({
+    validSelections: {},
+    skippedTables: [],
+    skippedAttributes: [],
+  });
+});
+
 test('validates previously saved datapoints against the current dictionary', () => {
   expect(
     validateSavedDatapointsAgainstTables(

--- a/src/DataRequests/DataRequestSelectAttributes.test.js
+++ b/src/DataRequests/DataRequestSelectAttributes.test.js
@@ -1,0 +1,56 @@
+import { validateSelectionsAgainstTables } from './DataRequestSelectAttributes';
+
+const tables = [
+  {
+    id: 'subject',
+    attributes: ['age', 'submitter_id'],
+  },
+  {
+    id: 'diagnosis',
+    attributes: ['disease_type'],
+  },
+];
+
+test('keeps template datapoints that exist in the project dictionary', () => {
+  expect(
+    validateSelectionsAgainstTables(
+      {
+        subject: ['submitter_id', 'age'],
+        diagnosis: ['disease_type'],
+      },
+      tables,
+    ),
+  ).toEqual({
+    validSelections: {
+      subject: ['age', 'submitter_id'],
+      diagnosis: ['disease_type'],
+    },
+    skippedTables: [],
+    skippedAttributes: [],
+  });
+});
+
+test('skips template tables and attributes missing from the dictionary', () => {
+  expect(
+    validateSelectionsAgainstTables(
+      {
+        subject: ['submitter_id', 'removed_attribute'],
+        molecular_analysis: ['gene_symbol'],
+      },
+      tables,
+    ),
+  ).toEqual({
+    validSelections: {
+      subject: ['submitter_id'],
+    },
+    skippedTables: ['molecular_analysis'],
+    skippedAttributes: ['subject.removed_attribute'],
+  });
+});
+
+test('removes duplicate valid attributes', () => {
+  expect(
+    validateSelectionsAgainstTables({ subject: ['age', 'age'] }, tables)
+      .validSelections,
+  ).toEqual({ subject: ['age'] });
+});

--- a/src/DataRequests/DataRequestSelectAttributes.test.js
+++ b/src/DataRequests/DataRequestSelectAttributes.test.js
@@ -1,4 +1,7 @@
-import { validateSelectionsAgainstTables } from './DataRequestSelectAttributes';
+import {
+  validateSavedDatapointsAgainstTables,
+  validateSelectionsAgainstTables,
+} from './DataRequestSelectAttributes';
 
 const tables = [
   {
@@ -53,4 +56,28 @@ test('removes duplicate valid attributes', () => {
     validateSelectionsAgainstTables({ subject: ['age', 'age'] }, tables)
       .validSelections,
   ).toEqual({ subject: ['age'] });
+});
+
+test('validates previously saved datapoints against the current dictionary', () => {
+  expect(
+    validateSavedDatapointsAgainstTables(
+      {
+        subject: {
+          id: 1,
+          value_list: ['age', 'removed_attribute'],
+        },
+        molecular_analysis: {
+          id: 2,
+          value_list: ['gene_symbol'],
+        },
+      },
+      tables,
+    ),
+  ).toEqual({
+    validSelections: {
+      subject: ['age'],
+    },
+    skippedTables: ['molecular_analysis'],
+    skippedAttributes: ['subject.removed_attribute'],
+  });
 });


### PR DESCRIPTION
Description about what this pull request does.

Adds validation for request datapoint templates using project's actual dictionary
- loads only tables and attributes that exist in current dictionary
- shows warning listing skipped/outdated datapoints
- validates selections to prevent invalid datapoints from reaching API 

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

- Implemented XXX

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
