### PR TITLE
PEDS-1599 feat(density-heatmap): progressive background category loading

### DIFF
--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/ExplorerDensityHeatmap.css
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/ExplorerDensityHeatmap.css
@@ -80,6 +80,13 @@
   border-left: 3px solid var(--g3-color__base-blue, #1769a3);
 }
 
+.explorer-density-heatmap__progress {
+  margin: 8px 0 0;
+  color: var(--g3-color__base-blue);
+  font-size: 13px;
+  font-weight: var(--g3-font__semi-bold-weight);
+}
+
 .explorer-density-heatmap__summary {
   display: grid;
   grid-template-columns: repeat(3, max-content);
@@ -205,6 +212,51 @@
 
 .explorer-density-heatmap__section .explorer-density-heatmap__row {
   padding: 12px 16px;
+}
+
+.explorer-density-heatmap__section--loading,
+.explorer-density-heatmap__section--pending {
+  opacity: 0.92;
+}
+
+.explorer-density-heatmap__section--error {
+  border-color: rgba(231, 76, 60, 0.35);
+}
+
+.explorer-density-heatmap__section-skeleton {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px 16px;
+}
+
+.explorer-density-heatmap__skeleton-row {
+  height: 14px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(125, 138, 156, 0.12) 0%,
+    rgba(125, 138, 156, 0.22) 50%,
+    rgba(125, 138, 156, 0.12) 100%
+  );
+  background-size: 200% 100%;
+  animation: explorer-density-heatmap-skeleton 1.4s ease-in-out infinite;
+}
+
+.explorer-density-heatmap__skeleton-row:nth-child(2) {
+  width: 88%;
+}
+
+.explorer-density-heatmap__skeleton-row:nth-child(3) {
+  width: 72%;
+}
+
+@keyframes explorer-density-heatmap-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 .explorer-density-heatmap__section

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/index.jsx
@@ -1,16 +1,18 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { capitalizeFirstLetter } from '../../utils';
-import { useAppSelector } from '../../redux/hooks';
-import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
-import { fetchWithCreds } from '../../utils.fetch';
-import { guppyGraphQLUrl } from '../../localconf';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import {
+  loadDensityHeatmap,
+  prioritizeDensityHeatmapCategory,
+} from '../../redux/explorer/densityHeatmapThunks';
 import UserAgreement from '../ExplorerSurvivalAnalysis/UserAgreement';
 
 import {
   extractFieldsFromFilter,
   formatDensityPercentage,
   getDensityHeatmapFieldLabel,
+  groupFieldPathsByCategory,
 } from './utils';
 import './ExplorerDensityHeatmap.css';
 
