### PR TITLE
PEDS-1641 Disabled datapoint actions during save

### DIFF
--- a/src/DataRequests/DataRequestSelectAttributes.jsx
+++ b/src/DataRequests/DataRequestSelectAttributes.jsx
@@ -13,6 +13,9 @@ import './DataRequestSelectAttributes.css';
 const normalizeAttributes = (attributes = []) =>
   [...new Set(attributes)].sort((a, b) => a.localeCompare(b));
 
+export const canTransferAttributes = (hasCheckedAttributes, isSaving) =>
+  hasCheckedAttributes && !isSaving;
+
 export const validateSelectionsAgainstTables = (
   selections = {},
   tables = [],
@@ -641,7 +644,10 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
                 label='Add selected attributes →'
                 buttonType='secondary'
                 onClick={moveAvailableAttributes}
-                enabled={hasAvailableCheckedAttributes}
+                enabled={canTransferAttributes(
+                  hasAvailableCheckedAttributes,
+                  isSaving,
+                )}
               />
             </section>
 
@@ -737,7 +743,10 @@ export default function DataRequestSelectAttributes({ projectId, onAction }) {
                 label='← Remove selected attributes'
                 buttonType='secondary'
                 onClick={removeSelectedAttributes}
-                enabled={hasSelectedCheckedAttributes}
+                enabled={canTransferAttributes(
+                  hasSelectedCheckedAttributes,
+                  isSaving,
+                )}
               />
             </section>
           </div>

--- a/src/DataRequests/DataRequestSelectAttributes.test.js
+++ b/src/DataRequests/DataRequestSelectAttributes.test.js
@@ -1,8 +1,15 @@
 import {
+  canTransferAttributes,
   toggleAllAttributes,
   validateSavedDatapointsAgainstTables,
   validateSelectionsAgainstTables,
 } from './DataRequestSelectAttributes';
+
+test('disables attribute transfers while attributes are saving', () => {
+  expect(canTransferAttributes(true, true)).toBe(false);
+  expect(canTransferAttributes(true, false)).toBe(true);
+  expect(canTransferAttributes(false, false)).toBe(false);
+});
 
 const tables = [
   {


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

- Disabled add and remove attribute buttons while datapoints are saving 

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