@@ -22,78 +24,6 @@ function checkUserAgreement() {
 
 function handleUserAgreement() {
   return window.localStorage.setItem(userAgreementLocalStorageKey, 'true');
-}
-
-function buildSelectionTree(fieldPaths) {
-  const root = {};
-
-  fieldPaths.forEach((fieldPath) => {
-    const segments = fieldPath.split('.').filter(Boolean);
-    let cursor = root;
-
-    segments.forEach((segment, index) => {
-      if (!cursor[segment]) {
-        cursor[segment] = {};
-      }
-
-      if (index === segments.length - 1) {
-        cursor[segment].__leaf = true;
-        return;
-      }
-
-      cursor = cursor[segment];
-    });
-  });
-
-  return root;
-}
-
-function renderSelectionTree(tree, depth = 0) {
-  const indent = '  '.repeat(depth);
-
-  return Object.entries(tree)
-    .map(([fieldName, child]) => {
-      const childEntries = Object.keys(child).filter((key) => key !== '__leaf');
-
-      if (child.__leaf || childEntries.length === 0) {
-        return `${indent}${fieldName} { histogram { key count } }`;
-      }
-
-      return `${indent}${fieldName} {
-${renderSelectionTree(child, depth + 1)}
-${indent}}`;
-    })
-    .join('\n');
-}
-
-function collectHistogramCount(node) {
-  if (node === null || node === undefined) {
-    return 0;
-  }
-
-  if (Array.isArray(node)) {
-    return node.reduce((sum, value) => sum + collectHistogramCount(value), 0);
-  }
-
-  if (typeof node !== 'object') {
-    return 0;
-  }
-
-  let total = 0;
-  if (Array.isArray(node.histogram)) {
-    total += node.histogram.reduce(
-      (sum, bucket) => sum + Math.max(bucket?.count ?? 0, 0),
-      0,
-    );
-  }
-
-  for (const value of Object.values(node)) {
-    if (value && typeof value === 'object') {
-      total += collectHistogramCount(value);
-    }
-  }
-
-  return total;
 }
 
 /**
@@ -117,13 +47,17 @@ function ExplorerDensityHeatmap({
   dataType,
   fieldInfo = {},
 }) {
+  const dispatch = useAppDispatch();
   const [isUserCompliant, setIsUserCompliant] = useState(checkUserAgreement());
-  const [densityRows, setDensityRows] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState('');
   const [showAllFields, setShowAllFields] = useState(false);
+  const sectionObserverRef = useRef(/** @type {IntersectionObserver | null} */ (null));
+  const sectionNodeMapRef = useRef(/** @type {Map<string, Element>} */ (new Map()));
+
   const guppyConfigDataType = useAppSelector(
     (state) => state.explorer.config.guppyConfig.dataType,
+  );
+  const densityHeatmapResult = useAppSelector(
+    (state) => state.explorer.densityHeatmapResult,
   );
   const activeDataType = dataType || guppyConfigDataType;
   const propFieldPaths = useMemo(
@@ -131,7 +65,6 @@ function ExplorerDensityHeatmap({
     [fields],
   );
 
-  // Extract field names from active filter selections
   const secondaryFields = useMemo(
     () => (expandByFilter ? extractFieldsFromFilter(filter) : []),
     [expandByFilter, filter],
@@ -145,16 +78,13 @@ function ExplorerDensityHeatmap({
   const hasPrimaryFields = primaryFields.length > 0;
 
   const fieldPaths = useMemo(() => {
-    // If showAllFields or no primary fields configured, use all available fields
     if (showAllFields || !hasPrimaryFields) {
       return propFieldPaths;
     }
 
-    // Combine primary + secondary (filter-derived) fields
     const combined = new Set([...primaryFields]);
     secondaryFields.forEach((f) => combined.add(f));
 
-    // Filter by what's actually available in the schema
     const available = new Set(propFieldPaths);
 
     return [...combined].filter((path) => available.has(path));
@@ -166,89 +96,76 @@ function ExplorerDensityHeatmap({
     showAllFields,
   ]);
 
-  const fieldQuery = useMemo(() => {
-    if (!fieldPaths.length) return '';
-
-    return renderSelectionTree(buildSelectionTree(fieldPaths));
-  }, [fieldPaths]);
-
   useEffect(() => {
-    if (!isUserCompliant || !fieldQuery || !activeDataType) {
-      setDensityRows([]);
-      setError('');
-      return undefined;
-    }
+    if (!isUserCompliant) return undefined;
 
-    let isCancelled = false;
+    dispatch(
+      loadDensityHeatmap({
+        dataType: activeDataType,
+        fieldPaths,
+        filter,
+        totalCount,
+      }),
+    );
 
-    async function loadDensityData() {
-      setIsLoading(true);
-      setError('');
-
-      try {
-        const query = `query ($filter_main: JSON) {
-          _aggregation {
-            main: ${activeDataType}(filter: $filter_main, accessibility: all) {
-              ${fieldQuery}
-            }
-          }
-        }`;
-        const body = {
-          query,
-          variables: { filter_main: getGQLFilter(filter) ?? {} },
-        };
-        const response = await fetchWithCreds({
-          path: guppyGraphQLUrl,
-          method: 'POST',
-          body: JSON.stringify(body),
-        });
-        const aggregation = response?.data?.data?._aggregation?.main;
-        const nextRows = fieldPaths.map((fieldPath) => {
-          const selection = fieldPath
-            .split('.')
-            .filter(Boolean)
-            .reduce((current, segment) => current?.[segment], aggregation);
-          const availableCount = collectHistogramCount(selection);
-          const completeness =
-            totalCount > 0 ? Math.min(availableCount / totalCount, 1) : 0;
-
-          return {
-            availableCount,
-            completeness,
-            field: fieldPath,
-            missingCount: Math.max(totalCount - availableCount, 0),
-          };
-        });
-
-        if (!isCancelled) {
-          setDensityRows(nextRows);
-        }
-      } catch (err) {
-        if (!isCancelled) {
-          setError('Unable to load density data from the GraphQL API.');
-          setDensityRows([]);
-        }
-        console.error(err); // eslint-disable-line no-console
-      } finally {
-        if (!isCancelled) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    loadDensityData();
-
-    return () => {
-      isCancelled = true;
-    };
+    return undefined;
   }, [
     activeDataType,
+    dispatch,
     fieldPaths,
-    fieldQuery,
     filter,
     isUserCompliant,
     totalCount,
   ]);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+
+    sectionObserverRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const categoryKey = /** @type {HTMLElement} */ (entry.target).dataset
+            .categoryKey;
+          if (categoryKey) prioritizeDensityHeatmapCategory(categoryKey);
+        });
+      },
+      { root: null, rootMargin: '120px 0px', threshold: 0.01 },
+    );
+
+    sectionNodeMapRef.current.forEach((node) => {
+      sectionObserverRef.current?.observe(node);
+    });
+
+    return () => {
+      sectionObserverRef.current?.disconnect();
+      sectionObserverRef.current = null;
+    };
+  }, []);
+
+  /**
+   * @param {string} categoryKey
+   * @param {HTMLElement | null} node
+   */
+  function bindSectionNode(categoryKey, node) {
+    const previous = sectionNodeMapRef.current.get(categoryKey);
+    if (previous && previous !== node) {
+      sectionObserverRef.current?.unobserve(previous);
+      sectionNodeMapRef.current.delete(categoryKey);
+    }
+    if (node) {
+      sectionNodeMapRef.current.set(categoryKey, node);
+      sectionObserverRef.current?.observe(node);
+    }
+  }
+
+  const densityRows = useMemo(
+    () =>
+      fieldPaths
+        .map((fieldPath) => densityHeatmapResult.rowsByField[fieldPath])
+        .filter(Boolean),
+    [densityHeatmapResult.rowsByField, fieldPaths],
+  );
 
   const stats = useMemo(
     () => [
@@ -258,88 +175,85 @@ function ExplorerDensityHeatmap({
     [fieldPaths.length, totalCount],
   );
 
-  /** Groups density rows by top-level field prefix, then wraps them in sections */
-  function groupRows(rows) {
-    const groups = [];
-    const groupIndex = new Map();
-
-    rows.forEach((row) => {
-      const groupKey = row.field.split('.')[0] || row.field;
-      if (!groupIndex.has(groupKey)) {
-        groupIndex.set(groupKey, groups.length);
-        groups.push({ key: groupKey, rows: [] });
-      }
-
-      groups[groupIndex.get(groupKey)].rows.push({
-        ...row,
-        groupKey,
-      });
-    });
-
-    return groups.map((group) => ({
-      ...group,
-      label: capitalizeFirstLetter(group.key.split('_').join(' ')),
-    }));
-  }
-
   const secondaryFieldSet = useMemo(
     () => new Set(secondaryFields),
     [secondaryFields],
   );
 
-  const groupedDensityRows = useMemo(() => {
-    // When there are no primary fields (or showAllFields is on),
-    // fall back to the original flat grouping
+  /**
+   * Stable category-ordered sections (loaded rows or skeleton placeholders).
+   * Order follows fieldPaths grouping so sections do not jump as batches arrive.
+   */
+  const matrixSections = useMemo(() => {
+    /**
+     * @param {string[]} partitionFields
+     * @param {'all' | 'primary' | 'secondary' | 'expanded'} sectionType
+     */
+    function buildSections(partitionFields, sectionType) {
+      if (partitionFields.length === 0) return [];
+
+      return groupFieldPathsByCategory(partitionFields).map(
+        ({ key, fields }) => {
+          const rows = fields
+            .map((fieldPath) => densityHeatmapResult.rowsByField[fieldPath])
+            .filter(Boolean);
+          const status =
+            densityHeatmapResult.categoryStatus[key] || 'pending';
+
+          if (rows.length > 0) {
+            return {
+              key,
+              label: capitalizeFirstLetter(key.split('_').join(' ')),
+              rows: rows.map((row) => ({ ...row, groupKey: key })),
+              sectionType,
+              status: 'loaded',
+              fieldCount: fields.length,
+            };
+          }
+
+          return {
+            key,
+            label: capitalizeFirstLetter(key.split('_').join(' ')),
+            rows: [],
+            sectionType,
+            status,
+            fieldCount: fields.length,
+          };
+        },
+      );
+    }
+
     if (!hasPrimaryFields || showAllFields) {
-      const allGroups = groupRows(densityRows);
-      return allGroups.map((g) => ({ ...g, sectionType: 'all' }));
+      return buildSections(fieldPaths, 'all');
     }
 
-    // Partition rows into primary, secondary, and expanded
-    const primaryRows = [];
-    const secondaryRows = [];
-    const expandedRows = [];
+    const primaryPartition = fieldPaths.filter((field) =>
+      primaryFieldSet.has(field),
+    );
+    const secondaryPartition = fieldPaths.filter(
+      (field) =>
+        secondaryFieldSet.has(field) && !primaryFieldSet.has(field),
+    );
+    const expandedPartition = fieldPaths.filter(
+      (field) =>
+        !primaryFieldSet.has(field) && !secondaryFieldSet.has(field),
+    );
 
-    densityRows.forEach((row) => {
-      if (primaryFieldSet.has(row.field)) {
-        primaryRows.push(row);
-      } else if (secondaryFieldSet.has(row.field)) {
-        secondaryRows.push(row);
-      } else {
-        expandedRows.push(row);
-      }
-    });
-
-    const sections = [];
-
-    if (primaryRows.length > 0) {
-      groupRows(primaryRows).forEach((g) =>
-        sections.push({ ...g, sectionType: 'primary' }),
-      );
-    }
-
-    if (secondaryRows.length > 0) {
-      groupRows(secondaryRows).forEach((g) =>
-        sections.push({ ...g, sectionType: 'secondary' }),
-      );
-    }
-
-    if (expandedRows.length > 0) {
-      groupRows(expandedRows).forEach((g) =>
-        sections.push({ ...g, sectionType: 'expanded' }),
-      );
-    }
-
-    return sections;
+    return [
+      ...buildSections(primaryPartition, 'primary'),
+      ...buildSections(secondaryPartition, 'secondary'),
+      ...buildSections(expandedPartition, 'expanded'),
+    ];
   }, [
-    densityRows,
+    densityHeatmapResult.categoryStatus,
+    densityHeatmapResult.rowsByField,
+    fieldPaths,
     hasPrimaryFields,
     primaryFieldSet,
     secondaryFieldSet,
     showAllFields,
   ]);
 
-  /** How many total fields are available from the schema mapping */
   const allFieldCount = propFieldPaths.length;
 
   const canShowToggle =
@@ -355,74 +269,116 @@ function ExplorerDensityHeatmap({
     return group.label;
   }
 
+  const hasLoadedRows = densityRows.length > 0;
+  const isBootstrapping =
+    densityHeatmapResult.isPending &&
+    !hasLoadedRows &&
+    matrixSections.length === 0 &&
+    !densityHeatmapResult.error;
+  const showFatalError =
+    !hasLoadedRows &&
+    !!densityHeatmapResult.error &&
+    !densityHeatmapResult.isPending;
+
   let heatmapContent = null;
-  if (isLoading) {
+  if (isBootstrapping) {
     heatmapContent = (
-      <div className='explorer-density-heatmap__state'>Loading...</div>
+      <div className='explorer-density-heatmap__state'>
+        Loading categories...
+      </div>
     );
-  } else if (error) {
+  } else if (showFatalError) {
     heatmapContent = (
       <div className='explorer-density-heatmap__state explorer-density-heatmap__state--error'>
-        {error}
+        {densityHeatmapResult.error}
       </div>
     );
-  } else if (groupedDensityRows.length > 0) {
-    heatmapContent = groupedDensityRows.map((group) => (
-      <div
-        className={`explorer-density-heatmap__section${
-          group.sectionType === 'secondary'
-            ? ' explorer-density-heatmap__section--secondary'
-            : ''
-        }`}
-        key={`${group.sectionType}-${group.key}`}
-      >
-        <div className='explorer-density-heatmap__section-header'>
-          <h3 className='explorer-density-heatmap__section-title'>
-            {getSectionLabel(group)}
-            {group.sectionType === 'secondary' && (
-              <span className='explorer-density-heatmap__badge'>
-                Active Filters
-              </span>
-            )}
-          </h3>
-          <span className='explorer-density-heatmap__section-count'>
-            {group.rows.length} field
-            {group.rows.length === 1 ? '' : 's'}
-          </span>
-        </div>
+  } else if (matrixSections.length > 0) {
+    heatmapContent = matrixSections.map((group) => {
+      const isLoaded = group.status === 'loaded';
+      const sectionRefKey = `${group.sectionType}-${group.key}`;
 
-        {group.rows.map((row) => (
-          <div className='explorer-density-heatmap__row' key={row.field}>
-            <div className='explorer-density-heatmap__field-name'>
-              {getFieldLabel(row.field)}
-              <span className='explorer-density-heatmap__field-path'>
-                {row.field}
-              </span>
-            </div>
-
-            <div
-              className='explorer-density-heatmap__strip'
-              aria-label={`${row.field} completeness ${formatDensityPercentage(row.completeness)}`}
-            >
-              <div
-                className='explorer-density-heatmap__strip-fill'
-                style={{
-                  clipPath: `inset(0 ${100 - row.completeness * 100}% 0 0)`,
-                }}
-              />
-            </div>
-
-            <div className='explorer-density-heatmap__counts'>
-              <span className='explorer-density-heatmap__bar-label'>
-                {formatDensityPercentage(row.completeness)} complete
-              </span>
-              <span>{row.availableCount.toLocaleString()} available</span>
-              <span>{row.missingCount.toLocaleString()} missing</span>
-            </div>
+      return (
+        <div
+          className={`explorer-density-heatmap__section${
+            group.sectionType === 'secondary'
+              ? ' explorer-density-heatmap__section--secondary'
+              : ''
+          }${
+            isLoaded
+              ? ''
+              : ` explorer-density-heatmap__section--${group.status}`
+          }`}
+          data-category-key={group.key}
+          key={sectionRefKey}
+          ref={(node) => bindSectionNode(sectionRefKey, node)}
+        >
+          <div className='explorer-density-heatmap__section-header'>
+            <h3 className='explorer-density-heatmap__section-title'>
+              {getSectionLabel(group)}
+              {group.sectionType === 'secondary' && (
+                <span className='explorer-density-heatmap__badge'>
+                  Active Filters
+                </span>
+              )}
+            </h3>
+            <span className='explorer-density-heatmap__section-count'>
+              {isLoaded
+                ? `${group.rows.length} field${
+                    group.rows.length === 1 ? '' : 's'
+                  }`
+                : group.status === 'error'
+                  ? 'Failed to load'
+                  : `Loading ${group.fieldCount} field${
+                      group.fieldCount === 1 ? '' : 's'
+                    }...`}
+            </span>
           </div>
-        ))}
-      </div>
-    ));
+
+          {isLoaded ? (
+            group.rows.map((row) => (
+              <div className='explorer-density-heatmap__row' key={row.field}>
+                <div className='explorer-density-heatmap__field-name'>
+                  {getFieldLabel(row.field)}
+                  <span className='explorer-density-heatmap__field-path'>
+                    {row.field}
+                  </span>
+                </div>
+
+                <div
+                  className='explorer-density-heatmap__strip'
+                  aria-label={`${row.field} completeness ${formatDensityPercentage(row.completeness)}`}
+                >
+                  <div
+                    className='explorer-density-heatmap__strip-fill'
+                    style={{
+                      clipPath: `inset(0 ${100 - row.completeness * 100}% 0 0)`,
+                    }}
+                  />
+                </div>
+
+                <div className='explorer-density-heatmap__counts'>
+                  <span className='explorer-density-heatmap__bar-label'>
+                    {formatDensityPercentage(row.completeness)} complete
+                  </span>
+                  <span>{row.availableCount.toLocaleString()} available</span>
+                  <span>{row.missingCount.toLocaleString()} missing</span>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div
+              className='explorer-density-heatmap__section-skeleton'
+              aria-hidden
+            >
+              <div className='explorer-density-heatmap__skeleton-row' />
+              <div className='explorer-density-heatmap__skeleton-row' />
+              <div className='explorer-density-heatmap__skeleton-row' />
+            </div>
+          )}
+        </div>
+      );
+    });
   } else {
     heatmapContent = (
       <div className='explorer-density-heatmap__state'>
@@ -443,6 +399,13 @@ function ExplorerDensityHeatmap({
               <p className='explorer-density-heatmap__description'>
                 Field availability and completeness across the dataset
               </p>
+              {densityHeatmapResult.isPending && hasLoadedRows && (
+                <p className='explorer-density-heatmap__progress'>
+                  Loading categories in the background (
+                  {densityHeatmapResult.loadedCount}/
+                  {densityHeatmapResult.totalCategories})
+                </p>
+              )}
             </div>
             <div className='explorer-density-heatmap__header-right'>
               {canShowToggle && (

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.js
@@ -22,6 +22,178 @@ export function collectDensityHeatmapFields({
   return orderedFields;
 }
 
+/** @param {string} fieldPath */
+export function getDensityFieldCategoryKey(fieldPath) {
+  const [head] = String(fieldPath).split('.').filter(Boolean);
+  return head || String(fieldPath);
+}
+
+/**
+ * Groups field paths by top-level category prefix, preserving first-seen order.
+ * @param {string[]} fieldPaths
+ * @returns {{ key: string, fields: string[] }[]}
+ */
+export function groupFieldPathsByCategory(fieldPaths = []) {
+  /** @type {{ key: string, fields: string[] }[]} */
+  const groups = [];
+  /** @type {Map<string, number>} */
+  const groupIndex = new Map();
+
+  fieldPaths.forEach((fieldPath) => {
+    const key = getDensityFieldCategoryKey(fieldPath);
+    if (!groupIndex.has(key)) {
+      groupIndex.set(key, groups.length);
+      groups.push({ key, fields: [] });
+    }
+    groups[groupIndex.get(key)].fields.push(fieldPath);
+  });
+
+  return groups;
+}
+
+/**
+ * Stable cache key for a density job (filter + fields + data type + cohort size).
+ * @param {{
+ *  dataType: string;
+ *  fieldPaths: string[];
+ *  gqlFilter: object;
+ *  totalCount: number;
+ * }} args
+ */
+export function buildDensityHeatmapCacheKey({
+  dataType,
+  fieldPaths = [],
+  gqlFilter = {},
+  totalCount = 0,
+}) {
+  return JSON.stringify({
+    dataType,
+    fieldPaths: [...fieldPaths].sort(),
+    gqlFilter,
+    totalCount,
+  });
+}
+
+/** @param {string[]} fieldPaths */
+export function buildSelectionTree(fieldPaths) {
+  const root = {};
+
+  fieldPaths.forEach((fieldPath) => {
+    const segments = fieldPath.split('.').filter(Boolean);
+    let cursor = root;
+
+    segments.forEach((segment, index) => {
+      if (!cursor[segment]) {
+        cursor[segment] = {};
+      }
+
+      if (index === segments.length - 1) {
+        cursor[segment].__leaf = true;
+        return;
+      }
+
+      cursor = cursor[segment];
+    });
+  });
+
+  return root;
+}
+
+/** @param {object} tree @param {number} [depth] */
+export function renderSelectionTree(tree, depth = 0) {
+  const indent = '  '.repeat(depth);
+
+  return Object.entries(tree)
+    .map(([fieldName, child]) => {
+      const childEntries = Object.keys(child).filter((key) => key !== '__leaf');
+
+      if (child.__leaf || childEntries.length === 0) {
+        return `${indent}${fieldName} { histogram { key count } }`;
+      }
+
+      return `${indent}${fieldName} {
+${renderSelectionTree(child, depth + 1)}
+${indent}}`;
+    })
+    .join('\n');
+}
+
+/**
+ * @param {string} dataType
+ * @param {string[]} fieldPaths
+ */
+export function buildCategoryAggregationQuery(dataType, fieldPaths) {
+  const selection = renderSelectionTree(buildSelectionTree(fieldPaths));
+  return `query ($filter_main: JSON) {
+          _aggregation {
+            main: ${dataType}(filter: $filter_main, accessibility: all) {
+${selection}
+            }
+          }
+        }`;
+}
+
+/** @param {any} node */
+export function collectHistogramCount(node) {
+  if (node === null || node === undefined) {
+    return 0;
+  }
+
+  if (Array.isArray(node)) {
+    return node.reduce((sum, value) => sum + collectHistogramCount(value), 0);
+  }
+
+  if (typeof node !== 'object') {
+    return 0;
+  }
+
+  let total = 0;
+  if (Array.isArray(node.histogram)) {
+    total += node.histogram.reduce(
+      (sum, bucket) => sum + Math.max(bucket?.count ?? 0, 0),
+      0,
+    );
+  }
+
+  for (const value of Object.values(node)) {
+    if (value && typeof value === 'object') {
+      total += collectHistogramCount(value);
+    }
+  }
+
+  return total;
+}
+
+/**
+ * @param {{
+ *  aggregation: any;
+ *  fieldPaths: string[];
+ *  totalCount: number;
+ * }} args
+ */
+export function parseDensityRowsFromAggregation({
+  aggregation,
+  fieldPaths = [],
+  totalCount = 0,
+}) {
+  return fieldPaths.map((fieldPath) => {
+    const selection = fieldPath
+      .split('.')
+      .filter(Boolean)
+      .reduce((current, segment) => current?.[segment], aggregation);
+    const availableCount = collectHistogramCount(selection);
+    const completeness =
+      totalCount > 0 ? Math.min(availableCount / totalCount, 1) : 0;
+
+    return {
+      availableCount,
+      completeness,
+      field: fieldPath,
+      missingCount: Math.max(totalCount - availableCount, 0),
+    };
+  });
+}
+
 /**
  * Prefer fieldMapping / filterConfig.info label; otherwise strip the first
  * path segment (node/table) so nested fields read as attribute names only.

--- a/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
+++ b/src/GuppyDataExplorer/ExplorerDensityHeatmap/utils.test.js
@@ -1,11 +1,16 @@
 import {
+  buildCategoryAggregationQuery,
+  buildDensityHeatmapCacheKey,
   buildDensityHeatmapModel,
   collectDensityHeatmapFields,
+  collectHistogramCount,
   extractFieldsFromFilter,
   formatDensityPercentage,
   getDensityHeatmapColor,
   getDensityHeatmapFieldLabel,
+  groupFieldPathsByCategory,
   hasHeatmapFieldValue,
+  parseDensityRowsFromAggregation,
 } from './utils';
 
 describe('Explorer density heatmap helpers', () => {
@@ -98,6 +103,95 @@ describe('Explorer density heatmap helpers', () => {
     expect(getDensityHeatmapColor(0.25)).toBe('#ee833e');
     expect(getDensityHeatmapColor(0.5)).toBe('#f4b940');
     expect(getDensityHeatmapColor(1.0)).toBe('#7ec500');
+  });
+});
+
+describe('progressive density helpers', () => {
+  it('groups field paths by top-level category in first-seen order', () => {
+    expect(
+      groupFieldPathsByCategory([
+        'histologies.age',
+        'studies.name',
+        'histologies.stage',
+        'race',
+      ]),
+    ).toEqual([
+      { key: 'histologies', fields: ['histologies.age', 'histologies.stage'] },
+      { key: 'studies', fields: ['studies.name'] },
+      { key: 'race', fields: ['race'] },
+    ]);
+  });
+
+  it('builds a stable cache key independent of field order', () => {
+    const a = buildDensityHeatmapCacheKey({
+      dataType: 'subject',
+      fieldPaths: ['b', 'a'],
+      gqlFilter: { race: { selectedValues: ['White'] } },
+      totalCount: 10,
+    });
+    const b = buildDensityHeatmapCacheKey({
+      dataType: 'subject',
+      fieldPaths: ['a', 'b'],
+      gqlFilter: { race: { selectedValues: ['White'] } },
+      totalCount: 10,
+    });
+    expect(a).toBe(b);
+  });
+
+  it('builds a per-category aggregation query', () => {
+    const query = buildCategoryAggregationQuery('subject', [
+      'histologies.age',
+      'histologies.stage',
+    ]);
+    expect(query).toContain('main: subject(filter: $filter_main, accessibility: all)');
+    expect(query).toContain('histologies');
+    expect(query).toContain('age { histogram { key count } }');
+    expect(query).toContain('stage { histogram { key count } }');
+  });
+
+  it('parses density rows from an aggregation payload', () => {
+    const rows = parseDensityRowsFromAggregation({
+      aggregation: {
+        histologies: {
+          age: { histogram: [{ key: '1', count: 4 }] },
+          stage: { histogram: [{ key: 'I', count: 1 }, { key: 'II', count: 1 }] },
+        },
+      },
+      fieldPaths: ['histologies.age', 'histologies.stage'],
+      totalCount: 10,
+    });
+
+    expect(rows).toEqual([
+      {
+        availableCount: 4,
+        completeness: 0.4,
+        field: 'histologies.age',
+        missingCount: 6,
+      },
+      {
+        availableCount: 2,
+        completeness: 0.2,
+        field: 'histologies.stage',
+        missingCount: 8,
+      },
+    ]);
+    expect(collectHistogramCount(null)).toBe(0);
+  });
+
+  it('ignores stale job results when cache keys differ', () => {
+    const activeKey = buildDensityHeatmapCacheKey({
+      dataType: 'subject',
+      fieldPaths: ['race'],
+      gqlFilter: {},
+      totalCount: 1,
+    });
+    const staleKey = buildDensityHeatmapCacheKey({
+      dataType: 'subject',
+      fieldPaths: ['race'],
+      gqlFilter: { sex: { selectedValues: ['Female'] } },
+      totalCount: 1,
+    });
+    expect(activeKey).not.toBe(staleKey);
   });
 });
 

--- a/src/redux/explorer/densityHeatmapAPI.js
+++ b/src/redux/explorer/densityHeatmapAPI.js
@@ -1,0 +1,47 @@
+import { fetchWithCreds } from '../utils.fetch';
+import { guppyGraphQLUrl } from '../../localconf';
+import {
+  buildCategoryAggregationQuery,
+  parseDensityRowsFromAggregation,
+} from '../../GuppyDataExplorer/ExplorerDensityHeatmap/utils';
+
+/**
+ * Fetch density rows for one category (field-path group).
+ * @param {{
+ *  dataType: string;
+ *  fieldPaths: string[];
+ *  gqlFilter: object;
+ *  totalCount: number;
+ *  signal?: AbortSignal;
+ * }} args
+ */
+export async function fetchCategoryDensity({
+  dataType,
+  fieldPaths,
+  gqlFilter,
+  totalCount,
+  signal,
+}) {
+  const body = {
+    query: buildCategoryAggregationQuery(dataType, fieldPaths),
+    variables: { filter_main: gqlFilter ?? {} },
+  };
+
+  const response = await fetchWithCreds({
+    path: guppyGraphQLUrl,
+    method: 'POST',
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (response?.data?.errors?.length) {
+    throw new Error(response.data.errors[0]?.message || 'GraphQL error');
+  }
+
+  const aggregation = response?.data?.data?._aggregation?.main;
+  return parseDensityRowsFromAggregation({
+    aggregation,
+    fieldPaths,
+    totalCount,
+  });
+}

--- a/src/redux/explorer/densityHeatmapThunks.js
+++ b/src/redux/explorer/densityHeatmapThunks.js
@@ -1,0 +1,172 @@
+import { getGQLFilter } from '../../GuppyComponents/Utils/queries';
+import {
+  buildDensityHeatmapCacheKey,
+  groupFieldPathsByCategory,
+} from '../../GuppyDataExplorer/ExplorerDensityHeatmap/utils';
+import { fetchCategoryDensity } from './densityHeatmapAPI';
+import {
+  densityHeatmapCategoryFailed,
+  densityHeatmapCategoryLoaded,
+  densityHeatmapCategoryLoading,
+  densityHeatmapJobFinished,
+  densityHeatmapJobStarted,
+  resetDensityHeatmapResult,
+} from './slice';
+
+const CONCURRENCY = 2;
+
+let jobGeneration = 0;
+/** @type {AbortController | null} */
+let jobAbortController = null;
+/** @type {Set<string>} */
+let priorityCategoryKeys = new Set();
+
+/**
+ * Prefer loading a category next (e.g. when its section scrolls into view).
+ * @param {string} categoryKey
+ */
+export function prioritizeDensityHeatmapCategory(categoryKey) {
+  if (categoryKey) priorityCategoryKeys.add(categoryKey);
+}
+
+/**
+ * Progressive, cancellable density load: one category at a time, concurrency 2.
+ * Survives leaving the heatmap view because work is owned by Redux + this module.
+ *
+ * @param {{
+ *  dataType: string;
+ *  fieldPaths: string[];
+ *  filter: object;
+ *  totalCount: number;
+ * }} args
+ */
+export function loadDensityHeatmap(args) {
+  return async (dispatch, getState) => {
+    const { dataType, fieldPaths = [], filter = {}, totalCount = 0 } = args;
+
+    if (!dataType || fieldPaths.length === 0) {
+      jobGeneration += 1;
+      if (jobAbortController) jobAbortController.abort();
+      jobAbortController = null;
+      priorityCategoryKeys = new Set();
+      dispatch(resetDensityHeatmapResult());
+      return;
+    }
+
+    const gqlFilter = getGQLFilter(filter) ?? {};
+    const cacheKey = buildDensityHeatmapCacheKey({
+      dataType,
+      fieldPaths,
+      gqlFilter,
+      totalCount,
+    });
+    const categories = groupFieldPathsByCategory(fieldPaths);
+    const current = getState().explorer.densityHeatmapResult;
+
+    if (current.cacheKey === cacheKey) {
+      if (current.isPending) return;
+      if (
+        current.totalCategories > 0 &&
+        current.loadedCount >= current.totalCategories
+      ) {
+        return;
+      }
+    }
+
+    jobGeneration += 1;
+    const myGeneration = jobGeneration;
+    if (jobAbortController) jobAbortController.abort();
+    jobAbortController = new AbortController();
+    const { signal } = jobAbortController;
+    priorityCategoryKeys = new Set();
+
+    const resumeSameJob = current.cacheKey === cacheKey;
+    const alreadyLoaded = new Set(
+      resumeSameJob ? current.loadedCategoryKeys : [],
+    );
+
+    dispatch(
+      densityHeatmapJobStarted({
+        cacheKey,
+        categoryKeys: categories.map((category) => category.key),
+        keepRows: resumeSameJob,
+      }),
+    );
+
+    /** @type {{ key: string, fields: string[] }[]} */
+    const queue = categories.filter(
+      (category) => !alreadyLoaded.has(category.key),
+    );
+
+    /**
+     * @param {{ key: string, fields: string[] }} category
+     */
+    async function fetchOne(category) {
+      if (myGeneration !== jobGeneration) return;
+
+      dispatch(
+        densityHeatmapCategoryLoading({
+          cacheKey,
+          categoryKey: category.key,
+        }),
+      );
+
+      try {
+        const rows = await fetchCategoryDensity({
+          dataType,
+          fieldPaths: category.fields,
+          gqlFilter,
+          totalCount,
+          signal,
+        });
+        if (myGeneration !== jobGeneration) return;
+        dispatch(
+          densityHeatmapCategoryLoaded({
+            cacheKey,
+            categoryKey: category.key,
+            rows,
+          }),
+        );
+      } catch (err) {
+        if (err?.name === 'AbortError') return;
+        if (myGeneration !== jobGeneration) return;
+        // eslint-disable-next-line no-console
+        console.error(err);
+        dispatch(
+          densityHeatmapCategoryFailed({
+            cacheKey,
+            categoryKey: category.key,
+            error: 'Unable to load density data from the GraphQL API.',
+          }),
+        );
+      }
+    }
+
+    async function worker() {
+      while (myGeneration === jobGeneration) {
+        if (queue.length === 0) break;
+
+        let nextIndex = queue.findIndex((category) =>
+          priorityCategoryKeys.has(category.key),
+        );
+        if (nextIndex === -1) nextIndex = 0;
+
+        const [category] = queue.splice(nextIndex, 1);
+        priorityCategoryKeys.delete(category.key);
+        await fetchOne(category);
+      }
+    }
+
+    const workerCount = Math.min(CONCURRENCY, queue.length);
+    if (workerCount > 0) {
+      await Promise.all(
+        Array.from({ length: workerCount }, () => worker()),
+      );
+    }
+
+    if (myGeneration === jobGeneration) {
+      dispatch(densityHeatmapJobFinished({ cacheKey }));
+      jobAbortController = null;
+    }
+  };
+}

--- a/src/redux/explorer/slice.js
+++ b/src/redux/explorer/slice.js
@@ -73,6 +73,17 @@ const slice = createSlice({
       error: null,
       isPending: false,
     },
+    densityHeatmapResult: {
+      cacheKey: null,
+      categoryOrder: [],
+      categoryStatus: {},
+      error: null,
+      isPending: false,
+      loadedCategoryKeys: [],
+      loadedCount: 0,
+      rowsByField: {},
+      totalCategories: 0,
+    },
     workspaces: initialWorkspaces,
   }),
   reducers: {
@@ -283,6 +294,112 @@ const slice = createSlice({
         isPending: false,
       };
     },
+    /**
+     * @param {PayloadAction<{
+     *  cacheKey: string;
+     *  categoryKeys: string[];
+     *  keepRows?: boolean;
+     * }>} action
+     */
+    densityHeatmapJobStarted(state, action) {
+      const { cacheKey, categoryKeys, keepRows = false } = action.payload;
+      const previousRows = keepRows
+        ? { ...state.densityHeatmapResult.rowsByField }
+        : {};
+      const previousLoaded = keepRows
+        ? [...state.densityHeatmapResult.loadedCategoryKeys]
+        : [];
+      const retainedLoaded = previousLoaded.filter((key) =>
+        categoryKeys.includes(key),
+      );
+      /** @type {ExplorerState['densityHeatmapResult']['categoryStatus']} */
+      const categoryStatus = {};
+      categoryKeys.forEach((key) => {
+        categoryStatus[key] = retainedLoaded.includes(key)
+          ? 'loaded'
+          : 'pending';
+      });
+
+      state.densityHeatmapResult = {
+        cacheKey,
+        categoryOrder: categoryKeys,
+        categoryStatus,
+        error: null,
+        isPending: true,
+        loadedCategoryKeys: retainedLoaded,
+        loadedCount: retainedLoaded.length,
+        rowsByField: previousRows,
+        totalCategories: categoryKeys.length,
+      };
+    },
+    /**
+     * @param {PayloadAction<{ cacheKey: string; categoryKey: string }>} action
+     */
+    densityHeatmapCategoryLoading(state, action) {
+      const { cacheKey, categoryKey } = action.payload;
+      if (state.densityHeatmapResult.cacheKey !== cacheKey) return;
+      state.densityHeatmapResult.categoryStatus[categoryKey] = 'loading';
+      state.densityHeatmapResult.error = null;
+    },
+    /**
+     * @param {PayloadAction<{
+     *  cacheKey: string;
+     *  categoryKey: string;
+     *  rows: ExplorerState['densityHeatmapResult']['rowsByField'][string][];
+     * }>} action
+     */
+    densityHeatmapCategoryLoaded(state, action) {
+      const { cacheKey, categoryKey, rows } = action.payload;
+      if (state.densityHeatmapResult.cacheKey !== cacheKey) return;
+
+      rows.forEach((row) => {
+        state.densityHeatmapResult.rowsByField[row.field] = row;
+      });
+      state.densityHeatmapResult.categoryStatus[categoryKey] = 'loaded';
+      if (!state.densityHeatmapResult.loadedCategoryKeys.includes(categoryKey)) {
+        state.densityHeatmapResult.loadedCategoryKeys.push(categoryKey);
+        state.densityHeatmapResult.loadedCount =
+          state.densityHeatmapResult.loadedCategoryKeys.length;
+      }
+    },
+    /**
+     * @param {PayloadAction<{
+     *  cacheKey: string;
+     *  categoryKey: string;
+     *  error: string;
+     * }>} action
+     */
+    densityHeatmapCategoryFailed(state, action) {
+      const { cacheKey, categoryKey, error } = action.payload;
+      if (state.densityHeatmapResult.cacheKey !== cacheKey) return;
+      state.densityHeatmapResult.categoryStatus[categoryKey] = 'error';
+      state.densityHeatmapResult.error = error;
+      if (!state.densityHeatmapResult.loadedCategoryKeys.includes(categoryKey)) {
+        state.densityHeatmapResult.loadedCategoryKeys.push(categoryKey);
+        state.densityHeatmapResult.loadedCount =
+          state.densityHeatmapResult.loadedCategoryKeys.length;
+      }
+    },
+    /**
+     * @param {PayloadAction<{ cacheKey: string }>} action
+     */
+    densityHeatmapJobFinished(state, action) {
+      if (state.densityHeatmapResult.cacheKey !== action.payload.cacheKey) return;
+      state.densityHeatmapResult.isPending = false;
+    },
+    resetDensityHeatmapResult(state) {
+      state.densityHeatmapResult = {
+        cacheKey: null,
+        categoryOrder: [],
+        categoryStatus: {},
+        error: null,
+        isPending: false,
+        loadedCategoryKeys: [],
+        loadedCount: 0,
+        rowsByField: {},
+        totalCategories: 0,
+      };
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -431,9 +548,15 @@ export const {
   clearWorkspaceAllFilterSets,
   clearWorkspaceFilterSet,
   createWorkspaceFilterSet,
+  densityHeatmapCategoryFailed,
+  densityHeatmapCategoryLoaded,
+  densityHeatmapCategoryLoading,
+  densityHeatmapJobFinished,
+  densityHeatmapJobStarted,
   duplicateWorkspaceFilterSet,
   loadWorkspaceFilterSet,
   removeWorkspaceFilterSet,
+  resetDensityHeatmapResult,
   resetTableOneResult,
   updateExplorerFilter,
   useExplorerById,

--- a/src/redux/explorer/types.d.ts
+++ b/src/redux/explorer/types.d.ts
@@ -88,6 +88,26 @@ export type ExplorerState = {
     isPending: boolean;
     error: Error;
   };
+  densityHeatmapResult: {
+    cacheKey: string | null;
+    categoryOrder: string[];
+    categoryStatus: {
+      [categoryKey: string]: 'pending' | 'loading' | 'loaded' | 'error';
+    };
+    error: string | null;
+    isPending: boolean;
+    loadedCategoryKeys: string[];
+    loadedCount: number;
+    rowsByField: {
+      [fieldPath: string]: {
+        availableCount: number;
+        completeness: number;
+        field: string;
+        missingCount: number;
+      };
+    };
+    totalCategories: number;
+  };
   workspaces: {
     [explorerId: ExplorerState['explorerId']]: ExplorerWorkspace;
   };


### PR DESCRIPTION
## Summary
- Load data-density aggregations one category at a time (concurrency 2) instead of one multi-minute all-fields GraphQL query that freezes the explorer.
- Keep the job in Redux (`densityHeatmapResult`) so loading continues when leaving the heatmap tab, with cache reuse for the same filter/field set and cancel/replace on filter changes.
- Paint category sections progressively (skeletons → rows), with IntersectionObserver prioritization for visible sections and a lightweight in-header progress note.

## Test plan
- [x] Open Density Heatmap (agree if needed) with curated fields: sections appear quickly and fill without freezing Summary/Table navigation.
- [x] Click **Show all fields**: categories load progressively; explorer remains interactive.
- [x] Switch to Summary mid-load, then return: loading continues / completed categories stay cached.
- [x] Change explorer filters mid-load: previous job is dropped and a new progressive load starts.
- [x] Toggle back to curated fields: correct field set loads without leftover categories.
- [x] Confirm unit tests: `npm test -- --testPathPattern=ExplorerDensityHeatmap/utils`

Refs: #735 & #740